### PR TITLE
Multilayer

### DIFF
--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -20,9 +20,9 @@ warnings.simplefilter('default')
 @click.command(short_help="Concatenate and print the features of datasets")
 @cligj.files_in_arg
 @click.option('--layer', default=None, multiple=True,
-              callback=options.cb_multi_layer,
-              help="Input layer(s), specified as 'fileindex.layer` "
-                   "For example, '1.foo,2.bar' will concatenate layer foo "
+              callback=options.cb_multilayer,
+              help="Input layer(s), specified as 'fileindex:layer` "
+                   "For example, '1:foo,2:bar' will concatenate layer foo "
                    "from file 1 and layer bar from file 2")
 @cligj.precision_opt
 @cligj.indent_opt
@@ -53,11 +53,15 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
         dump_kwds['indent'] = indent
     if compact:
         dump_kwds['separators'] = (',', ':')
-    # always use first layer as defualt
+    item_sep = compact and ',' or ', '
+    # Validate file idexes provided in --layer option
+    # (can't pass the files to option callback)
+    if layer:
+        options.validate_multilayer_file_index(files, layer)
+    # first layer is the default
     for i in range(1, len(files) + 1):
         if str(i) not in layer.keys():
             layer[str(i)] = [0]
-    item_sep = compact and ',' or ', '
     try:
         with fiona.drivers(CPL_DEBUG=verbosity > 2):
             for i, path in enumerate(files, 1):

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -21,9 +21,9 @@ warnings.simplefilter('default')
 @cligj.files_in_arg
 @click.option('--layer', default=None, multiple=True,
               callback=options.cb_multi_layer,
-              help="Comma separated string of layer name(s) or index(es). The "
-                   "first layer is used by default. Layers use zero-based "
-                   "numbering when accessed by index.")
+              help="Input layer(s), specified as 'fileindex.layer` "
+                   "For example, '1.foo,2.bar' will concatenate layer foo "
+                   "from file 1 and layer bar from file 2")
 @cligj.precision_opt
 @cligj.indent_opt
 @cligj.compact_opt

--- a/fiona/fio/dump.py
+++ b/fiona/fio/dump.py
@@ -10,11 +10,16 @@ import cligj
 
 import fiona
 from fiona.fio import helpers
+from fiona.fio import options
 from fiona.transform import transform_geom
 
 
 @click.command(short_help="Dump a dataset to GeoJSON.")
 @click.argument('input', type=click.Path(), required=True)
+@click.option('--layer', metavar="INDEX|NAME", callback=options.cb_layer,
+              help="Print information about a specific layer.  The first "
+                   "layer is used by default.  Layers use zero-based "
+                   "numbering when accessed by index.")
 @click.option('--encoding', help="Specify encoding of the input file.")
 @cligj.precision_opt
 @cligj.indent_opt
@@ -31,7 +36,7 @@ from fiona.transform import transform_geom
                    "context.")
 @click.pass_context
 def dump(ctx, input, encoding, precision, indent, compact, record_buffered,
-         ignore_errors, with_ld_context, add_ld_context_item):
+         ignore_errors, with_ld_context, add_ld_context_item, layer):
 
     """Dump a dataset either as a GeoJSON feature collection (the default)
     or a sequence of GeoJSON features."""
@@ -50,6 +55,8 @@ def dump(ctx, input, encoding, precision, indent, compact, record_buffered,
     open_kwds = {}
     if encoding:
         open_kwds['encoding'] = encoding
+    if layer:
+        open_kwds['layer'] = layer
 
     def transformer(crs, feat):
         tg = partial(transform_geom, crs, 'EPSG:4326',

--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -1,6 +1,8 @@
 """Common commandline options for `fio`"""
 
 
+from collections import defaultdict
+
 import click
 
 
@@ -10,8 +12,23 @@ dst_crs_opt = click.option('--dst-crs', '--dst_crs', help="Destination CRS.")
 
 def cb_layer(ctx, param, value):
     """Let --layer be a name or index."""
-
     if value is None or not value.isdigit():
         return value
     else:
         return int(value)
+
+
+def cb_multi_layer(ctx, param, value):
+    """
+    Transform layer options from strings ("1.a,1.b", "2.a,2.c,2.z") to
+    {
+    '1': ['a', 'b'],
+    '2': ['a', 'c', 'z']
+    }
+    """
+    out = defaultdict(list)
+    for raw in value:
+        for v in raw.split(','):
+            ds, name = v.split('.')
+            out[ds].append(name)
+    return out

--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -18,9 +18,9 @@ def cb_layer(ctx, param, value):
         return int(value)
 
 
-def cb_multi_layer(ctx, param, value):
+def cb_multilayer(ctx, param, value):
     """
-    Transform layer options from strings ("1.a,1.b", "2.a,2.c,2.z") to
+    Transform layer options from strings ("1:a,1:b", "2:a,2:c,2:z") to
     {
     '1': ['a', 'b'],
     '2': ['a', 'c', 'z']
@@ -29,6 +29,17 @@ def cb_multi_layer(ctx, param, value):
     out = defaultdict(list)
     for raw in value:
         for v in raw.split(','):
-            ds, name = v.split('.')
+            ds, name = v.split(':')
             out[ds].append(name)
     return out
+
+
+def validate_multilayer_file_index(files, layerdict):
+    """
+    Ensure file indexes provided in the --layer option are valid
+    """
+    for key in layerdict.keys():
+        click.echo(key)
+        if key not in [str(k) for k in range(1, len(files) + 1)]:
+            layer = key+":"+layerdict[key][0]
+            raise click.BadParameter("Layer {} does not exist".format(layer))

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -56,9 +56,16 @@ def test_bbox_json_yes():
 
 
 def test_multi_layer():
-    layerdef = "1.coutwildrnp,2.coutwildrnp"
+    layerdef = "1:coutwildrnp,1:coutwildrnp"
     runner = CliRunner()
     result = runner.invoke(
-        cat.cat,
-        [WILDSHP, WILDSHP, '--layer', layerdef])
+        cat.cat, ['--layer', layerdef, 'tests/data/'])
     assert result.output.count('"Feature"') == 134
+
+
+def test_multi_layer_fail():
+    runner = CliRunner()
+    result = runner.invoke(cat.cat, '--layer'
+                           '200000:coutlildrnp',
+                           'tests/data')
+    assert result.exit_code == 1

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -53,3 +53,12 @@ def test_bbox_json_yes():
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 19
+
+
+def test_multi_layer():
+    layerdef = "1.coutwildrnp,2.coutwildrnp"
+    runner = CliRunner()
+    result = runner.invoke(
+        cat.cat,
+        [WILDSHP, WILDSHP, '--layer', layerdef])
+    assert result.output.count('"Feature"') == 134

--- a/tests/test_fio_dump.py
+++ b/tests/test_fio_dump.py
@@ -14,3 +14,12 @@ def test_dump():
     result = runner.invoke(dump.dump, [WILDSHP])
     assert result.exit_code == 0
     assert '"FeatureCollection"' in result.output
+
+
+def test_dump_layer():
+    runner = CliRunner()
+    for layer in ('routes', '1'):
+        runner = CliRunner()
+        result = runner.invoke(dump.dump, [WILDSHP, '--layer ', layer])
+        assert result.exit_code == 0
+        assert '"FeatureCollection"' in result.output

--- a/tests/test_fio_dump.py
+++ b/tests/test_fio_dump.py
@@ -7,6 +7,7 @@ from fiona.fio import dump
 
 
 WILDSHP = 'tests/data/coutwildrnp.shp'
+TESTGPX = 'tests/data/test_gpx.gpx'
 
 
 def test_dump():
@@ -17,9 +18,8 @@ def test_dump():
 
 
 def test_dump_layer():
-    runner = CliRunner()
     for layer in ('routes', '1'):
         runner = CliRunner()
-        result = runner.invoke(dump.dump, [WILDSHP, '--layer ', layer])
+        result = runner.invoke(dump.dump, [TESTGPX, '--layer', layer])
         assert result.exit_code == 0
         assert '"FeatureCollection"' in result.output


### PR DESCRIPTION
For #349, adds `--layer` to `cat` and `dump`.  `fio cat` layer indexing is by name only to keep things simple.

The layer test function in `test_fio_cat.py` isn't very comprehensive but I didn't want to add a new test data source and couldn't seem to get any features out of `test_gpx.gpx`.  I did a better feature count test against a temp .gdb created with:
```
$ fio cat coutwildrnp.shp \
| fio filter "f.properties.NAME[:5] == 'Mount'" \
| fio collect \
| fio load multilayer.gdb --driver FileGDB --layer mountains

$ fio cat coutwildrnp.shp \
| fio filter "f.properties.NAME[:5] != 'Mount'" \
| fio collect \
| fio load multilayer.gdb --driver FileGDB --layer others

$ fio cat multilayer.gdb --layer "1.mountains,1.others" | wc -l 
67
```