### PR TITLE
Changed gdal_output[3] to gdalversion in copy_gdalapi()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,11 @@ with open('CHANGES.txt', **open_kwds) as f:
 
 def copy_gdalapi(gdalversion):
     if gdalversion[0] == u'1':
-        log.info("Building Fiona for gdal 1.x: {}".format(gdal_output[3]))
+        log.info("Building Fiona for gdal 1.x: {0}".format(gdalversion))
         shutil.copy('fiona/ogrext1.pyx', 'fiona/ogrext.pyx')
         shutil.copy('fiona/ograpi1.pxd', 'fiona/ograpi.pxd')
     else:
-        log.info("Building Fiona for gdal 2.x: {}".format(gdal_output[3]))
+        log.info("Building Fiona for gdal 2.x: {0}".format(gdalversion))
         shutil.copy('fiona/ogrext2.pyx', 'fiona/ogrext.pyx')
         shutil.copy('fiona/ograpi2.pxd', 'fiona/ograpi.pxd')
 


### PR DESCRIPTION
 Also made the .format() Python 2.6 compliant.

This is the same PR as #298.  My git-fu was not good enough to figure out git "squashing".