### PR TITLE
Accept datetime.date objects when field type is 'date'

### DIFF
--- a/src/fiona/ogrext.pyx
+++ b/src/fiona/ogrext.pyx
@@ -521,6 +521,22 @@ cdef class OGRFeatureBuilder:
                     y, m, d, hh, mm, ss, ff = parse_datetime(value)
                 ograpi.OGR_F_SetFieldDateTime(
                     cogr_feature, i, y, m, d, hh, mm, ss, 0)
+            elif (isinstance(value, datetime.date)
+            and schema_type == 'date'):
+                y, m, d = value.year, value.month, value.day
+                ograpi.OGR_F_SetFieldDateTime(
+                    cogr_feature, i, y, m, d, 0, 0, 0, 0)
+            elif (isinstance(value, datetime.datetime)
+            and schema_type == 'datetime'):
+                y, m, d = value.year, value.month, value.day
+                hh, mm, ss = value.hour, value.minute, value.second
+                ograpi.OGR_F_SetFieldDateTime(
+                    cogr_feature, i, y, m, d, hh, mm, ss, 0)
+            elif (isinstance(value, datetime.time)
+            and schema_type == 'time'):
+                hh, mm, ss = value.hour, value.minute, value.second
+                ograpi.OGR_F_SetFieldDateTime(
+                    cogr_feature, i, 0, 0, 0, hh, mm, ss, 0)
             elif isinstance(value, string_types):
                 try:
                     value_bytes = value.encode(encoding)


### PR DESCRIPTION
This enables the use of datetime.date/datetime/time objects for field types 'date'/'datetime'/'time', respectively.

For Shapefiles, however, the only possible field type is 'date' as 'datetime' and 'time' are not available.
