### PR TITLE
Single gdal version jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - gfortran
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 before_install:
   - pip install -U pip
   - pip install wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
 python:
   - "2.7"
   - "3.4"
-  - "3.5"
 before_install:
   - pip install -U pip
   - pip install wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ addons:
     - gfortran
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 before_install:

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -54,7 +54,7 @@ fi
 
 ls -l $GDALINST
 
-if [ "$GDALVERSION" -eq "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
+if [ "$GDALVERSION" = "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   cd $GDALBUILD
   wget http://download.osgeo.org/gdal/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -55,42 +55,12 @@ fi
 ls -l $GDALINST
 
 # download and compile gdal version
-if [ ! -d $GDALINST/gdal-1.9.2 ]; then
+if [ ! -d $GDALINST/gdal-$GDALVERSION ]; then
   cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/gdal-1.9.2.tar.gz
-  tar -xzf gdal-1.9.2.tar.gz
-  cd gdal-1.9.2
-  ./configure --prefix=$GDALINST/gdal-1.9.2 $GDALOPTS
-  make -s -j 2
-  make install
-fi
-
-if [ ! -d $GDALINST/gdal-1.11.5 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/1.11.5/gdal-1.11.5.tar.gz
-  tar -xzf gdal-1.11.5.tar.gz
-  cd gdal-1.11.5
-  ./configure --prefix=$GDALINST/gdal-1.11.5 $GDALOPTS
-  make -s -j 2
-  make install
-fi
-
-if [ ! -d $GDALINST/gdal-2.0.3 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/2.0.3/gdal-2.0.3.tar.gz
-  tar -xzf gdal-2.0.3.tar.gz
-  cd gdal-2.0.3
-  ./configure --prefix=$GDALINST/gdal-2.0.3 $GDALOPTS
-  make -s -j 2
-  make install
-fi
-
-if [ ! -d $GDALINST/gdal-2.1.1 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/2.1.1/gdal-2.1.1.tar.gz
-  tar -xzf gdal-2.1.1.tar.gz
-  cd gdal-2.1.1
-  ./configure --prefix=$GDALINST/gdal-2.1.1 $GDALOPTS
+  wget http://download.osgeo.org/gdal/gdal-$GDALVERSION.tar.gz
+  tar -xzf gdal-$GDALVERSION.tar.gz
+  cd gdal-$GDALVERSION
+  ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -s -j 2
   make install
 fi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -68,7 +68,7 @@ fi
 # download and compile gdal version
 if [ "$GDALVERSION" != "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   cd $GDALBUILD
-  wget http://download.osgeo.org/$GDALVERSION/gdal-$GDALVERSION.tar.gz
+  wget http://download.osgeo.org/gdal/$GDALVERSION/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz
   cd gdal-$GDALVERSION
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -54,7 +54,7 @@ fi
 
 ls -l $GDALINST
 
-if [ $GDALVERSION = "1.9.2" && ! -d $GDALINST/gdal-$GDALVERSION ]; then
+if [ "$GDALVERSION" -eq "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   cd $GDALBUILD
   wget http://download.osgeo.org/gdal/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz
@@ -66,7 +66,7 @@ fi
 
 
 # download and compile gdal version
-if [ $GDALVERSION != "1.9.2" && ! -d $GDALINST/gdal-$GDALVERSION ]; then
+if [ "$GDALVERSION" != "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   cd $GDALBUILD
   wget http://download.osgeo.org/$GDALVERSION/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -54,10 +54,21 @@ fi
 
 ls -l $GDALINST
 
-# download and compile gdal version
-if [ ! -d $GDALINST/gdal-$GDALVERSION ]; then
+if [ $GDALVERSION = "1.9.2" && ! -d $GDALINST/gdal-$GDALVERSION ]; then
   cd $GDALBUILD
   wget http://download.osgeo.org/gdal/gdal-$GDALVERSION.tar.gz
+  tar -xzf gdal-$GDALVERSION.tar.gz
+  cd gdal-$GDALVERSION
+  ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
+  make -s -j 2
+  make install
+fi
+
+
+# download and compile gdal version
+if [ $GDALVERSION != "1.9.2" && ! -d $GDALINST/gdal-$GDALVERSION ]; then
+  cd $GDALBUILD
+  wget http://download.osgeo.org/$GDALVERSION/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz
   cd gdal-$GDALVERSION
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS


### PR DESCRIPTION
This PR builds only one version of GDAL per Travis job and prunes all Python versions but 2.7 and 3.5. Fiona doesn't use any 3-only features and so 3.5 is as good as any other Python 3.x version. Benefits: faster builds when we have no caches, such as when we want to update GDAL versions, and smaller caches.