### PR TITLE
Add fio -D option and ability to set json_lib

### DIFF
--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -80,7 +80,7 @@ def id_record(rec):
               help="log errors but do not stop serialization.")
 @options.dst_crs_opt
 @use_rs_opt
-@click.option('--sort-keys/--no-sort-keys', is_flag=True, default=True,
+@click.option('--sort-keys/--no-sort-keys', is_flag=True, default=False,
               show_default=True, help="Sort JSON keys when serializing.")
 @click.option('--bbox', default=None, metavar="w,s,e,n",
               help="filter for features intersecting a bounding box")

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -80,11 +80,13 @@ def id_record(rec):
               help="log errors but do not stop serialization.")
 @options.dst_crs_opt
 @use_rs_opt
+@click.option('--sort-keys/--no-sort-keys', is_flag=True, default=True,
+              show_default=True, help="Sort JSON keys when serializing.")
 @click.option('--bbox', default=None, metavar="w,s,e,n",
               help="filter for features intersecting a bounding box")
 @click.pass_context
 def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
-        use_rs, bbox):
+        use_rs, bbox, sort_keys):
     """Concatenate and print the features of input datasets as a
     sequence of GeoJSON features."""
     
@@ -92,12 +94,13 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
     verbosity = (ctx.obj and ctx.obj['verbosity']) or 2
     logger = logging.getLogger('fio')
 
-    # dump_kwds = {'sort_keys': True}
     dump_kwds = {}
     if indent:
         dump_kwds['indent'] = indent
     if compact:
         dump_kwds['separators'] = (',', ':')
+    if sort_keys:
+        dump_kwds['sort_keys'] = True
     item_sep = compact and ',' or ', '
 
     try:

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -87,10 +87,13 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
         use_rs, bbox):
     """Concatenate and print the features of input datasets as a
     sequence of GeoJSON features."""
+    
+    json_lib = ctx.obj['json_lib']
     verbosity = (ctx.obj and ctx.obj['verbosity']) or 2
     logger = logging.getLogger('fio')
 
-    dump_kwds = {'sort_keys': True}
+    # dump_kwds = {'sort_keys': True}
+    dump_kwds = {}
     if indent:
         dump_kwds['indent'] = indent
     if compact:
@@ -105,7 +108,7 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
                         try:
                             bbox = tuple(map(float, bbox.split(',')))
                         except ValueError:
-                            bbox = json.loads(bbox)
+                            bbox = json_lib.loads(bbox)
                     for i, feat in src.items(bbox=bbox):
                         if dst_crs or precision > 0:
                             g = transform_geom(
@@ -116,7 +119,7 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
                             feat['bbox'] = fiona.bounds(g)
                         if use_rs:
                             click.echo(u'\u001e', nl=False)
-                        click.echo(json.dumps(feat, **dump_kwds))
+                        click.echo(json_lib.dumps(feat, **dump_kwds))
 
     except Exception:
         logger.exception("Exception caught during processing")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from pkg_resources import iter_entry_points
 import re
 
+import click
 from click.testing import CliRunner
 
 from fiona.fio.main import main_group
@@ -36,3 +37,14 @@ def test_all_registered():
     # Make sure all the subcommands are actually registered to the main CLI group
     for ep in iter_entry_points('fiona.fio_commands'):
         assert ep.name in main_group.commands
+
+
+def test_define_json_lib():
+    # Don't need to actually import another JSON library.  Just import
+    # something and make sure the correct variable is populated.
+    @main_group.command()
+    @click.pass_context
+    def cmd(ctx):
+        assert ctx.obj['json_lib'] == click
+    result = CliRunner().invoke(main_group, ['-D', 'json_lib=click', 'cmd'])
+    assert result.exit_code == 0

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -1,9 +1,12 @@
-import json
+"""
+Unittests for fio cat
+"""
 
-import click
+
 from click.testing import CliRunner
 
 from fiona.fio import cat
+from fiona.fio.main import main_group
 
 from .fixtures import (
     feature_collection, feature_collection_pp, feature_seq, feature_seq_pp_rs)
@@ -14,14 +17,14 @@ WILDSHP = 'tests/data/coutwildrnp.shp'
 
 def test_one():
     runner = CliRunner()
-    result = runner.invoke(cat.cat, [WILDSHP])
+    result = runner.invoke(main_group, ['cat', WILDSHP])
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 67
 
 
 def test_two():
     runner = CliRunner()
-    result = runner.invoke(cat.cat, [WILDSHP, WILDSHP])
+    result = runner.invoke(main_group, ['cat', WILDSHP, WILDSHP])
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 134
 
@@ -29,8 +32,8 @@ def test_two():
 def test_bbox_no():
     runner = CliRunner()
     result = runner.invoke(
-        cat.cat,
-        [WILDSHP, '--bbox', '0,10,80,20'],
+        main_group,
+        ['cat', WILDSHP, '--bbox', '0,10,80,20'],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output == ""
@@ -39,8 +42,8 @@ def test_bbox_no():
 def test_bbox_yes():
     runner = CliRunner()
     result = runner.invoke(
-        cat.cat,
-        [WILDSHP, '--bbox', '-109,37,-107,39'],
+        main_group,
+        ['cat', WILDSHP, '--bbox', '-109,37,-107,39'],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 19
@@ -49,8 +52,8 @@ def test_bbox_yes():
 def test_bbox_json_yes():
     runner = CliRunner()
     result = runner.invoke(
-        cat.cat,
-        [WILDSHP, '--bbox', '[-109,37,-107,39]'],
+        main_group,
+        ['cat', WILDSHP, '--bbox', '[-109,37,-107,39]'],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 19


### PR DESCRIPTION
**Not ready**

Closes #271 

@sgillies I was thinking something like this.  As an MVP I only changed `fio cat`.  The assumption is that the user will supply a library that implements `json_lib.loads()` and `json_lib.dumps()`.   `ujson` doesn't like the `sort_keys` parameter so I moved it to an option so it can be disabled.  `simplejson` supports all of the optional `json.dumps()` options.

```console
$ fio -D json_lib=ujson cat tests/data/coutwildrnp.shp --no-sort-keys
```