### PR TITLE
Normalize --opt_opt, let fio-load --dst-crs default to --src-crs, and clarified some docstrings.

### DIFF
--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -1,0 +1,8 @@
+"""Common commandline options for `fio`"""
+
+
+import click
+
+
+src_crs_opt = click.option('--src-crs', '--src_crs', help="Source CRS.")
+dst_crs_opt = click.option('--dst-crs', '--dst_crs', help="Destination CRS.")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,7 +4,14 @@ import os.path
 def read_file(name):
     return open(os.path.join(os.path.dirname(__file__), name)).read()
 
+# GeoJSON feature collection on a single line
 feature_collection = read_file('data/collection.txt')
+
+# Same as above but with pretty-print styling applied
 feature_collection_pp = read_file('data/collection-pp.txt')
+
+# One feature per line
 feature_seq = read_file('data/sequence.txt')
+
+# Same as above but each feature has pretty-print styling
 feature_seq_pp_rs = read_file('data/sequence-pp.txt')

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -60,7 +60,7 @@ def test_collect_rs():
     runner = CliRunner()
     result = runner.invoke(
         cat.collect,
-        ['--src_crs', 'EPSG:3857'],
+        ['--src-crs', 'EPSG:3857'],
         feature_seq_pp_rs,
         catch_exceptions=False)
     assert result.exit_code == 0
@@ -71,7 +71,7 @@ def test_collect_no_rs():
     runner = CliRunner()
     result = runner.invoke(
         cat.collect,
-        ['--src_crs', 'EPSG:3857'],
+        ['--src-crs', 'EPSG:3857'],
         feature_seq,
         catch_exceptions=False)
     assert result.exit_code == 0


### PR DESCRIPTION
Closes #241
Closes #240

@sgillies can you make sure I'm on the right track with my change to the [`fio load --sequence`](https://github.com/geowurster/Fiona/commit/1846951e97887f74e5e6312a05593d26b47bd876#diff-052c7c2327e7f08f4b54f8cc8f075331R499) help string?  It was using [cligj](https://github.com/mapbox/cligj/blob/master/cligj/__init__.py#L83-L88) but that help string only covers writing GeoJSON rather than reading.

I should have split this into 3 or 4 separate commits and 1 PR but its too late now (unless some of these changes need to be removed in which case I'll make the modifications)!