### PR TITLE
Import all modules from Python space to help cx_Freeze et al.

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -74,6 +74,10 @@ from fiona._drivers import driver_count, GDALEnv, supported_drivers
 from fiona.odict import OrderedDict
 from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP
 
+# These modules are imported by fiona.ogrext, but are also import here to
+# help tools like cx_Freeze find them automatically
+from fiona import _geometry, _err, rfc3339
+import uuid
 
 log = logging.getLogger('Fiona')
 class NullHandler(logging.Handler):


### PR DESCRIPTION
To build an executable from a Python script using cx_Freeze, you do something like this:

```
pip3 install cx_Freeze
cxfreeze test.py
dist/./test
```

If we try to do this for a simple script that imports fiona, it raises an error as not all of the modules used are detected automatically. This can be worked around by manually telling cx_Freeze which modules to import. http://cx-freeze.readthedocs.org/en/latest/faq.html#problems-with-running-frozen-programs

This happens because some of the modules are only called from the Cython extensions, which cx_Freeze can't parse. We could make this easier for the user by making sure all of the modules used are imported from Python space. This shouldn't add any overhead, as the modules are already imported elsewhere.

This should help similar tools, such as PyInstaller and py2exe, although I've not tested them.

The same issue exists for rasterio, and could be rectified in the same manner (again, haven't tested yet).