### PR TITLE
Properly handle JSON when reading OGR string fields

### DIFF
--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -1,5 +1,7 @@
 import json
+import os.path
 from six import text_type
+import tempfile
 
 import fiona
 from fiona import prop_type, prop_width
@@ -25,7 +27,7 @@ def test_types():
     assert prop_type('date') == FionaDateType
 
 
-def test_read_json_object_properties(tmpdir):
+def test_read_json_object_properties():
     """JSON object properties are properly serialized"""
     data = """
 {
@@ -71,7 +73,8 @@ def test_read_json_object_properties(tmpdir):
   ]
 }
 """
-    filename = str(tmpdir.join('test.json'))
+    tmpdir = tempfile.mkdtemp()
+    filename = os.path.join(tmpdir, 'test.json')
 
     with open(filename, 'w') as f:
         f.write(data)
@@ -84,7 +87,7 @@ def test_read_json_object_properties(tmpdir):
         assert props['tricky'] == "{gotcha"
 
 
-def test_write_json_object_properties(tmpdir):
+def test_write_json_object_properties():
     """Python object properties are properly serialized"""
     data = """
 {
@@ -131,7 +134,8 @@ def test_write_json_object_properties(tmpdir):
 }
 """
     data = json.loads(data)['features'][0]
-    filename = str(tmpdir.join('test.json'))
+    tmpdir = tempfile.mkdtemp()
+    filename = os.path.join(tmpdir, 'test.json')
     with fiona.open(
             filename, 'w',
             driver='GeoJSON',

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -1,16 +1,21 @@
-
+import json
 from six import text_type
+
+import fiona
 from fiona import prop_type, prop_width
 from fiona.rfc3339 import FionaDateType
+
 
 def test_width_str():
     assert prop_width('str:254') == 254
     assert prop_width('str') == 80
 
+
 def test_width_other():
     assert prop_width('int') == None
     assert prop_width('float') == None
     assert prop_width('date') == None
+
 
 def test_types():
     assert prop_type('str:254') == text_type
@@ -18,3 +23,127 @@ def test_types():
     assert prop_type('int') == type(0)
     assert prop_type('float') == type(0.0)
     assert prop_type('date') == FionaDateType
+
+
+def test_read_json_object_properties(tmpdir):
+    """JSON object properties are properly serialized"""
+    data = """
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              87.33588,
+              43.53139
+            ],
+            [
+              87.33588,
+              45.66894
+            ],
+            [
+              90.27542,
+              45.66894
+            ],
+            [
+              90.27542,
+              43.53139
+            ],
+            [
+              87.33588,
+              43.53139
+            ]
+          ]
+        ]
+      },
+      "type": "Feature",
+      "properties": {
+        "upperLeftCoordinate": {
+          "latitude": 45.66894,
+          "longitude": 87.91166
+        },
+        "tricky": "{gotcha"
+      }
+    }
+  ]
+}
+"""
+    filename = str(tmpdir.join('test.json'))
+
+    with open(filename, 'w') as f:
+        f.write(data)
+
+    with fiona.open(filename) as src:
+        ftr = next(src)
+        props = ftr['properties']
+        assert props['upperLeftCoordinate']['latitude'] == 45.66894
+        assert props['upperLeftCoordinate']['longitude'] == 87.91166
+        assert props['tricky'] == "{gotcha"
+
+
+def test_write_json_object_properties(tmpdir):
+    """Python object properties are properly serialized"""
+    data = """
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              87.33588,
+              43.53139
+            ],
+            [
+              87.33588,
+              45.66894
+            ],
+            [
+              90.27542,
+              45.66894
+            ],
+            [
+              90.27542,
+              43.53139
+            ],
+            [
+              87.33588,
+              43.53139
+            ]
+          ]
+        ]
+      },
+      "type": "Feature",
+      "properties": {
+        "upperLeftCoordinate": {
+          "latitude": 45.66894,
+          "longitude": 87.91166
+        },
+        "tricky": "{gotcha"
+      }
+    }
+  ]
+}
+"""
+    data = json.loads(data)['features'][0]
+    filename = str(tmpdir.join('test.json'))
+    with fiona.open(
+            filename, 'w',
+            driver='GeoJSON',
+            schema={
+                'geometry': 'Polygon',
+                'properties': {'upperLeftCoordinate': 'str', 'tricky': 'str'}}
+            ) as dst:
+        dst.write(data)
+
+    with fiona.open(filename) as src:
+        ftr = next(src)
+        props = ftr['properties']
+        assert props['upperLeftCoordinate']['latitude'] == 45.66894
+        assert props['upperLeftCoordinate']['longitude'] == 87.91166
+        assert props['tricky'] == "{gotcha"


### PR DESCRIPTION
Closes #245.

Now (after we merge this) when you open a GeoJSON file which has features with object (not just number or string) properties using the OGR GeoJSON driver (ie with `fiona.open()`) those properties will return to you as Python objects (not JSON-encoded strings).

NB that there is no "dict" type in OGR, so when serializing, you must set the type in the schema to "str". See the example in the new tests.