### PR TITLE
Fixes encoding errors for issue #191.

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -156,7 +156,7 @@ cdef class FeatureBuilder:
             if key_c == NULL:
                 raise ValueError("Null field name reference")
             key_b = key_c
-            key = key_b.decode('utf-8')
+            key = key_b.decode(encoding)
             fieldtypename = FIELD_TYPES[ograpi.OGR_Fld_GetType(fdefn)]
             if not fieldtypename:
                 log.warn(
@@ -445,7 +445,7 @@ cdef class Session:
             key_b = key_c
             if not bool(key_b):
                 raise ValueError("Invalid field name ref: %s" % key)
-            key = key_b.decode('utf-8')
+            key = key_b.decode(self.get_internalencoding())
             fieldtypename = FIELD_TYPES[ograpi.OGR_Fld_GetType(cogr_fielddefn)]
             if not fieldtypename:
                 log.warn(


### PR DESCRIPTION
This commit fixes some issues with reading layers with encodings other than UTF-8 (e.g. GBK), raised in issue #191.

The script I've been using for testing is given below. We could include a more formal unit test, but it would require including some non UTF-8 sample data.

There are still several hard-coded references to UTF-8 in the source for `ogrext.pyx`, and it's possible some more of them need changing. For example, could the CRS data ever be in something other than UTF-8? Possibly not. Could a path name contain non UTF-8 characters? More likely?

```
#!/usr/bin/env python

from __future__ import print_function

import fiona

with fiona.open('points.shp', 'r', encoding='gbk') as f1, fiona.open('points-without-chs.shp', 'r', encoding='utf-8') as f2:
    next(f2)
    next(f1)

with fiona.open('points.shp', 'r', encoding='gbk') as f1, fiona.open('points-without-chs.shp', 'r', encoding='utf-8') as f2:
    meta = f1.meta
    next(f2)
    f = next(f1)
    print(f['properties'].keys())

with fiona.open('test.shp', 'w', encoding='gbk', **meta) as f3:
    f3.write(f)
```
