### PR TITLE
Free memory malloc'ed in string_list. Fixes #337.

### DIFF
--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -421,6 +421,7 @@ cdef class Session:
                                                drvs,
                                                NULL,
                                                NULL)
+                        free(drvs)
                     if ds != NULL:
                         self.cogr_ds = ds
                         collection._driver = name


### PR DESCRIPTION
As title. `malloc` was missing a corresponding `free`.