### PR TITLE
crs.to_string properly handles Unicode values. [#83]

### DIFF
--- a/src/fiona/crs.py
+++ b/src/fiona/crs.py
@@ -10,6 +10,8 @@
 #   {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
 #
 
+from six import string_types
+
 def to_string(crs):
     """Turn a parameter mapping into a more conventional PROJ.4 string.
 
@@ -20,8 +22,8 @@ def to_string(crs):
     """
     items = []
     for k, v in sorted(filter(
-            lambda x: x[0] in all_proj_keys and x[1] is not False and type
-                (x[1]) in (bool, int, float, str), 
+            lambda x: x[0] in all_proj_keys and x[1] is not False and (type
+                (x[1]) in (bool, int, float) or isinstance(x[1],string_types)),
             crs.items() )):
         items.append(
             "+" + "=".join(


### PR DESCRIPTION
So this was simpler than I expected... 
