### PR TITLE
Remove sys.exit() calls from CLI

### DIFF
--- a/fiona/fio/bounds.py
+++ b/fiona/fio/bounds.py
@@ -79,7 +79,6 @@ def bounds(ctx, precision, explode, with_id, with_obj, use_rs):
                     click.echo(u'\u001e', nl=False)
                 click.echo(json.dumps(rec))
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -117,10 +117,10 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
                         if use_rs:
                             click.echo(u'\u001e', nl=False)
                         click.echo(json.dumps(feat, **dump_kwds))
-        sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Collect command
@@ -293,10 +293,9 @@ def collect(ctx, precision, indent, compact, record_buffered, ignore_errors,
             json.dump(collection, sink, **dump_kwds)
             sink.write("\n")
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Distribute command
@@ -322,9 +321,9 @@ def distrib(ctx, use_rs):
                 if use_rs:
                     click.echo(u'\u001e', nl=False)
                 click.echo(json.dumps(feat))
-        sys.exit(0)
     except Exception:
-        raise
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Dump command
@@ -483,10 +482,9 @@ def dump(ctx, input, encoding, precision, indent, compact, record_buffered,
                         collection['features'] = [transformer(source.crs, rec) for rec in source]
                     json.dump(collection, sink, **dump_kwds)
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Load command.
@@ -566,10 +564,7 @@ def load(ctx, output, driver, src_crs, dst_crs, sequence):
                     schema=schema) as dst:
                 dst.write(first)
                 dst.writerecords(source)
-        sys.exit(0)
-    except IOError:
-        logger.info("IOError caught")
-        sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -69,10 +69,10 @@ def info(ctx, input, indent, meta_member):
                         click.echo(info[meta_member])
                 else:
                     click.echo(json.dumps(info, indent=indent))
-        sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Insp command.
@@ -92,7 +92,7 @@ def insp(ctx, src_path):
                         fiona.__version__, '.'.join(
                             map(str, sys.version_info[:3]))),
                     local=locals())
-            sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()


### PR DESCRIPTION
Click handles this automatically - `raise click.Abort()` instead.  Closes #234.