### PR TITLE
Better broken plugin handling

### DIFF
--- a/fiona/fio/cli.py
+++ b/fiona/fio/cli.py
@@ -1,6 +1,11 @@
+"""Fiona's commandline interface core"""
+
+
 import json
 import logging
+import os
 import sys
+import traceback
 import warnings
 
 import click
@@ -10,6 +15,7 @@ from fiona import __version__ as fio_version
 
 
 warnings.simplefilter('default')
+
 
 def configure_logging(verbosity):
     log_level = max(10, 30 - 10*verbosity)
@@ -23,8 +29,61 @@ def print_version(ctx, param, value):
     ctx.exit()
 
 
+class BrokenCommand(click.Command):
+
+    """A dummy command that provides help for broken plugins."""
+
+    def __init__(self, name):
+        click.Command.__init__(self, name)
+        self.help = (
+            "Warning: entry point could not be loaded. Contact "
+            "its author for help.\n\n\b\n"
+            + traceback.format_exc())
+        self.short_help = (
+            "Warning: could not load plugin. See `fio %s --help`." % self.name)
+
+    def invoke(self, ctx):
+
+        """Print the error message instead of doing nothing."""
+
+        click.echo(self.help, color=ctx.color)
+        ctx.exit()
+
+
+class FioGroup(click.Group):
+    """Custom formatting for the commands of broken plugins."""
+
+    def format_commands(self, ctx, formatter):
+        """Extra format methods for multi methods that adds all the commands
+        after the options.
+        """
+
+        rows = []
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            # What is this, the tool lied about a command.  Ignore it
+            if cmd is None:
+                continue
+
+            help = cmd.short_help or ''
+
+            # Mark broken subcommands with a pile of poop.
+            name = cmd.name
+            if isinstance(cmd, BrokenCommand):
+                if os.environ.get('FIO_HONESTLY'):
+                    name += u'\U0001F4A9'
+                else:
+                    name += u'\u2020'
+
+            rows.append((name, help))
+
+        if rows:
+            with formatter.section('Commands'):
+                formatter.write_dl(rows)
+
+
 # The CLI command group.
-@click.group(help="Fiona command line interface.")
+@click.group(help="Fiona command line interface.", cls=FioGroup)
 @verbose_opt
 @quiet_opt
 @click.option('--version', is_flag=True, callback=print_version,

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -2,12 +2,9 @@
 # main: loader of all the command entry points.
 
 
-import sys
-import traceback
-
 from pkg_resources import iter_entry_points
 
-from fiona.fio.cli import cli
+from fiona.fio.cli import BrokenCommand, cli
 
 
 # Find and load all entry points in the fiona.rio_commands group.
@@ -28,17 +25,7 @@ for entry_point in iter_entry_points('fiona.fio_commands'):
         entry_point.load()
     except Exception:
         # Catch this so a busted plugin doesn't take down the CLI.
-        # Handled by registering a stub that does nothing other than
-        # explain the error.
-        msg = (
-            "Warning: Plugin module could not be loaded. Contact "
-            "its author for help.\n\n\b\n"
-            + traceback.format_exc())
-
-        short_msg = (
-            "Warning: Plugin module could not be loaded. See "
-            "`fio %s --help` for details." % entry_point.name)
-
-        @cli.command(entry_point.name, help=msg, short_help=short_msg)
-        def cmd_stub():
-            pass
+        # Handled by registering a dummy command that does nothing
+        # other than explain the error.
+        cli.add_command(
+            BrokenCommand(entry_point.name))


### PR DESCRIPTION
@sgillies - as described in mapbox/rasterio@225179d30db07205108364c424d4094d61ebc4d3

I also overrode `click.Command.invoke()` in [`fiona.fio.cli.BrokenCommand()`](https://github.com/geowurster/Fiona/blob/184c074681b464dea35624fd640ea7d802e63737/fiona/fio/cli.py#L32) so that if the user attempts to execute the command they still get the help message.  Without this executing the command does nothing.  I'm [pretty sure](https://github.com/mitsuhiko/click/blob/0d9731e97c9af9e5b0f5fd8421aeb0184ad42b70/click/core.py#L712) I got the printing and exiting correct.

```console
(venv)Captain:Fiona wursterk$ fio
Usage: fio [OPTIONS] COMMAND [ARGS]...

  Fiona command line interface.

Options:
  -v, --verbose  Increase verbosity.
  -q, --quiet    Decrease verbosity.
  --version      Print Fiona version.
  --help         Show this message and exit.

Commands:
  bounds    Print the extent of GeoJSON objects
  cat       Concatenate and print the features of datasets
  collect   Collect a sequence of features.
  distrib   Distribute features from a collection
  dump      Dump a dataset to GeoJSON.
  env       Print information about the fio environment.
  info      Print information about a dataset.
  insp      Open a dataset and start an interpreter.
  load      Load GeoJSON to a dataset in another format.
  metasay†  Warning: could not load plugin. See `fio metasay --help`.


(venv)Captain:Fiona wursterk$ export FIO_HONESTLY=1
(venv)Captain:Fiona wursterk$ fio
Usage: fio [OPTIONS] COMMAND [ARGS]...

  Fiona command line interface.

Options:
  -v, --verbose  Increase verbosity.
  -q, --quiet    Decrease verbosity.
  --version      Print Fiona version.
  --help         Show this message and exit.

Commands:
  bounds    Print the extent of GeoJSON objects
  cat       Concatenate and print the features of datasets
  collect   Collect a sequence of features.
  distrib   Distribute features from a collection
  dump      Dump a dataset to GeoJSON.
  env       Print information about the fio environment.
  info      Print information about a dataset.
  insp      Open a dataset and start an interpreter.
  load      Load GeoJSON to a dataset in another format.
  metasay💩  Warning: could not load plugin. See `fio metasay --help`.


(venv)Captain:Fiona wursterk$ fio metasay --help
Usage: fio metasay [OPTIONS]

  Warning: entry point could not be loaded. Contact its author for help.

  Traceback (most recent call last):
    File "/Users/wursterk/github/Fiona/fiona/fio/main.py", line 25, in <module>
      entry_point.load()
    File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2345, in load
      return self.resolve()
    File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2351, in resolve
      module = __import__(self.module_name, fromlist=['__name__'], level=0)
  ImportError: No module named 'fio_metasaya'

Options:
  --help  Show this message and exit.


(venv)Captain:Fiona wursterk$ fio metasay
Warning: entry point could not be loaded. Contact its author for help.


Traceback (most recent call last):
  File "/Users/wursterk/github/Fiona/fiona/fio/main.py", line 25, in <module>
    entry_point.load()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2345, in load
    return self.resolve()
  File "/Users/wursterk/github/Fiona/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2351, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ImportError: No module named 'fio_metasaya'
```