### PR TITLE
add a --no-parse option to fio collect

### DIFF
--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -116,3 +116,49 @@ def test_dump():
     result = runner.invoke(cat.dump, [WILDSHP])
     assert result.exit_code == 0
     assert '"FeatureCollection"' in result.output
+
+
+def test_collect_noparse():
+    runner = CliRunner()
+    result = runner.invoke(
+        cat.collect,
+        ['--no-parse'],
+        feature_seq,
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 2
+    assert len(json.loads(result.output)['features']) == 2
+
+
+def test_collect_noparse_records():
+    runner = CliRunner()
+    result = runner.invoke(
+        cat.collect,
+        ['--no-parse', '--record-buffered'],
+        feature_seq,
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 2
+    assert len(json.loads(result.output)['features']) == 2
+
+
+def test_collect_src_crs():
+    runner = CliRunner()
+    result = runner.invoke(
+        cat.collect,
+        ['--no-parse', '--src-crs', 'epsg:4326'],
+        feature_seq,
+        catch_exceptions=False)
+    assert result.exit_code == 2
+
+
+def test_collect_noparse_rs():
+    runner = CliRunner()
+    result = runner.invoke(
+        cat.collect,
+        ['--no-parse'],
+        feature_seq_pp_rs,
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 2
+    assert len(json.loads(result.output)['features']) == 2


### PR DESCRIPTION
This is working but needs some review. 

It should work with `--record-buffered` and `--no-record-buffered`, and with line-delimited and rs-delimited sequences. 

if we're not parsing the json, we can't transform it so the `--src-crs` option isn't compatible with `--no-parse` and raises a click usage error.

I'm not thrilled at adding lots of if statements everywhere; there might be an entirely different way to structure this logic that doesn't result in so many nested conditionals.

resolves #306 