### PR TITLE
Add --layer to $ fio info and $ fio load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - coverage run --source=fiona --omit='*.pxd,*.pyx,*/tests/*,*/docs/*,*/examples/*,*/benchmarks/*' -m nose --exclude test_filter_vsi --exclude test_geopackage
 
 after_success:
-  - coveralls
+  - coveralls || echo "!! intermittent coveralls failure"
 
 env:
 

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -527,8 +527,11 @@ def dump(ctx, input, encoding, precision, indent, compact, record_buffered,
     '--sequence / --no-sequence', default=False,
     help="Specify whether the input stream is a LF-delimited sequence of GeoJSON "
          "features (the default) or a single GeoJSON feature collection.")
+@click.option('--layer', metavar="INDEX|NAME", callback=options.cb_layer,
+              help="Load features into specified layer.  Layers use zero-based numbering when "
+                   "accessed by index.")
 @click.pass_context
-def load(ctx, output, driver, src_crs, dst_crs, sequence):
+def load(ctx, output, driver, src_crs, dst_crs, sequence, layer):
     """Load features from JSON to a file in another format.
 
     The input is a GeoJSON feature collection or optionally a sequence of
@@ -594,7 +597,8 @@ def load(ctx, output, driver, src_crs, dst_crs, sequence):
                     output, 'w',
                     driver=driver,
                     crs=dst_crs,
-                    schema=schema) as dst:
+                    schema=schema,
+                    layer=layer) as dst:
                 dst.write(first)
                 dst.writerecords(source)
 

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -14,6 +14,7 @@ from cligj import indent_opt
 
 import fiona
 import fiona.crs
+from fiona.fio import options
 
 
 @click.command(short_help="Print information about the fio environment.")
@@ -36,9 +37,13 @@ def env(ctx, key):
 
 
 # Info command.
-@click.command(short_help="Print information about a dataset.")
+@click.command()
 # One or more files.
 @click.argument('input', type=click.Path(exists=True))
+@click.option('--layer', metavar="INDEX|NAME", callback=options.cb_layer,
+              help="Print information about a specific layer.  The first layer "
+                   "is used by default.  Layers use zero-based numbering when "
+                   "accessed by index.")
 @indent_opt
 # Options to pick out a single metadata item and print it as
 # a string.
@@ -54,19 +59,27 @@ def env(ctx, key):
 @click.option('--name', 'meta_member', flag_value='name',
               help="Print the datasource's name.")
 @click.pass_context
-def info(ctx, input, indent, meta_member):
+def info(ctx, input, indent, meta_member, layer):
+
+    """
+    Print information about a dataset.
+
+    When working with a multi-layer dataset the first layer is used by default.
+    Use the '--layer' option to select a different layer.
+    """
+
     verbosity = (ctx.obj and ctx.obj['verbosity']) or 2
     logger = logging.getLogger('fio')
     try:
         with fiona.drivers(CPL_DEBUG=verbosity>2):
-            with fiona.open(input) as src:
+            with fiona.open(input, layer=layer) as src:
                 info = src.meta
                 info.update(bounds=src.bounds, name=src.name)
                 try:
                     info.update(count=len(src))
                 except TypeError as e:
                     info.update(count=None)
-                    msg = str(e) + "  Setting 'count' to 'null'"
+                    msg = "{exc} Setting 'count' to 'null'".format(exc=str(e))
                     warnings.warn(msg, RuntimeWarning)
                 proj4 = fiona.crs.to_string(src.crs)
                 if proj4.startswith('+init=epsg'):

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -7,6 +7,7 @@ import code
 import logging
 import json
 import sys
+import warnings
 
 import click
 from cligj import indent_opt
@@ -58,7 +59,13 @@ def info(ctx, input, indent, meta_member):
         with fiona.drivers(CPL_DEBUG=verbosity>2):
             with fiona.open(input) as src:
                 info = src.meta
-                info.update(bounds=src.bounds, count=len(src))
+                info.update(bounds=src.bounds)
+                try:
+                    info.update(count=len(src))
+                except TypeError as e:
+                    info.update(count=None)
+                    msg = str(e) + "  Setting 'count' to 'null'"
+                    warnings.warn(msg, RuntimeWarning)
                 proj4 = fiona.crs.to_string(src.crs)
                 if proj4.startswith('+init=epsg'):
                     proj4 = proj4.split('=')[1].upper()

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -51,6 +51,8 @@ def env(ctx, key):
 @click.option('--bounds', 'meta_member', flag_value='bounds',
               help="Print the boundary coordinates "
                    "(left, bottom, right, top).")
+@click.option('--name', 'meta_member', flag_value='name',
+              help="Print the datasource's name.")
 @click.pass_context
 def info(ctx, input, indent, meta_member):
     verbosity = (ctx.obj and ctx.obj['verbosity']) or 2
@@ -59,7 +61,7 @@ def info(ctx, input, indent, meta_member):
         with fiona.drivers(CPL_DEBUG=verbosity>2):
             with fiona.open(input) as src:
                 info = src.meta
-                info.update(bounds=src.bounds)
+                info.update(bounds=src.bounds, name=src.name)
                 try:
                     info.update(count=len(src))
                 except TypeError as e:

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -7,7 +7,6 @@ import code
 import logging
 import json
 import sys
-import warnings
 
 import click
 from cligj import indent_opt
@@ -79,8 +78,8 @@ def info(ctx, input, indent, meta_member, layer):
                     info.update(count=len(src))
                 except TypeError as e:
                     info.update(count=None)
-                    msg = "{exc} Setting 'count' to 'null'".format(exc=str(e))
-                    warnings.warn(msg, RuntimeWarning)
+                    logger.debug("Setting 'count' to None/null - layer does "
+                                 "not support counting")
                 proj4 = fiona.crs.to_string(src.crs)
                 if proj4.startswith('+init=epsg'):
                     proj4 = proj4.split('=')[1].upper()

--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -6,3 +6,17 @@ import click
 
 src_crs_opt = click.option('--src-crs', '--src_crs', help="Source CRS.")
 dst_crs_opt = click.option('--dst-crs', '--dst_crs', help="Destination CRS.")
+
+
+def cb_layer(ctx, param, value):
+    """Let --layer be a name or index."""
+
+    if value is None or not value.isdigit():
+        return value
+    else:
+        value = int(value)
+        if value < 0:
+            raise click.BadParameter(
+                "layer indexes must be >= 1, not {}".format(value))
+        else:
+            return value

--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -14,9 +14,4 @@ def cb_layer(ctx, param, value):
     if value is None or not value.isdigit():
         return value
     else:
-        value = int(value)
-        if value < 0:
-            raise click.BadParameter(
-                "layer indexes must be >= 1, not {}".format(value))
-        else:
-            return value
+        return int(value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 from pkg_resources import iter_entry_points
 import re
 
@@ -36,3 +37,17 @@ def test_all_registered():
     # Make sure all the subcommands are actually registered to the main CLI group
     for ep in iter_entry_points('fiona.fio_commands'):
         assert ep.name in main_group.commands
+
+
+def test_info_no_count():
+    """Make sure we can still get a `$ fio info` report on datasources that do
+    not support feature counting, AKA `len(collection)`.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main_group, ['info', 'tests/data/test_gpx.gpx'])
+    assert result.exit_code == 0
+    lines = list(filter(
+        lambda x: 'RuntimeWarning' not in x,
+        result.output.splitlines()))
+    assert len(lines) == 1, "First line is warning & second is JSON.  No more."
+    assert json.loads(lines[0])['count'] is None

--- a/tests/test_fio_info.py
+++ b/tests/test_fio_info.py
@@ -40,6 +40,13 @@ def test_all_registered():
         assert ep.name in main_group.commands
 
 
+def _filter_info_warning(lines):
+    """$ fio info can issue a RuntimeWarning, but click adds stderr to stdout
+    so we have to filter it out before decoding JSON lines."""
+    lines = list(filter(lambda x: 'RuntimeWarning' not in x, lines))
+    return lines
+
+
 def test_info_no_count():
     """Make sure we can still get a `$ fio info` report on datasources that do
     not support feature counting, AKA `len(collection)`.
@@ -47,8 +54,20 @@ def test_info_no_count():
     runner = CliRunner()
     result = runner.invoke(main_group, ['info', 'tests/data/test_gpx.gpx'])
     assert result.exit_code == 0
-    lines = list(filter(
-        lambda x: 'RuntimeWarning' not in x,
-        result.output.splitlines()))
+    lines = _filter_info_warning(result.output.splitlines())
     assert len(lines) == 1, "First line is warning & second is JSON.  No more."
     assert json.loads(lines[0])['count'] is None
+
+
+def test_info_layer():
+    for layer in ('routes', '1'):
+        runner = CliRunner()
+        result = runner.invoke(main_group, [
+            'info',
+            'tests/data/test_gpx.gpx',
+            '--layer', layer])
+        print(result.output)
+        assert result.exit_code == 0
+        lines = _filter_info_warning(result.output.splitlines())
+        assert len(lines) == 1, "1st line is warning & 2nd is JSON - no more."
+        assert json.loads(lines[0])['name'] == 'routes'

--- a/tests/test_fio_info.py
+++ b/tests/test_fio_info.py
@@ -17,6 +17,7 @@ def test_info_json():
     assert '"count": 67' in result.output
     assert '"crs": "EPSG:4326"' in result.output
     assert '"driver": "ESRI Shapefile"' in result.output
+    assert '"name": "coutwildrnp"' in result.output
 
 
 def test_info_count():


### PR DESCRIPTION
Closes #299 
Closes #316 

@sgillies Ready for review.

This PR adds `--layer` to `$ fio info` to let users specify which layer they want to run a report on, and `--layer` to `$ fio load` so users can specify which layer they want to load data into.

**info example**
```console
$ fio info --layer routes tests/data/test_gpx.gpx --name
/Users/wursterk/code/Fiona/fiona/fio/info.py:83: RuntimeWarning: Layer does not support counting Setting 'count' to 'null'
  warnings.warn(msg, RuntimeWarning)
routes
```

**load example**

```console
$ fio cat tests/data/coutwildrnp.shp \
    | fio load OUT.gdb -f FileGDB --src-crs EPSG:4326 --sequence --layer new
$ fio ls OUT.gdb
["new"]
```

This also addresses an issue where `$ fio info` crashed when `len(collection)` crashed so now we catch the exception, issue a `RuntimeWarning`, and set `count=None`.

`$ ogrinfo`'s report sets the feature count to `0`, but `None/null` seems more appropriate and more likely to alert users that they may need to convert their data to a different format.

Previously:

```console
fio info tests/data/test_gpx.gpx 
ERROR:fio:Exception caught during processing
Traceback (most recent call last):
  File "/Users/wursterk/code/Fiona/fiona/fio/info.py", line 61, in info
    info.update(bounds=src.bounds, count=len(src))
  File "/Users/wursterk/code/Fiona/fiona/collection.py", line 375, in __len__
    raise TypeError("Layer does not support counting")
TypeError: Layer does not support counting
Aborted!
```

/ cc @micahcochran @smnorris