### PR TITLE
New CLI command for listing layers: fio ls

### DIFF
--- a/fiona/fio/ls.py
+++ b/fiona/fio/ls.py
@@ -1,0 +1,19 @@
+import json
+
+import fiona
+
+import click
+from cligj import indent_opt
+
+
+@click.command()
+@click.argument('input', type=click.Path(exists=True))
+@indent_opt
+def ls(input, indent):
+
+    """
+    List layers in a datasource.
+    """
+
+    result = fiona.listlayers(input)
+    click.echo(json.dumps(result, indent=indent))

--- a/fiona/fio/ls.py
+++ b/fiona/fio/ls.py
@@ -9,11 +9,15 @@ from cligj import indent_opt
 @click.command()
 @click.argument('input', type=click.Path(exists=True))
 @indent_opt
-def ls(input, indent):
+@click.pass_context
+def ls(ctx, input, indent):
 
     """
     List layers in a datasource.
     """
 
-    result = fiona.listlayers(input)
-    click.echo(json.dumps(result, indent=indent))
+    verbosity = (ctx.obj and ctx.obj['verbosity']) or 2
+
+    with fiona.drivers(CPL_DEBUG=verbosity > 2):
+        result = fiona.listlayers(input)
+        click.echo(json.dumps(result, indent=indent))

--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,7 @@ setup_args = dict(
         info=fiona.fio.info:info
         insp=fiona.fio.info:insp
         load=fiona.fio.cat:load
+        ls=fiona.fio.ls:ls
         filter=fiona.fio.filter:filter
         ''',
     install_requires=requirements,

--- a/tests/test_fio_ls.py
+++ b/tests/test_fio_ls.py
@@ -1,0 +1,58 @@
+"""Unittests for `$ fio ls`"""
+
+
+import json
+import shutil
+import tempfile
+
+from click.testing import CliRunner
+
+import fiona
+from fiona.fio.main import main_group
+
+
+def test_fio_ls_single_layer():
+
+    result = CliRunner().invoke(main_group, [
+        'ls',
+        'tests/data/'])
+    assert result.exit_code == 0
+    assert len(result.output.splitlines()) == 1
+    assert json.loads(result.output) == ['coutwildrnp']
+
+
+def test_fio_ls_indent():
+
+    result = CliRunner().invoke(main_group, [
+        'ls',
+        '--indent', '4',
+        'tests/data/coutwildrnp.shp'])
+    assert result.exit_code == 0
+    assert len(result.output.strip().splitlines()) == 3
+    assert json.loads(result.output) == ['coutwildrnp']
+
+
+def test_fio_ls_multi_layer():
+
+    infile = 'tests/data/coutwildrnp.shp'
+    outdir = tempfile.mkdtemp()
+    try:
+        
+        # Copy test shapefile into new directory
+        # Shapefile driver treats a directory of shapefiles as a single
+        # multi-layer datasource
+        layer_names = ['l1', 'l2']
+        for layer in layer_names:
+            with fiona.open(infile) as src, \
+                    fiona.open(outdir, 'w', layer=layer, **src.meta) as dst:
+                for feat in src:
+                    dst.write(feat)
+
+        # Run CLI test
+        result = CliRunner().invoke(main_group, [
+            'ls', outdir])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == layer_names
+
+    finally:
+        shutil.rmtree(outdir)


### PR DESCRIPTION
Related to https://github.com/Toblerity/Fiona/issues/316

@sgillies While looking at #316 it seems useful to have a CLI command for listing the layers contained within a datasource.

```console
$ mkdir datasource
$ ogr2ogr datasource/layer1.shp tests/data/coutwildrnp.shp
$ ogr2ogr datasource/layer2.shp tests/data/coutwildrnp.shp
$ fio ls datasource/ --indent 4
[
    "layer1",
    "layer2"
]
```

```console
$ fio ls --help
Usage: fio ls [OPTIONS] INPUT

  List layers in a datasource.

Options:
  --indent INTEGER  Indentation level for JSON output
  --help            Show this message and exit.
```