### PR TITLE
Added builtin OpenFileGDB driver support

### DIFF
--- a/fiona/_drivers.pyx
+++ b/fiona/_drivers.pyx
@@ -186,6 +186,7 @@ supported_drivers = dict([
 #ESRI FileGDB 	FileGDB 	Yes 	Yes 	No, needs FileGDB API library
 # multi-layer
     ("FileGDB", "raw"),
+    ("OpenFileGDB", "r"),
 #ESRI Personal GeoDatabase 	PGeo 	No 	Yes 	No, needs ODBC library
 #ESRI ArcSDE 	SDE 	No 	Yes 	No, needs ESRI SDE
 #ESRI Shapefile 	ESRI Shapefile 	Yes 	Yes 	Yes


### PR DESCRIPTION
Adds an entry for the builtin [OpenFileGDB driver](http://www.gdal.org/drv_openfilegdb.html), which is available as of GDAL 1.11.  Now you are no longer required to install the separate ArcGIS SDK required for the [FileGDB driver](http://www.gdal.org/drv_filegdb.html), at least to read file geodatabases.

I tested manually with an ArcGIS 10.0 file geodatabase, and it worked perfectly once this change was made.  I tested manually when built against GDAL 1.10, and it did not appear to cause negative side effects by referencing a driver not yet in that version; it simply didn't open with the geodatabase (as expected).

I did not test with the ArcGIS FileGDB SDK installed and enabled in GDAL, so this change may interfere with users that were expecting to get that driver by default rather than specifying it as indicated in #192