### PR TITLE
Add fixes to support gdal2

### DIFF
--- a/fiona/ograpi.pxd
+++ b/fiona/ograpi.pxd
@@ -147,4 +147,5 @@ cdef extern from "ogr_api.h":
 
 cdef extern from "cpl_error.h":
     void CPLErrorReset()
+    char * CPLGetLastErrorMsg()
 

--- a/fiona/ograpi.pxd
+++ b/fiona/ograpi.pxd
@@ -5,6 +5,7 @@
 cdef extern from "gdal.h":
     char * GDALVersionInfo (char *pszRequest)
 
+
 cdef extern from "gdal_version.h":
     int    GDAL_COMPUTE_VERSION(int maj, int min, int rev)
 
@@ -143,3 +144,7 @@ cdef extern from "ogr_api.h":
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
+
+cdef extern from "cpl_error.h":
+    void CPLErrorReset()
+

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -47,6 +47,8 @@ FIELD_TYPES = [
     'date',         # OFTDate, Date
     'time',         # OFTTime, Time
     'datetime',     # OFTDateTime, Date and Time
+    'int',          # OFTInteger64, Single 64bit integer
+    None,           # OFTInteger64List, List of 64bit integers
     ]
 
 # Mapping of Fiona field type names to Python types.

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -430,7 +430,7 @@ cdef class Session:
             self._fileencoding = (
                 ograpi.OGR_L_TestCapability(
                     self.cogr_layer, OLC_STRINGSASUTF8) and
-                OGR_DETECTED_ENCODING) or (
+                'utf-8') or (
                 self.get_driver() == "ESRI Shapefile" and
                 'ISO-8859-1') or locale.getpreferredencoding().upper()
 
@@ -718,7 +718,7 @@ cdef class WritingSession(Session):
             userencoding = self.collection.encoding
             self._fileencoding = (userencoding or (
                 ograpi.OGR_L_TestCapability(self.cogr_layer, OLC_STRINGSASUTF8) and
-                OGR_DETECTED_ENCODING) or (
+                'utf-8') or (
                 self.get_driver() == "ESRI Shapefile" and
                 'ISO-8859-1') or locale.getpreferredencoding()).upper()
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -956,6 +956,7 @@ cdef class WritingSession(Session):
         if cogr_ds == NULL:
             raise ValueError("Null data source")
         log.debug("Syncing OGR to disk")
+        ograpi.CPLErrorReset()
         retval = ograpi.OGR_DS_SyncToDisk(cogr_ds)
         if retval != OGRERR_NONE:
             raise RuntimeError("Failed to sync to disk")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,7 +17,7 @@ class SchemaOrder(unittest.TestCase):
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
                 driver="ESRI Shapefile",
                 schema={
-                    'geometry': 'LineString', 
+                    'geometry': 'LineString',
                     'properties': items }) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
@@ -56,7 +56,7 @@ class ShapefileSchema(unittest.TestCase):
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
                 driver="ESRI Shapefile",
                 schema={
-                    'geometry': 'Polygon', 
+                    'geometry': 'Polygon',
                     'properties': items }) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
             c.write(
@@ -90,39 +90,40 @@ class ShapefileSchema(unittest.TestCase):
                     'Lat': 33.759999999999998,
                     'Location': 'NA-US-CA-SANTA ANA',
                     'LocationType': 'PRIMARY',
-                    'Long': -117.88,
+                    'Long':-117.88,
                     'MTFCC10': 'G6350',
                     'State': 'CA',
                     'TaxReturnsFiled': 14635.0,
                     'TotalWages': 521280485.0,
                     'ZipCodeType': 'STANDARD'},
-                 'type': 'Feature'} )
+                 'type': 'Feature'})
             self.assertEqual(len(c), 1)
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
             self.assertEqual(
-                list(c.schema['properties'].items()), 
-                sorted([('AWATER10', 'float:24.15'), 
-                 ('CLASSFP10', 'str:80'), 
-                 ('ZipCodeTyp', 'str:80'), 
-                 ('EstimatedP', 'float:24.15'), 
-                 ('LocationTy', 'str:80'), 
-                 ('ALAND10', 'float:24.15'), 
-                 ('INTPTLAT10', 'str:80'), 
-                 ('FUNCSTAT10', 'str:80'), 
-                 ('Long', 'float:24.15'), 
-                 ('City', 'str:80'), 
-                 ('TaxReturns', 'float:24.15'), 
-                 ('State', 'str:80'), 
-                 ('Location', 'str:80'), 
-                 ('GSrchCnt', 'float:24.15'), 
-                 ('TotalWages', 'float:24.15'), 
-                 ('Lat', 'float:24.15'), 
-                 ('MTFCC10', 'str:80'), 
-                 ('INTPTLON10', 'str:80'), 
-                 ('GEOID10', 'str:80'), 
-                 ('Decommisio', 'str:80')]) )
+                list(c.schema['properties'].items()),
+                sorted([('AWATER10', 'float:24.15'),
+                 ('CLASSFP10', 'str:80'),
+                 ('ZipCodeTyp', 'str:80'),
+                 ('EstimatedP', 'float:24.15'),
+                 ('LocationTy', 'str:80'),
+                 ('ALAND10', 'float:24.15'),
+                 ('INTPTLAT10', 'str:80'),
+                 ('FUNCSTAT10', 'str:80'),
+                 ('Long', 'float:24.15'),
+                 ('City', 'str:80'),
+                 ('TaxReturns', 'float:24.15'),
+                 ('State', 'str:80'),
+                 ('Location', 'str:80'),
+                 ('GSrchCnt', 'float:24.15'),
+                 ('TotalWages', 'float:24.15'),
+                 ('Lat', 'float:24.15'),
+                 ('MTFCC10', 'str:80'),
+                 ('INTPTLON10', 'str:80'),
+                 ('GEOID10', 'str:80'),
+                 ('Decommisio', 'str:80')]))
             f = next(c)
             self.assertEqual(f['properties']['EstimatedP'], 27773.0)
+            self.assertEqual(f['properties']['TotalWages'], 521280485.0)
 
 
 class FieldTruncationTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR includes:
- Adding of 64bit types. (For Python 2.7 64bit Integers are mapped to the 32bit int type, not long)
- Session.sync resets previous errors before executing OGR_DS_SyncToDisk (*)
- If OGR_L_TestCapability of OLC_STRINGSASUTF8 is successful, utf-8 is chosen as encoding and not  OGR_DETECTED_ENCODING

(*) : The tests in test_issue177 (tests.test_schema.FieldTruncationTestCase) respectively test_schema (tests.test_schema.ShapefileSchema) return as last error message
"Normalized/laundered field name: 'a_fieldname' to 'a_fieldnam'" respectively "Value 521280485 of field TotalWages of feature 0 not successfully written. Possibly due to too larger number with respect to field width"

These errror messages do not have a connection with OGR_DS_SyncToDisk. Thus past errors are reset. A test was added for value 521280485 of total wages for test_schema (tests.test_schema.ShapefileSchema