### PR TITLE
Restore Python 2.6 support

### DIFF
--- a/fiona/inspector.py
+++ b/fiona/inspector.py
@@ -12,14 +12,15 @@ logger = logging.getLogger('fiona.inspector')
 
 def main(srcfile):
     
-    with fiona.drivers(), fiona.open(srcfile) as src:
+    with fiona.drivers():
+        with fiona.open(srcfile) as src:
             
-        code.interact(
-            'Fiona %s Interactive Inspector (Python %s)\n'
-            'Type "src.schema", "next(src)", or "help(src)" '
-            'for more information.' %  (
-                fiona.__version__, '.'.join(map(str, sys.version_info[:3]))),
-            local=locals())
+            code.interact(
+                'Fiona %s Interactive Inspector (Python %s)\n'
+                'Type "src.schema", "next(src)", or "help(src)" '
+                'for more information.' %  (
+                    fiona.__version__, '.'.join(map(str, sys.version_info[:3]))),
+                local=locals())
 
     return 1
 


### PR DESCRIPTION
The original nested with statement in inspector.py was syntax that was not introduced until Python 2.7.  This alternative, equivalent version is specified in PEP343.

Without these changes, this module will fail with syntax error on Python 2.6