### PR TITLE
CLI for filtering features, fio filter

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -20,6 +20,7 @@ Fiona's new command line interface is a program named "fio".
       collect  Collect a sequence of features.
       dump     Dump a dataset to GeoJSON.
       env      Print information about the rio environment.
+      filter   Filter GeoJSON features by python expression
       info     Print information about a dataset.
       insp     Open a dataset and start an interpreter.
       load     Load GeoJSON to a dataset in another format.
@@ -219,6 +220,26 @@ collection into a feature sequence.
     > 'each(data.features,function(o){console.log(JSON.stringify(o))})' \
     > | fio load /tmp/test-seq.shp --x-json-seq --driver Shapefile
 
+
+filter
+------
+The filter command reads GeoJSON features from stdin and writes the feature to 
+stdout *if* the provided expression evalutates to `True` for that feature. 
+
+The python expression is evaluated in a restricted namespace containing 3 functions 
+(`sum`, `min`, `max`), the `math` module, and an object `f` representing the
+feature to be evaluated. If the expression evaluates to a false-y value, the
+feature is not included in the output. Otherwise, the feature is printed
+verbatim. 
+
+For example 
+
+    fio cat data.shp \
+    | fio filter "f['properties']['area'] > 1000.0" \
+    | fio collect > large_polygons.geojson
+
+Would create a geojson file with only those features from `data.shp` where the
+area was over a given threshold.
 
 Coordinate Reference System Transformations
 -------------------------------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -227,15 +227,17 @@ The filter command reads GeoJSON features from stdin and writes the feature to
 stdout *if* the provided expression evalutates to `True` for that feature. 
 
 The python expression is evaluated in a restricted namespace containing 3 functions 
-(`sum`, `min`, `max`), the `math` module, and an object `f` representing the
-feature to be evaluated. If the expression evaluates to a false-y value, the
-feature is not included in the output. Otherwise, the feature is printed
-verbatim. 
+(`sum`, `min`, `max`), the `math` module, the shapely `shape` function, 
+and an object `f` representing the feature to be evaluated. This `f` object allows
+access in javascript-style dot notation for convenience. 
+
+If the expression evaluates to a "truthy" value, the feature is printed verbatim.
+Otherwise, the feature is excluded from the output.
 
 For example 
 
     fio cat data.shp \
-    | fio filter "f['properties']['area'] > 1000.0" \
+    | fio filter "f.properties.area > 1000.0" \
     | fio collect > large_polygons.geojson
 
 Would create a geojson file with only those features from `data.shp` where the

--- a/fiona/fio/filter.py
+++ b/fiona/fio/filter.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import math
+
+import click
+from cligj import use_rs_opt
+
+from .helpers import obj_gen
+
+
+@click.command(short_help="Filter GeoJSON features by python expression")
+@click.argument('filter')
+@use_rs_opt
+@click.pass_context
+def filter(ctx, filter, use_rs):
+    """
+    Filter GeoJSON objects read from stdin against the specified expression.
+
+    The expression is evaluated in a restricted namespace containing:
+        - sum
+        - min
+        - max
+        - math, imported module
+        - f, the feature in question
+
+    The expression will be evaluated for each feature and, if true,
+    the feature will be included in the output.
+
+    e.g. fio cat data.shp \
+         | fio filter "f['properties']['area'] > 1000.0" \
+         | fio collect > large_polygons.geojson
+    """
+    logger = logging.getLogger('fio')
+    stdin = click.get_text_stream('stdin')
+
+    def filter_func(feature):
+        safe_dict = {'f': feature}
+        safe_dict['sum'] = sum
+        safe_dict['pow'] = sum
+        safe_dict['min'] = min
+        safe_dict['max'] = max
+        safe_dict['math'] = math
+        return eval(filter, {"__builtins__": None}, safe_dict)
+
+    try:
+        source = obj_gen(stdin)
+        for i, obj in enumerate(source):
+            features = obj.get('features') or [obj]
+            for j, feat in enumerate(features):
+                if not filter_func(feat):
+                    continue
+
+                if use_rs:
+                    click.echo(u'\u001e', nl=False)
+                click.echo(json.dumps(feat))
+
+    except Exception:
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ argparse
 cligj
 six
 ordereddict
+munch

--- a/setup.py
+++ b/setup.py
@@ -193,6 +193,7 @@ setup_args = dict(
         info=fiona.fio.info:info
         insp=fiona.fio.info:insp
         load=fiona.fio.cat:load
+        filter=fiona.fio.filter:filter
         ''',
     install_requires=requirements,
     tests_require=['nose'],

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,8 @@ else:
 requirements = [
     'cligj',
     'click-plugins',
-    'six'
+    'six',
+    'munch'
 ]
 if sys.version_info < (2, 7):
     requirements.append('argparse')

--- a/tests/test_fio_filter.py
+++ b/tests/test_fio_filter.py
@@ -1,0 +1,29 @@
+from click.testing import CliRunner
+
+from fiona.fio import filter
+
+from .fixtures import feature_seq
+
+
+def test_fail():
+    runner = CliRunner()
+    result = runner.invoke(filter.filter,
+                           ["f.properties.test > 5"],
+                           "{'type': 'no_properties'}")
+    assert result.exit_code == 1
+
+
+def test_seq():
+    runner = CliRunner()
+
+    result = runner.invoke(filter.filter, ["f.properties.AREA > 0.01"], feature_seq)
+    assert result.exit_code == 0
+    assert result.output.count('Feature') == 2
+
+    result = runner.invoke(filter.filter, ["f.properties.AREA > 0.015"], feature_seq)
+    assert result.exit_code == 0
+    assert result.output.count('Feature') == 1
+
+    result = runner.invoke(filter.filter, ["f.properties.AREA > 0.02"], feature_seq)
+    assert result.exit_code == 0
+    assert result.output.count('Feature') == 0


### PR DESCRIPTION
I started writing this as a standalone script and realized it might be useful as a built in `fio` command.

The `fio filter` command reads GeoJSON features from stdin and writes the feature to 
stdout *if* the provided expression evalutates to `True` for that feature.

For example to create a geojson feature collection containing large polygons only:

    fio cat data.shp \
    | fio filter "f['properties']['area'] > 1000.0" \
    | fio collect > large_polygons.geojson

With the munch library, we can use dot notation for convenience 

    fio cat data.shp \
    | fio filter "f.properties.area > 1000.0" \
    | fio collect > large_polygons.geojson

The python expression is evaluated in a restricted namespace, what is allowed in that namespace is TBD. For now it's just (`sum`, `min`, `max`), the shapely `shape` constructor, the `math` module, and an object `f` representing the feature to be evaluated. 

The whole approach of eval in a restricted namespace seems safe enough for a command line tool but there might be other DSLs that could accomplish the same things (snuggs?)