### PR TITLE
reset spatial filter when no bounding box given

### DIFF
--- a/src/fiona/ogrext.pyx
+++ b/src/fiona/ogrext.pyx
@@ -1090,6 +1090,9 @@ cdef class Iterator:
         if bbox:
             ograpi.OGR_L_SetSpatialFilterRect(
                 cogr_layer, bbox[0], bbox[1], bbox[2], bbox[3])
+        else:
+            ograpi.OGR_L_SetSpatialFilter(
+                cogr_layer, NULL)
         self.encoding = session.get_internalencoding()
 
     def __iter__(self):


### PR DESCRIPTION
a spatial filter, once set, is never removed. 

import fiona

with fiona.open("test_uk.shp", 'r') as c:
    c1 = 0
    for f in c:
        c1 += 1
    c2 = 0
    for f in c.filter(bbox=(-1000, -1000, 0, 0)):
        c2 += 1
    c3 = 0
    for f in c:
        c3 += 1
    print(c1)
    print(c2)
    print(c3)

Output:
48
0
0
