### PR TITLE
Add 'type' field to output features

### DIFF
--- a/src/fiona/tool.py
+++ b/src/fiona/tool.py
@@ -162,6 +162,7 @@ def main():
                 # Try the first record.
                 try:
                     i, first = 0, next(itr)
+                    first['type'] = 'Feature'
                     if args.use_ld_context:
                         first = id_record(first)
                     if indented:
@@ -195,6 +196,7 @@ def main():
                 # we'll write the item separator before each of the
                 # remaining features.
                 for i, rec in enumerate(itr, 1):
+                    rec['type'] = 'Feature'
                     try:
                         if args.use_ld_context:
                             rec = id_record(rec)
@@ -239,6 +241,8 @@ def main():
                     collection['features'] = list(map(id_record, source))[:1]
                 else:
                     collection['features'] = list(source)
+                for f in collection['features']:
+                    f['type'] = 'Feature'
                 json.dump(collection, sink, **dump_kw)
 
     return 0


### PR DESCRIPTION
Adds 'type':'Feature' key:value pair to each feature in dumpgj's output feature
collection

Based on the GeoJSON spec, I'm pretty sure it's required.  The missing field was at least causing an error in Leaflet's GeoJSON parser which expects it to be there.
