### PR TITLE
Python 3.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     - gfortran
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 before_install:
   - "pip install -U pip"
   - "pip install wheel coveralls>=1.1 --upgrade"


### PR DESCRIPTION
I also tried updating Appveyor to `3.5.2`, but the build failed so I reverted and left it at `3.4`: https://ci.appveyor.com/project/sgillies/fiona/build/1.0.177