### PR TITLE
Gdal version attr

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
-1.6.3 (2015-09-22)
+1.6.3 (2015-12-22)
 ------------------
 - Daytime has been decreasing in the Northern Hemisphere, but is now
   increasing again as it should.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,12 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
+1.6.4 (2016-05-06)
+------------------
+- Raise ImportError if the active GDAL library version is >= 2.0 instead of
+  failing unpredictably (#338, #341). Support for GDAL>=2.0 is coming in
+  Fiona 1.7.
+
 1.6.3.post1 (2016-03-27)
 ------------------------
 - No changes to the library in this post-release version, but there is a

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,14 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
+1.6.3.post1 (2016-03-27)
+------------------------
+- No changes to the library in this post-release version, but there is a
+  significant change to the distributions on PyPI: to help make Fiona more
+  compatible with Shapely on OS X, the GDAL shared library included in the
+  macosx (only) binary wheels now statically links the GEOS library. See
+  https://github.com/sgillies/frs-wheel-builds/issues/5.
+
 1.6.3 (2015-12-22)
 ------------------
 - Daytime has been decreasing in the Northern Hemisphere, but is now
@@ -16,7 +24,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 ------------------
 - Providing only PROJ4 representations in the dataset meta property resulted in
   loss of CRS information when using the `fiona.open(..., **src.meta) as dst`
-  pattern (#265). This bug has been addressed by adding a crs_wkt item to the
+  pattern (#265). This bug has been addressed by adding a crs_wkt item to the`
   meta property and extending the `fiona.open()` and the collection constructor
   to look for and prioritize this keyword argument.
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -24,7 +24,7 @@ attribute table. For example:
    'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
    'properties': {'label': u'Null Island'} }
 
-is a Fiona feature with a point geometry and one property. 
+is a Fiona feature with a point geometry and one property.
 
 Features are read and written using objects returned by the
 ``collection`` function. These ``Collection`` objects are a lot like
@@ -62,9 +62,6 @@ Because Fiona collections are context managers, they are closed and (in
 writing modes) flush contents to disk when their ``with`` blocks end.
 """
 
-__all__ = ['bounds', 'listlayers', 'open', 'prop_type', 'prop_width']
-__version__ = "1.6.3.post1"
-
 import logging
 import os
 from six import string_types
@@ -82,18 +79,22 @@ import warnings
 from fiona import _geometry, _err, rfc3339
 import uuid
 
+
+__all__ = ['bounds', 'listlayers', 'open', 'prop_type', 'prop_width']
+__version__ = "1.6.4"
+__gdal_version__ = get_gdal_release_name().decode('utf-8')
+
+# Warn user that they use fiona 1.x with gdal 2.0
+if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
+    raise ImportError(
+        "Fiona {0} is only compatible with GDAL 1.x (installed: {1})".format(
+            __version__, __gdal_version__))
+
 log = logging.getLogger('Fiona')
 class NullHandler(logging.Handler):
     def emit(self, record):
         pass
 log.addHandler(NullHandler())
-
-
-# Warn user that they use fiona 1.x with gdal 2.0
-if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
-    msg = "Fiona {} is only compatible with GDAL 1.x (installed {})"
-    warnings.warn(msg.format(__version__, get_gdal_release_name()))            
-
 
 def open(
         path,
@@ -106,7 +107,6 @@ def open(
         vfs=None,
         enabled_drivers=None,
         crs_wkt=None):
-    
     """Open file at ``path`` in ``mode`` "r" (read), "a" (append), or
     "w" (write) and return a ``Collection`` object.
     

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -63,7 +63,7 @@ writing modes) flush contents to disk when their ``with`` blocks end.
 """
 
 __all__ = ['bounds', 'listlayers', 'open', 'prop_type', 'prop_width']
-__version__ = "1.6.3"
+__version__ = "1.6.3.post1"
 
 import logging
 import os

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -73,6 +73,9 @@ from fiona.collection import Collection, BytesCollection, vsi_path
 from fiona._drivers import driver_count, GDALEnv, supported_drivers
 from fiona.odict import OrderedDict
 from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP
+from fiona.ogrext import (
+    calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
+import warnings
 
 # These modules are imported by fiona.ogrext, but are also import here to
 # help tools like cx_Freeze find them automatically
@@ -84,6 +87,12 @@ class NullHandler(logging.Handler):
     def emit(self, record):
         pass
 log.addHandler(NullHandler())
+
+
+# Warn user that they use fiona 1.x with gdal 2.0
+if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
+    msg = "Fiona {} is only compatible with GDAL 1.x (installed {})"
+    warnings.warn(msg.format(__version__, get_gdal_release_name()))            
 
 
 def open(

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -49,6 +49,8 @@ FIELD_TYPES = [
     'date',         # OFTDate, Date
     'time',         # OFTTime, Time
     'datetime',     # OFTDateTime, Date and Time
+    'int',          # OFTInteger64, Single 64bit integer #Not supported
+    None,           # OFTInteger64List, List of 64bit integers #Not supported
     ]
 
 # Mapping of Fiona field type names to Python types.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('fiona/__init__.py', 'r') as f:
             version = line.split("=")[1].strip()
             version = version.strip('"')
             version = version.strip("'")
-            continue
+            break
 
 # Fiona's auxiliary files are UTF-8 encoded and we'll specify this when
 # reading with Python 3+


### PR DESCRIPTION
Adds a `__gdal_version__` attribute and raises `ImportError` if GDAL>=2.0 (until the 1.7 release).