### PR TITLE
Protect against bad dates

### DIFF
--- a/fiona/ogrext1.pyx
+++ b/fiona/ogrext1.pyx
@@ -203,6 +203,12 @@ cdef class FeatureBuilder:
             elif fieldtype in (FionaDateType, FionaTimeType, FionaDateTimeType):
                 retval = ogrext1.OGR_F_GetFieldAsDateTime(
                     feature, i, &y, &m, &d, &hh, &mm, &ss, &tz)
+                if not y:
+                    y = 1970
+                if not m:
+                    m = 1
+                if not d:
+                    d = 1
                 if fieldtype is FionaDateType:
                     props[key] = datetime.date(y, m, d).isoformat()
                 elif fieldtype is FionaTimeType:

--- a/fiona/ogrext1.pyx
+++ b/fiona/ogrext1.pyx
@@ -203,8 +203,6 @@ cdef class FeatureBuilder:
             elif fieldtype in (FionaDateType, FionaTimeType, FionaDateTimeType):
                 retval = ogrext1.OGR_F_GetFieldAsDateTime(
                     feature, i, &y, &m, &d, &hh, &mm, &ss, &tz)
-                if not y or not m or not d:
-                    log.warning("Invalid date")
                 try:
                     if fieldtype is FionaDateType:
                          props[key] = datetime.date(y, m, d).isoformat()
@@ -213,7 +211,8 @@ cdef class FeatureBuilder:
                     else:
                          props[key] = datetime.datetime(
                              y, m, d, hh, mm, ss).isoformat()
-                except ValueError:
+                except ValueError as err:
+                    log.exception(err)
                     props[key] = None
             else:
                 log.debug("%s: None, fieldtype: %r, %r" % (key, fieldtype, fieldtype in string_types))

--- a/fiona/ogrext1.pyx
+++ b/fiona/ogrext1.pyx
@@ -203,19 +203,18 @@ cdef class FeatureBuilder:
             elif fieldtype in (FionaDateType, FionaTimeType, FionaDateTimeType):
                 retval = ogrext1.OGR_F_GetFieldAsDateTime(
                     feature, i, &y, &m, &d, &hh, &mm, &ss, &tz)
-                if not y:
-                    y = 1970
-                if not m:
-                    m = 1
-                if not d:
-                    d = 1
-                if fieldtype is FionaDateType:
-                    props[key] = datetime.date(y, m, d).isoformat()
-                elif fieldtype is FionaTimeType:
-                    props[key] = datetime.time(hh, mm, ss).isoformat()
-                else:
-                    props[key] = datetime.datetime(
-                        y, m, d, hh, mm, ss).isoformat()
+                if not y or not m or not d:
+                    log.warning("Invalid date")
+                try:
+                    if fieldtype is FionaDateType:
+                         props[key] = datetime.date(y, m, d).isoformat()
+                    elif fieldtype is FionaTimeType:
+                         props[key] = datetime.time(hh, mm, ss).isoformat()
+                    else:
+                         props[key] = datetime.datetime(
+                             y, m, d, hh, mm, ss).isoformat()
+                except ValueError:
+                    props[key] = None
             else:
                 log.debug("%s: None, fieldtype: %r, %r" % (key, fieldtype, fieldtype in string_types))
                 props[key] = None

--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -217,13 +217,18 @@ cdef class FeatureBuilder:
             elif fieldtype in (FionaDateType, FionaTimeType, FionaDateTimeType):
                 retval = ogrext2.OGR_F_GetFieldAsDateTime(
                     feature, i, &y, &m, &d, &hh, &mm, &ss, &tz)
-                if fieldtype is FionaDateType:
-                    props[key] = datetime.date(y, m, d).isoformat()
-                elif fieldtype is FionaTimeType:
-                    props[key] = datetime.time(hh, mm, ss).isoformat()
-                else:
-                    props[key] = datetime.datetime(
-                        y, m, d, hh, mm, ss).isoformat()
+                if not y or not m or not d:
+                    log.warning("Bad date")
+                try:
+                    if fieldtype is FionaDateType:
+                        props[key] = datetime.date(y, m, d).isoformat()
+                    elif fieldtype is FionaTimeType:
+                        props[key] = datetime.time(hh, mm, ss).isoformat()
+                    else:
+                        props[key] = datetime.datetime(
+                            y, m, d, hh, mm, ss).isoformat()
+                except ValueError:
+                    props[key] = None
             else:
                 log.debug("%s: None, fieldtype: %r, %r" % (key, fieldtype, fieldtype in string_types))
                 props[key] = None

--- a/fiona/ogrext2.pyx
+++ b/fiona/ogrext2.pyx
@@ -217,8 +217,6 @@ cdef class FeatureBuilder:
             elif fieldtype in (FionaDateType, FionaTimeType, FionaDateTimeType):
                 retval = ogrext2.OGR_F_GetFieldAsDateTime(
                     feature, i, &y, &m, &d, &hh, &mm, &ss, &tz)
-                if not y or not m or not d:
-                    log.warning("Bad date")
                 try:
                     if fieldtype is FionaDateType:
                         props[key] = datetime.date(y, m, d).isoformat()
@@ -227,7 +225,8 @@ cdef class FeatureBuilder:
                     else:
                         props[key] = datetime.datetime(
                             y, m, d, hh, mm, ss).isoformat()
-                except ValueError:
+                except ValueError as err:
+                    log.exception(err)
                     props[key] = None
             else:
                 log.debug("%s: None, fieldtype: %r, %r" % (key, fieldtype, fieldtype in string_types))


### PR DESCRIPTION
In case the date in the input isn't correct (yielding any of y=0, and/or m=0, and/or d=0), there is an error in datetime.date(). Protect against such case by defaulting to unix timestamp 0 (Jan 1st, 1970)