### PR TITLE
Enable CLI plugins

### DIFF
--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -2,6 +2,9 @@
 # main: loader of all the command entry points.
 
 
+import sys
+import traceback
+
 from pkg_resources import iter_entry_points
 
 from fiona.fio.cli import cli
@@ -21,4 +24,21 @@ from fiona.fio.cli import cli
 #       ...
 
 for entry_point in iter_entry_points('fiona.fio_commands'):
-    entry_point.load()
+    try:
+        entry_point.load()
+    except Exception:
+        # Catch this so a busted plugin doesn't take down the CLI.
+        # Handled by registering a stub that does nothing other than
+        # explain the error.
+        msg = (
+            "Warning: Plugin module could not be loaded. Contact "
+            "its author for help.\n\n\b\n"
+            + traceback.format_exc())
+
+        short_msg = (
+            "Warning: Plugin module could not be loaded. See "
+            "`fio %s --help` for details." % entry_point.name)
+
+        @cli.command(entry_point.name, help=msg, short_help=short_msg)
+        def cmd_stub():
+            pass

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -25,7 +25,4 @@ log = logging.getLogger("Fiona")
 #       ...
 
 for entry_point in iter_entry_points('fiona.fio_commands'):
-    try:
-        entry_point.load()
-    except ImportError:
-        log.exception('Encountered import error when loading entry point: %s' % entry_point)
+    entry_point.load()

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -2,13 +2,9 @@
 # main: loader of all the command entry points.
 
 
-import logging
 from pkg_resources import iter_entry_points
 
 from fiona.fio.cli import cli
-
-
-log = logging.getLogger("Fiona")
 
 
 # Find and load all entry points in the fiona.rio_commands group.

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# main: loader of all the command entry points.
+
+
+import logging
+from pkg_resources import iter_entry_points
+
+from fiona.fio.cli import cli
+
+
+log = logging.getLogger("Fiona")
+
+
+# Find and load all entry points in the fiona.rio_commands group.
+# This includes the standard commands included with Fiona as well
+# as commands provided by other packages.
+#
+# At a mimimum, commands must use the fiona.fio.cli.cli command
+# group decorator like so:
+#
+#   from fiona.fio.cli import cli
+#
+#   @cli.command()
+#   def foo(...):
+#       ...
+
+for entry_point in iter_entry_points('fiona.fio_commands'):
+    try:
+        entry_point.load()
+    except ImportError:
+        log.exception('Encountered import error when loading entry point: %s' % entry_point)

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,18 @@ setup_args = dict(
     packages=['fiona', 'fiona.fio'],
     entry_points='''
         [console_scripts]
-        fio=fiona.fio.fio:cli
+        fio=fiona.fio.main:cli
+
+        [fiona.fio_commands]
+        bounds=fiona.fio.fio:bounds
+        cat=fiona.fio.fio:cat
+        collect=fiona.fio.fio:collect
+        distrib=fiona.fio.fio:distrib
+        dump=fiona.fio.fio:dump
+        env=fiona.fio.fio:env
+        info=fiona.fio.fio:info
+        insp=fiona.fio.fio:insp
+        load=fiona.fio.fio:load
         ''',
     install_requires=requirements,
     tests_require=['nose'],


### PR DESCRIPTION
For #224.

Following the [rasterio model](https://github.com/mapbox/rasterio/pull/346):

1. Added `fiona.fio.main` to load entry points on import.
2. Changed the `entry_points` arg in `setup.py` to reference `fio.fio.main:cli`.
3. Added a `fiona.fio_commands` to the same place and listed subcommands.
4. Forked [`rio-plugin-example`](https://github.com/sgillies/rio-plugin-example) to create a [`fio-plugin-example`](https://github.com/geowurster/fio-plugin-example) for testing purposes.  It's not in PyPi, and I'm happy to hand it off to the Toblerity org if requested, so `pip install git+https://github.com/geowurster/fio-plugin-example` to test.

I also found that attempting to load a malformed plugin totally hoses the CLI to the point where the user has to parse the traceback to identify the problem and manually uninstall the offending plugin, which doesn't seem very user friendly.  At first I had `entry_point.load()` wrapped in a try / except and silently logged the exception but if I installed a plugin and didn't see it listed in the subcommands I would be confused.  Maybe a warning would be more appropriate?  At one point I had a naming mismatch in the [`fio-example-plugin`](https://github.com/geowurster/fio-plugin-example) that produced the following traceback:

```python
(venv)Captain:Fiona wursterk$ fio
Traceback (most recent call last):
  File "/Users/wursterk/github/Fiona/venv/bin/fio", line 9, in <module>
    load_entry_point('Fiona==1.6.0rc0', 'console_scripts', 'fio')()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 546, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2666, in load_entry_point
    return ep.load()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2339, in load
    return self.resolve()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2345, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/wursterk/github/Fiona/fiona/fio/main.py", line 32, in <module>
    entry_point.load()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2339, in load
    return self.resolve()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2345, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ImportError: No module named 'metasay'
```