### PR TITLE
Fix compilation error on debian

### DIFF
--- a/fiona/_transform.pyx
+++ b/fiona/_transform.pyx
@@ -122,9 +122,10 @@ def _transform_geom(
         transform = ograpi.OCTNewCoordinateTransformation(src, dst)
 
         # Transform options.
+        antimeridian_offset_str = str(antimeridian_offset).encode('utf-8')
         options = ograpi.CSLSetNameValue(
                     options, "DATELINEOFFSET", 
-                    str(antimeridian_offset).encode('utf-8'))
+                    antimeridian_offset_str)
         if antimeridian_cutting:
             options = ograpi.CSLSetNameValue(options, "WRAPDATELINE", "YES")
 


### PR DESCRIPTION
On debian I get the following error without this patch:

Error compiling Cython file:

---

...
        transform = ograpi.OCTNewCoordinateTransformation(src, dst)

```
    # Transform options.
    options = ograpi.CSLSetNameValue(
                options, "DATELINEOFFSET", 
                str(antimeridian_offset).encode('utf-8'))
                                              ^
```

---

fiona/_transform.pyx:127:51: Obtaining 'char *' from temporary Python value

(Cython version 0.20.1post0)
