### PR TITLE
Prevent sending undefined or non-UTF strings into OGR

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,14 +3,13 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
-1.6.2 (2015-09-18)
+1.6.2 (2015-09-22)
 ------------------
-- Providing only PROJ4 representations in the dataset meta property resulted
-  in loss of CRS information when using the 
-  `fiona.open(..., **src.meta) as dst` pattern (#265). This bug has been 
-  addressed by adding a crs_wkt item to the meta property and extending the
-  `fiona.open()` and the collection constructor to look for and prioritize
-  this keyword argument.
+- Providing only PROJ4 representations in the dataset meta property resulted in
+  loss of CRS information when using the `fiona.open(..., **src.meta) as dst`
+  pattern (#265). This bug has been addressed by adding a crs_wkt item to the
+  meta property and extending the `fiona.open()` and the collection constructor
+  to look for and prioritize this keyword argument.
 
 1.6.1 (2015-08-12)
 ------------------

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -1,14 +1,33 @@
+# Errors.
+
+
 class FionaValueError(ValueError):
     """Fiona-specific value errors"""
+
 
 class DriverError(FionaValueError):
     """Encapsulates unsupported driver and driver mode errors."""
 
+
 class SchemaError(FionaValueError):
     """When a schema mapping has no properties or no geometry."""
+
 
 class CRSError(FionaValueError):
     """When a crs mapping has neither init or proj items."""
 
+
 class DataIOError(IOError):
-    """IO errors involving driver registration or availability"""
+    """IO errors involving driver registration or availability."""
+
+
+class FieldNameEncodeError(UnicodeEncodeError):
+    """Failure to encode a field name."""
+
+
+class StringFieldEncodeError(UnicodeEncodeError):
+    """Failure to encode a string field value."""
+
+
+class StringFieldDecodeError(UnicodeDecodeError):
+    """Failure to decode a string field value."""

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -264,7 +264,7 @@ cdef class OGRFeatureBuilder:
 
             # Catch and re-raise unicode encoding errors.
             try:
-                key_bytes = ogr_key.encode(encoding) #'utf-8')
+                key_bytes = ogr_key.encode(encoding)
             except (UnicodeEncodeError, UnicodeEncodeError) as exc:
                 raise FieldNameEncodeError(
                     "Failed to encode {0} using {1} codec: {2}".format(
@@ -314,7 +314,7 @@ cdef class OGRFeatureBuilder:
                 
                 # Catch and re-raise string field value encoding errors.
                 try:
-                    value_bytes = value.encode(encoding) #'utf-8')
+                    value_bytes = value.encode(encoding)
                 except (UnicodeEncodeError, UnicodeDecodeError) as exc:
                     raise StringFieldEncodeError(
                         "Failed to encode {0} using {1} codec: {2}".format(

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -16,7 +16,9 @@ from fiona cimport ograpi
 from fiona._geometry cimport GeomBuilder, OGRGeomBuilder
 from fiona._err import cpl_errs
 from fiona._geometry import GEOMETRY_TYPES
-from fiona.errors import DriverError, SchemaError, CRSError, FionaValueError
+from fiona.errors import (
+    DriverError, SchemaError, CRSError, FionaValueError, FieldNameEncodeError,
+    StringFieldEncodeError, StringFieldDecodeError)
 from fiona.odict import OrderedDict
 from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
@@ -180,9 +182,10 @@ cdef class FeatureBuilder:
                 try:
                     val = ograpi.OGR_F_GetFieldAsString(feature, i)
                     val = val.decode(encoding)
-                except UnicodeDecodeError:
-                    log.warn(
-                        "Failed to decode %s using %s codec", val, encoding)
+                except UnicodeDecodeError as exc:
+                    raise StringFieldDecodeError(
+                        "Failed to decode {0} using {1} codec: {2}".format(
+                            val, encoding, str(exc)))
 
                 # Does the text contain a JSON object? Let's check.
                 # Let's check as cheaply as we can.
@@ -258,11 +261,15 @@ cdef class OGRFeatureBuilder:
                 "Looking up %s in %s", key, repr(session._schema_mapping))
             ogr_key = session._schema_mapping[key]
             schema_type = collection.schema['properties'][key]
+
+            # Catch and re-raise unicode encoding errors.
             try:
-                key_bytes = ogr_key.encode(encoding)
-            except UnicodeDecodeError:
-                log.warn("Failed to encode %s using %s codec", key, encoding)
-                key_bytes = ogr_key
+                key_bytes = ogr_key.encode(encoding) #'utf-8')
+            except (UnicodeEncodeError, UnicodeEncodeError) as exc:
+                raise FieldNameEncodeError(
+                    "Failed to encode {0} using {1} codec: {2}".format(
+                        key, encoding, str(exc)))
+
             key_c = key_bytes
             i = ograpi.OGR_F_GetFieldIndex(cogr_feature, key_c)
             if i < 0:
@@ -304,12 +311,15 @@ cdef class OGRFeatureBuilder:
                 ograpi.OGR_F_SetFieldDateTime(
                     cogr_feature, i, 0, 0, 0, hh, mm, ss, 0)
             elif isinstance(value, string_types):
+                
+                # Catch and re-raise string field value encoding errors.
                 try:
-                    value_bytes = value.encode(encoding)
-                except UnicodeDecodeError:
-                    log.warn(
-                        "Failed to encode %s using %s codec", value, encoding)
-                    value_bytes = value
+                    value_bytes = value.encode(encoding) #'utf-8')
+                except (UnicodeEncodeError, UnicodeDecodeError) as exc:
+                    raise StringFieldEncodeError(
+                        "Failed to encode {0} using {1} codec: {2}".format(
+                            value, encoding, str(exc)))
+
                 string_c = value_bytes
                 ograpi.OGR_F_SetFieldString(cogr_feature, i, string_c)
             elif value is None:


### PR DESCRIPTION
And raise more helpful errors.

Closes #303 