### PR TITLE
Warn users if they use gdal2 with fiona 1.x

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -91,8 +91,8 @@ log.addHandler(NullHandler())
 
 # Warn user that they use fiona 1.x with gdal 2.0
 if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
-    warnings.warn("Fiona {} is not compatible with installed GDAL {}".format(__version__,
-                                                                             get_gdal_release_name()))            
+    msg = "Fiona {} is only compatible with GDAL 1.x (installed {})"
+    warnings.warn(msg.format(__version__, get_gdal_release_name()))            
 
 
 def open(

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -73,6 +73,9 @@ from fiona.collection import Collection, BytesCollection, vsi_path
 from fiona._drivers import driver_count, GDALEnv, supported_drivers
 from fiona.odict import OrderedDict
 from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP
+from fiona.ogrext import (
+    calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
+import warnings
 
 # These modules are imported by fiona.ogrext, but are also import here to
 # help tools like cx_Freeze find them automatically
@@ -84,6 +87,12 @@ class NullHandler(logging.Handler):
     def emit(self, record):
         pass
 log.addHandler(NullHandler())
+
+
+# Warn user that they use fiona 1.x with gdal 2.0
+if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
+    warnings.warn("Fiona {} is not compatible with installed GDAL {}".format(__version__,
+                                                                             get_gdal_release_name()))            
 
 
 def open(

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -49,6 +49,8 @@ FIELD_TYPES = [
     'date',         # OFTDate, Date
     'time',         # OFTTime, Time
     'datetime',     # OFTDateTime, Date and Time
+    'int',          # OFTInteger64, Single 64bit integer #Not supported
+    None,           # OFTInteger64List, List of 64bit integers #Not supported
     ]
 
 # Mapping of Fiona field type names to Python types.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('fiona/__init__.py', 'r') as f:
             version = line.split("=")[1].strip()
             version = version.strip('"')
             version = version.strip("'")
-            continue
+            break
 
 # Fiona's auxiliary files are UTF-8 encoded and we'll specify this when
 # reading with Python 3+


### PR DESCRIPTION
This PR includes two updates:

- The user is presented a warning if he uses fiona 1.x with gdal2 when he imports fiona
- The FIELD_TYPES list is extended with the 64bit Integer Types of gdal2.0.  64bit integers are thus internally treated as normal integers. 

This should have no effect when gdal1.x is used. For some drivers (e.g. shapefile), integer fields with a large enough length are treated as 64bit integer in gdal2.x while as "normal" 32bit integers in gdal1.x. Adding the 64bit Integer type to the FIELD_TYPES should thus fix the 'IndexError: list index out of range' present in some bug reports of the past.