### PR TITLE
Provide read access to feature data using FID as an index.

### DIFF
--- a/src/fiona/collection.py
+++ b/src/fiona/collection.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-from fiona.ogrext import Iterator, Session, WritingSession
+from fiona.ogrext import Iterator, Session, WritingSession, _getfeature
 from fiona.errors import DriverError, SchemaError, CRSError
 from fiona._drivers import driver_count, GDALEnv
 from six import string_types
@@ -204,6 +204,9 @@ class Collection(object):
         return next(self.iterator)
 
     next = __next__
+
+    def __getitem__(self, fid):
+        return _getfeature(self, fid)
 
     def writerecords(self, records):
         """Stages multiple records for writing to disk."""

--- a/src/fiona/ogrext.pyx
+++ b/src/fiona/ogrext.pyx
@@ -1072,6 +1072,25 @@ cdef class Iterator:
         _deleteOgrFeature(cogr_feature)
         return feature
 
+def _getfeature(collection, fid):
+
+    """Provides access to feature data by FID.
+    """
+
+    cdef void * cogr_feature
+    cdef Session session
+    cdef encoding
+
+    fid = int(fid)
+    if collection.session is None:
+        raise ValueError("I/O operation on closed collection")
+    session = collection.session
+    cogr_feature = ograpi.OGR_L_GetFeature(session.cogr_layer, fid)
+    if cogr_feature == NULL:
+        return None
+    encoding = session.get_internalencoding()
+    feature = FeatureBuilder().build(cogr_feature, encoding)
+    return feature
 
 def _listlayers(path):
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -202,6 +202,21 @@ class ReadingTest(unittest.TestCase):
         self.failUnlessEqual(f['id'], "0")
         self.failUnlessEqual(f['properties']['FIPS_CNTRY'], 'UK')
 
+    def test_getitem_one(self):
+        f = self.c[0]
+        self.failUnlessEqual(f['id'], "0")
+        self.failUnlessEqual(f['properties']['FIPS_CNTRY'], 'UK')
+
+    def test_getitem_iter_combo(self):
+        i = iter(self.c)
+        f = next(i)
+        f = next(i)
+        self.failUnlessEqual(f['id'], "1")
+        f = self.c[0]
+        self.failUnlessEqual(f['id'], "0")
+        f = next(i)
+        self.failUnlessEqual(f['id'], "2")
+
     def test_no_write(self):
         self.assertRaises(IOError, self.c.write, {})
 


### PR DESCRIPTION
I've added a method for accessing feature data directly using the OGR_L_GetFeature API method, used as follows:

```
with fiona.open('data.shp', 'r') as src:
    feature = src[42]
```

This is useful in situations such as when using a spatial index to access features that are spatially close but not stored together, in a memory constrained environment or when working with very large datasets where multiple file reads are preferable to storing all of the layer in memory.

I've added a couple of unit tests, which illustrate the basic usage and also shows it plays nicely with the existing iterator-based access.

Currently **getitem** will return None if an index that is out of range is passed (e.g. -1) - perhaps it would be more appropriate to raise an IndexError? The method attempts to cast to an integer before calling, so "0" is also valid index, but "zero" is not.
