### PR TITLE
Add --gdal-version command line option to fio

### DIFF
--- a/fiona/fio/env.py
+++ b/fiona/fio/env.py
@@ -11,6 +11,9 @@ import fiona
 @click.command(short_help="Print information about the fio environment.")
 @click.option('--formats', 'key', flag_value='formats', default=True,
               help="Enumerate the available formats.")
+@click.option('--gdalversion', 'key', flag_value='gdalversion',
+              help="Print GDAL Version")
+
 @click.pass_context
 def env(ctx, key):
 
@@ -27,3 +30,5 @@ def env(ctx, key):
                 modes = ', '.join("'" + m + "'" for m in v)
                 stdout.write("%s (modes %s)\n" % (k, modes))
             stdout.write('\n')
+        if key == 'gdalversion':
+            click.echo("GDAL Version is {0}".format(fiona.__gdal_version__))

--- a/fiona/fio/env.py
+++ b/fiona/fio/env.py
@@ -11,9 +11,6 @@ import fiona
 @click.command(short_help="Print information about the fio environment.")
 @click.option('--formats', 'key', flag_value='formats', default=True,
               help="Enumerate the available formats.")
-@click.option('--gdalversion', 'key', flag_value='gdalversion',
-              help="Print GDAL Version")
-
 @click.pass_context
 def env(ctx, key):
 
@@ -30,5 +27,3 @@ def env(ctx, key):
                 modes = ', '.join("'" + m + "'" for m in v)
                 stdout.write("%s (modes %s)\n" % (k, modes))
             stdout.write('\n')
-        if key == 'gdalversion':
-            click.echo("GDAL Version is {0}".format(fiona.__gdal_version__))

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -20,12 +20,6 @@ def configure_logging(verbosity):
     log_level = max(10, 30 - 10*verbosity)
     logging.basicConfig(stream=sys.stderr, level=log_level)
 
-def gdal_version_cb(ctx, param, value):
-    if not value or ctx.resilient_parsing:
-        return
-    click.echo("{0}".format(fiona.__gdal_version__), color=ctx.color)
-    ctx.exit()
-
 
 @with_plugins(ep for ep in list(iter_entry_points('fiona.fio_commands')) +
               list(iter_entry_points('fiona.fio_plugins')))
@@ -33,8 +27,9 @@ def gdal_version_cb(ctx, param, value):
 @verbose_opt
 @quiet_opt
 @click.version_option(fio_version)
-@click.option(
-    '--gdal-version', is_eager=True, is_flag=True, callback=gdal_version_cb)
+@click.version_option(fiona.__gdal_version__, '--gdal-version',
+    prog_name='GDAL')
+@click.version_option(sys.version, '--python-version', prog_name='Python')
 @click.pass_context
 def main_group(ctx, verbose, quiet):
 

--- a/fiona/fio/main.py
+++ b/fiona/fio/main.py
@@ -12,12 +12,19 @@ import click
 from click_plugins import with_plugins
 from cligj import verbose_opt, quiet_opt
 
+import fiona
 from fiona import __version__ as fio_version
 
 
 def configure_logging(verbosity):
     log_level = max(10, 30 - 10*verbosity)
     logging.basicConfig(stream=sys.stderr, level=log_level)
+
+def gdal_version_cb(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo("{0}".format(fiona.__gdal_version__), color=ctx.color)
+    ctx.exit()
 
 
 @with_plugins(ep for ep in list(iter_entry_points('fiona.fio_commands')) +
@@ -26,6 +33,8 @@ def configure_logging(verbosity):
 @verbose_opt
 @quiet_opt
 @click.version_option(fio_version)
+@click.option(
+    '--gdal-version', is_eager=True, is_flag=True, callback=gdal_version_cb)
 @click.pass_context
 def main_group(ctx, verbose, quiet):
 


### PR DESCRIPTION
This command line option gives the GDAL Version that Fiona is using when running `fio` commands.

Console example on Linux:
```
$ fio env --gdalversion
GDAL Version is 1.11.2
```

There could possibly be a use case if have multiple installations of GDAL on a system.  I was using this on Travis to figure out if the correct GDAL version was being used by Fiona.  I'm not sure if this is really useful.