### PR TITLE
Initial attempt at fiona.remove for deleting data sources

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -183,13 +183,30 @@ def open(
 collection = open
 
 
-def remove(path, driver=None):
-    # collection was passed instead of path
-    if isinstance(path, Collection):
-        collection = path
+def remove(path_or_collection, driver=None):
+    """Deletes an OGR data source
+
+    The required ``path`` argument may be an absolute or relative file path.
+    Alternatively, a Collection can be passed instead in which case the path
+    and driver are automatically determined. Otherwise the ``driver`` argument
+    must be specified.
+
+    Raises a ``RuntimeError`` if the data source cannot be deleted.
+
+    Example usage:
+
+      fiona.remove('test.shp', 'ESRI Shapefile')
+
+    """
+    if isinstance(path_or_collection, Collection):
+        collection = path_or_collection
         path = collection.path
         driver = collection.driver
         collection.close()
+    else:
+        path = path_or_collection
+        if driver is None:
+            raise ValueError("The driver argument is required when removing a path")
     _remove(path, driver)
 
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -73,7 +73,7 @@ from fiona.collection import Collection, BytesCollection, vsi_path
 from fiona._drivers import driver_count, GDALEnv
 from fiona.drvsupport import supported_drivers
 from fiona.odict import OrderedDict
-from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP
+from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP, _remove
 
 # These modules are imported by fiona.ogrext, but are also import here to
 # help tools like cx_Freeze find them automatically
@@ -181,6 +181,16 @@ def open(
     return c
 
 collection = open
+
+
+def remove(path, driver=None):
+    # collection was passed instead of path
+    if isinstance(path, Collection):
+        collection = path
+        path = collection.path
+        driver = collection.driver
+        collection.close()
+    _remove(path, driver)
 
 
 def listlayers(path, vfs=None):

--- a/fiona/ograpi1.pxd
+++ b/fiona/ograpi1.pxd
@@ -62,6 +62,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_Dr_CreateDataSource (void *driver, const char *path, char **options)
     int     OGR_Dr_DeleteDataSource (void *driver, char *)
     void *  OGR_Dr_Open (void *driver, const char *path, int bupdate)
+    int     OGR_Dr_TestCapability (void *driver, const char *)
     int     OGR_DS_DeleteLayer (void *datasource, int n)
     void *  OGR_DS_CreateLayer (void *datasource, char *name, void *crs, int geomType, char **options)
     void *  OGR_DS_ExecuteSQL (void *datasource, char *name, void *filter, char *dialext)

--- a/fiona/ograpi2.pxd
+++ b/fiona/ograpi2.pxd
@@ -111,6 +111,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_Dr_CreateDataSource (void *driver, const char *path, char **options)
     int     OGR_Dr_DeleteDataSource (void *driver, char *)
     void *  OGR_Dr_Open (void *driver, const char *path, int bupdate)
+    int     OGR_Dr_TestCapability (void *driver, const char *)
     void *  OGR_F_Create (void *featuredefn)
     void    OGR_F_Destroy (void *feature)
     long    OGR_F_GetFID (void *feature)

--- a/fiona/ograpi2.pxd
+++ b/fiona/ograpi2.pxd
@@ -36,6 +36,7 @@ cdef extern from "gdal.h":
     void GDALFlushCache(void * hDS)
     char * GDALGetDriverShortName(void * hDriver)
     char * GDALGetDatasetDriver (void * hDataset)
+    int GDALDeleteDataset(void * hDriver, const char * pszFilename)
 
 
     ctypedef enum GDALDataType:

--- a/fiona/ogrext1.pyx
+++ b/fiona/ogrext1.pyx
@@ -59,6 +59,10 @@ FIELD_TYPES_MAP = {
     'datetime': FionaDateTimeType
    }
 
+# OGR Driver capability
+ODrCCreateDataSource = b"CreateDataSource"
+ODrCDeleteDataSource = b"DeleteDataSource"
+
 # OGR Layer capability
 OLC_RANDOMREAD = b"RandomRead"
 OLC_SEQUENTIALWRITE = b"SequentialWrite"
@@ -1183,6 +1187,9 @@ def _remove(path, driver=None):
     cogr_driver = ograpi.OGRGetDriverByName(driver.encode('utf-8'))
     if cogr_driver == NULL:
         raise ValueError("Null driver")
+
+    if not ograpi.OGR_Dr_TestCapability(cogr_driver, ODrCDeleteDataSource):
+        raise RuntimeError("Driver does not support dataset removal operation")
 
     result = ograpi.OGR_Dr_DeleteDataSource(cogr_driver, path.encode('utf-8'))
     if result != OGRERR_NONE:

--- a/fiona/ogrext1.pyx
+++ b/fiona/ogrext1.pyx
@@ -1171,6 +1171,24 @@ cdef class KeysIterator(Iterator):
         return fid
 
 
+def _remove(path, driver=None):
+    """Deletes an OGR data source
+    """
+    cdef void *cogr_driver
+    cdef int result
+
+    if driver is None:
+        driver = 'ESRI Shapefile'
+
+    cogr_driver = ograpi.OGRGetDriverByName(driver.encode('utf-8'))
+    if cogr_driver == NULL:
+        raise ValueError("Null driver")
+
+    result = ograpi.OGR_Dr_DeleteDataSource(cogr_driver, path.encode('utf-8'))
+    if result != OGRERR_NONE:
+        raise RuntimeError("Failed to remove data source {}".format(path))
+
+
 def _listlayers(path):
 
     """Provides a list of the layers in an OGR data source.

--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -64,6 +64,10 @@ FIELD_TYPES_MAP = {
     'datetime': FionaDateTimeType
    }
 
+# OGR Driver capability
+ODrCCreateDataSource = b"CreateDataSource"
+ODrCDeleteDataSource = b"DeleteDataSource"
+
 # OGR Layer capability
 OLC_RANDOMREAD = b"RandomRead"
 OLC_SEQUENTIALWRITE = b"SequentialWrite"
@@ -1256,6 +1260,9 @@ def _remove(path, driver=None):
     cogr_driver = ograpi.OGRGetDriverByName(driver.encode('utf-8'))
     if cogr_driver == NULL:
         raise ValueError("Null driver")
+
+    if not ograpi.OGR_Dr_TestCapability(cogr_driver, ODrCDeleteDataSource):
+        raise RuntimeError("Driver does not support dataset removal operation")
 
     result = ograpi.GDALDeleteDataset(cogr_driver, path.encode('utf-8'))
     if result != OGRERR_NONE:

--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -1244,6 +1244,24 @@ cdef class KeysIterator(Iterator):
         return fid
 
 
+def _remove(path, driver=None):
+    """Deletes an OGR data source
+    """
+    cdef void *cogr_driver
+    cdef int result
+
+    if driver is None:
+        driver = 'ESRI Shapefile'
+
+    cogr_driver = ograpi.OGRGetDriverByName(driver.encode('utf-8'))
+    if cogr_driver == NULL:
+        raise ValueError("Null driver")
+
+    result = ograpi.OGR_Dr_DeleteDataSource(cogr_driver, path.encode('utf-8'))
+    if result != OGRERR_NONE:
+        raise RuntimeError("Failed to remove data source {}".format(path))
+
+
 def _listlayers(path):
 
     """Provides a list of the layers in an OGR data source.

--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -1257,7 +1257,7 @@ def _remove(path, driver=None):
     if cogr_driver == NULL:
         raise ValueError("Null driver")
 
-    result = ograpi.OGR_Dr_DeleteDataSource(cogr_driver, path.encode('utf-8'))
+    result = ograpi.GDALDeleteDataset(cogr_driver, path.encode('utf-8'))
     if result != OGRERR_NONE:
         raise RuntimeError("Failed to remove data source {}".format(path))
 

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import os
 
+import tempfile
 import pytest
 
 import fiona
@@ -10,7 +11,7 @@ import fiona
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def create_test_data(filename, driver):
+def create_sample_data(filename, driver):
     meta = {
         'driver': driver,
         'schema': {
@@ -29,29 +30,36 @@ def create_test_data(filename, driver):
     assert(os.path.exists(filename))
 
 
-def test_remove(tmpdir):
-    filename_shp = str(tmpdir.join('test.shp'))
+def test_remove(tmpdir=None):
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp()
+    filename_shp = os.path.join(tmpdir, 'test.shp')
     
-    create_test_data(filename_shp, driver='ESRI Shapefile')
+    create_sample_data(filename_shp, driver='ESRI Shapefile')
     fiona.remove(filename_shp, driver='ESRI Shapefile')
     assert(not os.path.exists(filename_shp))
     
     with pytest.raises(RuntimeError):
         fiona.remove(filename_shp, driver='ESRI Shapefile')
 
-def test_remove_driver(tmpdir):
-    filename_shp = str(tmpdir.join('test.shp'))
-    filename_json = str(tmpdir.join('test.json'))
-    
-    create_test_data(filename_shp, driver='ESRI Shapefile')
-    create_test_data(filename_json, driver='GeoJSON')
+def test_remove_driver(tmpdir=None):
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp()
+    filename_shp = os.path.join(tmpdir, 'test.shp')
+    filename_json = os.path.join(tmpdir, 'test.json')
+        
+    create_sample_data(filename_shp, driver='ESRI Shapefile')
+    create_sample_data(filename_json, driver='GeoJSON')
     fiona.remove(filename_json, driver='GeoJSON')
     assert(not os.path.exists(filename_json))
     assert(os.path.exists(filename_shp))
 
-def test_remove_collection(tmpdir):
-    filename_shp = str(tmpdir.join('test.shp'))
-    create_test_data(filename_shp, driver='ESRI Shapefile')
+def test_remove_collection(tmpdir=None):
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp()
+    filename_shp = os.path.join(tmpdir, 'test.shp')
+    
+    create_sample_data(filename_shp, driver='ESRI Shapefile')
     collection = fiona.open(filename_shp, 'r')
     fiona.remove(collection)
     assert(not os.path.exists(filename_shp))

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -63,3 +63,15 @@ def test_remove_collection(tmpdir=None):
     collection = fiona.open(filename_shp, 'r')
     fiona.remove(collection)
     assert(not os.path.exists(filename_shp))
+
+def test_remove_path_without_driver(tmpdir=None):
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp()
+    filename_shp = os.path.join(tmpdir, 'test.shp')
+
+    create_sample_data(filename_shp, driver='ESRI Shapefile')
+
+    with pytest.raises(Exception):
+        fiona.remove(filename_shp)
+
+    assert(os.path.exists(filename_shp))

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,57 @@
+import logging
+import sys
+import os
+
+import pytest
+
+import fiona
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def create_test_data(filename, driver):
+    meta = {
+        'driver': driver,
+        'schema': {
+            'geometry': 'Point',
+            'properties': {}
+        }
+    }
+    with fiona.open(filename, 'w', **meta) as dst:
+        dst.write({
+            'geometry': {
+                'type': 'Point',
+                'coordinates': (0, 0),
+            },
+            'properties': {},
+        })
+    assert(os.path.exists(filename))
+
+
+def test_remove(tmpdir):
+    filename_shp = str(tmpdir.join('test.shp'))
+    
+    create_test_data(filename_shp, driver='ESRI Shapefile')
+    fiona.remove(filename_shp, driver='ESRI Shapefile')
+    assert(not os.path.exists(filename_shp))
+    
+    with pytest.raises(RuntimeError):
+        fiona.remove(filename_shp, driver='ESRI Shapefile')
+
+def test_remove_driver(tmpdir):
+    filename_shp = str(tmpdir.join('test.shp'))
+    filename_json = str(tmpdir.join('test.json'))
+    
+    create_test_data(filename_shp, driver='ESRI Shapefile')
+    create_test_data(filename_json, driver='GeoJSON')
+    fiona.remove(filename_json, driver='GeoJSON')
+    assert(not os.path.exists(filename_json))
+    assert(os.path.exists(filename_shp))
+
+def test_remove_collection(tmpdir):
+    filename_shp = str(tmpdir.join('test.shp'))
+    create_test_data(filename_shp, driver='ESRI Shapefile')
+    collection = fiona.open(filename_shp, 'r')
+    fiona.remove(collection)
+    assert(not os.path.exists(filename_shp))


### PR DESCRIPTION
As suggested in #285.

This was slightly more tricky than I initially realised, as OGR needs to know which driver to use in order to delete the data source.

I've only implemented this for GDAL 1.x for now, and still need to write the function documentation. Posting here for comment.