### PR TITLE
Deprecate Collection.__next__()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,8 +3,8 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
-1.7.1 (2016-11-16)
-------------------
+1.7.2 (soon)
+------------
 
 Future Deprecation:
 
@@ -14,6 +14,9 @@ Future Deprecation:
   usage of this deprecated feature by running your tests or programs with
   `PYTHONWARNINGS="always:::fiona"` or `-W"always:::fiona"` and switch from
   `next(collection)` to `next(iter(collection))` (#301).
+
+1.7.1 (2016-11-16)
+------------------
 
 Bug Fixes:
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,15 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.7.1 (2016-11-16)
 ------------------
 
+Future Deprecation:
+
+- `Collection.__next__()` is buggy in that it can lead to duplication of 
+  features when used in combination with `Collection.filter()` or
+  `Collection.__iter__()`. It will be removed in Fiona 2.0. Please check for
+  usage of this deprecated feature by running your tests or programs with
+  `PYTHONWARNINGS="always:::fiona"` or `-W"always:::fiona"` and switch from
+  `next(collection)` to `next(iter(collection))` (#301).
+
 Bug Fixes:
 
 - Prevent Fiona from stumbling over '*Z', '*M', and '*ZM' geometry types

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -81,7 +81,7 @@ import uuid
 
 
 __all__ = ['bounds', 'listlayers', 'open', 'prop_type', 'prop_width']
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __gdal_version__ = get_gdal_release_name().decode('utf-8')
 
 log = logging.getLogger('Fiona')

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -3,6 +3,7 @@
 
 
 import os
+import warnings
 
 from fiona import compat
 from fiona.ogrext import Iterator, ItemsIterator, KeysIterator
@@ -311,6 +312,9 @@ class Collection(object):
 
     def __next__(self):
         """Returns next record from iterator."""
+        warnings.warn("Collection.__next__() is buggy and will be removed in "
+                      "Fiona 2.0. Switch to `next(iter(collection))`.",
+                      DeprecationWarning, stacklevel=2)
         if not self.iterator:
             iter(self)
         return next(self.iterator)

--- a/tests/test_bigint.py
+++ b/tests/test_bigint.py
@@ -60,7 +60,7 @@ class TestBigInt(unittest.TestCase):
 
             with fiona.open(name) as src:
                 if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
-                    first = next(src)
+                    first = next(iter(src))
                     self.assertEqual(first['properties'][fieldname], a_bigint)
 
 

--- a/tests/test_multiconxn.py
+++ b/tests/test_multiconxn.py
@@ -28,9 +28,9 @@ class ReadAccess(unittest.TestCase):
             self.assertEqual(sorted(self.c.schema.items()), sorted(c2.schema.items()))
 
     def test_meta(self):
-        f1 = next(self.c)
+        f1 = next(iter(self.c))
         with fiona.open("tests/data/coutwildrnp.shp", "r", layer="coutwildrnp") as c2:
-            f2 = next(c2)
+            f2 = next(iter(c2))
             self.assertEqual(f1, f2)
 
 @unittest.skipIf(FIXME_WINDOWS, 
@@ -68,14 +68,14 @@ class ReadWriteAccess(unittest.TestCase):
 
     def test_read(self):
         c2 = fiona.open(os.path.join(self.tempdir, "multi_write_test.shp"), "r")
-        f2 = next(c2)
+        f2 = next(iter(c2))
         del f2['id']
         self.assertEqual(self.f, f2)
 
     def test_read_after_close(self):
         c2 = fiona.open(os.path.join(self.tempdir, "multi_write_test.shp"), "r")
         self.c.close()
-        f2 = next(c2)
+        f2 = next(iter(c2))
         del f2['id']
         self.assertEqual(self.f, f2)
 
@@ -117,13 +117,13 @@ class LayerCreation(unittest.TestCase):
 
     def test_read(self):
         c2 = fiona.open(os.path.join(self.dir, "write_test.shp"), "r")
-        f2 = next(c2)
+        f2 = next(iter(c2))
         del f2['id']
         self.assertEqual(self.f, f2)
 
     def test_read_after_close(self):
         c2 = fiona.open(os.path.join(self.dir, "write_test.shp"), "r")
         self.c.close()
-        f2 = next(c2)
+        f2 = next(iter(c2))
         del f2['id']
         self.assertEqual(self.f, f2)

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -80,7 +80,7 @@ def test_read_json_object_properties():
         f.write(data)
 
     with fiona.open(filename) as src:
-        ftr = next(src)
+        ftr = next(iter(src))
         props = ftr['properties']
         assert props['upperLeftCoordinate']['latitude'] == 45.66894
         assert props['upperLeftCoordinate']['longitude'] == 87.91166
@@ -146,7 +146,7 @@ def test_write_json_object_properties():
         dst.write(data)
 
     with fiona.open(filename) as src:
-        ftr = next(src)
+        ftr = next(iter(src))
         props = ftr['properties']
         assert props['upperLeftCoordinate']['latitude'] == 45.66894
         assert props['upperLeftCoordinate']['longitude'] == 87.91166
@@ -187,7 +187,7 @@ def test_json_prop_decode_non_geojson_driver():
         dst.write(feature)
 
     with fiona.open(filename) as src:
-        actual = next(src)
+        actual = next(iter(src))
 
     assert isinstance(actual['properties']['ulc'], text_type)
     a = json.loads(actual['properties']['ulc'])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -124,7 +124,7 @@ class ShapefileSchema(unittest.TestCase):
                  ('INTPTLON10', 'str:80'), 
                  ('GEOID10', 'str:80'), 
                  ('Decommisio', 'str:80')]) )
-            f = next(c)
+            f = next(iter(c))
             self.assertEqual(f['properties']['EstimatedP'], 27773.0)
 
 
@@ -153,7 +153,7 @@ class FieldTruncationTestCase(unittest.TestCase):
             dst.write(rec)
 
         with fiona.open(name) as src:
-            first = next(src)
+            first = next(iter(src))
             assert first['geometry'] == {'type': 'Point', 'coordinates': (0, 0)}
             assert first['properties']['a_fieldnam'] == 3.0
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -88,7 +88,7 @@ class UnicodeStringFieldTest(unittest.TestCase):
                     'num': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='latin1') as c:
-            f = next(c)
+            f = next(iter(c))
             # Next assert fails.
             self.assertEqual(f['properties']['label'], u'徐汇区')
 
@@ -106,7 +106,7 @@ class UnicodeStringFieldTest(unittest.TestCase):
                     'label': u'Ba\u2019kelalan', u'verit\xe9': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='utf-8') as c:
-            f = next(c)
+            f = next(iter(c))
             self.assertEqual(f['properties']['label'], u'Ba\u2019kelalan')
             self.assertEqual(f['properties'][u'verit\xe9'], 0)
 
@@ -124,6 +124,6 @@ class UnicodeStringFieldTest(unittest.TestCase):
                 'properties': {'label': u'徐汇区', 'num': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='gb18030') as c:
-            f = next(c)
+            f = next(iter(c))
             self.assertEqual(f['properties']['label'], u'徐汇区')
             self.assertEqual(f['properties']['num'], 0)


### PR DESCRIPTION
From `CHANGES.txt`:

```
Future Deprecation:

- `Collection.__next__()` is buggy in that it can lead to duplication of 
  features when used in combination with `Collection.filter()` or
  `Collection.__iter__()`. It will be removed in Fiona 2.0. Please check for
  usage of this deprecated feature by running your tests or programs with
  `PYTHONWARNINGS="always:::fiona"` or `-W"always:::fiona"` and switch from
  `next(collection)` to `next(iter(collection))` (#301).
```

Resolves #301