### PR TITLE
Consolidate GeoJSON feature stream I/O

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -69,7 +69,7 @@ import logging
 import os
 from six import string_types
 
-from fiona.collection import Collection, BytesCollection, vsi_path
+from fiona.collection import Collection, BytesCollection, FeatureStream, vsi_path
 from fiona._drivers import driver_count, GDALEnv, supported_drivers
 from fiona.odict import OrderedDict
 from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP
@@ -95,7 +95,9 @@ def open(
         encoding=None,
         layer=None,
         vfs=None,
-        enabled_drivers=None):
+        enabled_drivers=None,
+        sequence=False,
+        use_rs=False):
     
     """Open file at ``path`` in ``mode`` "r" (read), "a" (append), or
     "w" (write) and return a ``Collection`` object.
@@ -145,6 +147,10 @@ def open(
           'example.shp', enabled_drivers=['GeoJSON', 'ESRI Shapefile'])
 
     """
+
+    if sequence:
+        return FeatureStream(path, mode=mode, use_rs=use_rs)
+
     # Parse the vfs into a vsi and an archive path.
     path, vsi, archive = parse_paths(path, vfs)
     if mode in ('a', 'r'):
@@ -257,4 +263,3 @@ def bounds(ob):
     The ``ob`` may be a feature record or geometry."""
     geom = ob.get('geometry') or ob
     return _bounds(geom)
-


### PR DESCRIPTION
In progress.  Feedback welcome.

@sgillies This is a rough draft (without unittests) of #251 that implements a new `fiona.collections.FeatureStream()` file-like object for working with GeoJSON feature streams.  If it is decided that this object doesn't really belong in Fiona, this about how I planned on implementing https://github.com/geowurster/fio-buffer/issues/4, so feel free to shoot this down.

**Generate some sample data**

```console
$ fio cat tests/data/coutwildrnp.shp > features.geojson
```

**Inspect it with Python**

```python
import fiona
with fiona.open('features.geojson', sequence=True) as src:
    print(next(src))
```

RS prefixes are supported as well as reading from `stdin` and writing to `stdout`:

```python
import fiona
with fiona.open('-', sequence=True) as src, fiona.open('-', 'w', sequence=True, use_rs=True) as dst:
    for feat in src:
        dst.write(feat)
```