### PR TITLE
Fix windows tests

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -441,7 +441,7 @@ class BytesCollection(Collection):
         self.virtual_file = buffer_to_virtual_file(self.bytesbuf)
 
         # Instantiate the parent class.
-        super(BytesCollection, self).__init__(self.virtual_file)
+        super(BytesCollection, self).__init__(self.virtual_file, encoding='utf-8')
 
     def close(self):
         """Removes the virtual file associated with the class."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,20 +24,20 @@ def _read_file(name):
 @pytest.fixture(scope='session')
 def data_dir():
     """Absolute file path to the directory containing test datasets."""
-    return os.path.abspath('tests/data')
+    return os.path.abspath(os.path.join('tests','data'))
 
 
 @pytest.fixture(scope='session')
 def path_coutwildrnp_shp():
     """Path to ```coutwildrnp.shp``"""
-    return '{}/coutwildrnp.shp'.format(data_dir())
+    return os.path.join(data_dir(), 'coutwildrnp.shp')
 
 
 @pytest.fixture(scope='session')
 def path_coutwildrnp_zip():
     """Creates ``coutwildrnp.zip`` if it does not exist and returns the absolute
     file path."""
-    path = '{}/coutwildrnp.zip'.format(data_dir())
+    path = os.path.join(data_dir(), 'coutwildrnp.zip')
     if not os.path.exists(path):
         with zipfile.ZipFile(path, 'w') as zip:
             for filename in _COUTWILDRNP_FILES:
@@ -49,7 +49,7 @@ def path_coutwildrnp_zip():
 def path_coutwildrnp_tar():
     """Creates ``coutwildrnp.tar`` if it does not exist and returns the absolute
     file path."""
-    path = '{}/coutwildrnp.tar'.format(data_dir())
+    path = os.path.join(data_dir(), 'coutwildrnp.tar')
     if not os.path.exists(path):
         with tarfile.open(path, 'w') as tar:
             for filename in _COUTWILDRNP_FILES:
@@ -63,7 +63,7 @@ def path_coutwildrnp_tar():
 def path_coutwildrnp_json():
     """Creates ``coutwildrnp.json`` if it does not exist and returns the absolute
     file path."""
-    path = '{}/coutwildrnp.json'.format(data_dir())
+    path = os.path.join(data_dir(), 'coutwildrnp.json')
     if not os.path.exists(path):
         name = _COUTWILDRNP_FILES[0]
         with fiona.open(os.path.join(data_dir(), name), 'r') as source:
@@ -84,25 +84,25 @@ def path_gpx(data_dir):
 @pytest.fixture(scope='session')
 def feature_collection():
     """GeoJSON feature collection on a single line."""
-    return _read_file('data/collection.txt')
+    return _read_file(os.path.join('data', 'collection.txt'))
 
 
 @pytest.fixture(scope='session')
 def feature_collection_pp():
     """Same as above but with pretty-print styling applied."""
-    return _read_file('data/collection-pp.txt')
+    return _read_file(os.path.join('data','collection-pp.txt'))
 
 
 @pytest.fixture(scope='session')
 def feature_seq():
     """One feature per line."""
-    return _read_file('data/sequence.txt')
+    return _read_file(os.path.join('data','sequence.txt'))
 
 
 @pytest.fixture(scope='session')
 def feature_seq_pp_rs():
     """Same as above but each feature has pretty-print styling"""
-    return _read_file('data/sequence-pp.txt')
+    return _read_file(os.path.join('data','sequence-pp.txt'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -9,10 +9,6 @@ import six
 
 import fiona
 
-
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_json')
 class ReadingTest(unittest.TestCase):
 
@@ -30,20 +26,16 @@ class ReadingTest(unittest.TestCase):
             strbuf = src.read()
         self.assertRaises(ValueError, fiona.BytesCollection, strbuf)
 
-    @pytest.mark.skipif(
-        FIXME_WINDOWS,
-        reason="FIXME on Windows. Please look into why this test is not working.")
     def test_open_repr(self):
         # I'm skipping checking the name of the virtual file as it produced by uuid.
+        print(repr(self.c))
         self.assertTrue(repr(self.c).startswith("<open BytesCollection '/vsimem/"))
         self.assertTrue(repr(self.c).endswith(":OGRGeoJSON', mode 'r' at %s>" % hex(id(self.c))))
 
-    @pytest.mark.skipif(
-        FIXME_WINDOWS,
-        reason="FIXME on Windows. Please look into why this test is not working.")
     def test_closed_repr(self):
         # I'm skipping checking the name of the virtual file as it produced by uuid.
         self.c.close()
+        print(repr(self.c))
         self.assertTrue(repr(self.c).startswith("<closed BytesCollection '/vsimem/"))
         self.assertTrue(repr(self.c).endswith(":OGRGeoJSON', mode 'r' at %s>" % hex(id(self.c))))
 
@@ -64,9 +56,6 @@ class ReadingTest(unittest.TestCase):
     def test_mode(self):
         self.assertEqual(self.c.mode, 'r')
 
-    @pytest.mark.skipif(
-        FIXME_WINDOWS,
-        reason="FIXME on Windows. Please look into why this test is not working.")
     def test_collection(self):
         self.assertEqual(self.c.encoding, 'utf-8')
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -15,13 +15,13 @@ import fiona
 from fiona.collection import Collection, supported_drivers
 from fiona.errors import FionaValueError, DriverError
 
-FIXME_WINDOWS = sys.platform.startswith('win')
+
 OGRINFO_TOOL = "ogrinfo"
-if FIXME_WINDOWS:
+if sys.platform.startswith('win'):
     # Set extra path if in windows
     OGRINFO_TOOL = 'gdal\\apps\\' + OGRINFO_TOOL
 
-WILDSHP = 'tests/data/coutwildrnp.shp'
+WILDSHP = os.path.join('tests', 'data','coutwildrnp.shp')
 
 #logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -109,15 +109,15 @@ class ReadingTest(unittest.TestCase):
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection 'tests/data/coutwildrnp.shp:coutwildrnp', mode 'r' "
-             "at %s>" % hex(id(self.c))))
+            ("<open Collection '{path}:coutwildrnp', mode 'r' "
+             "at {hexid}>".format(hexid=hex(id(self.c)), path=WILDSHP)))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection 'tests/data/coutwildrnp.shp:coutwildrnp', mode 'r' "
-             "at %s>" % hex(id(self.c))))
+            ("<closed Collection '{path}:coutwildrnp', mode 'r' "
+             "at {hexid}>".format(hexid=hex(id(self.c)), path=WILDSHP)))
 
     def test_path(self):
         self.assertEqual(self.c.path, WILDSHP)
@@ -317,10 +317,6 @@ class UnsupportedDriverTest(unittest.TestCase):
             fiona.open, os.path.join(TEMPDIR, "foo"), "w", "Bogus", schema=schema)
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test isn't working. "
-           "There is a codepage issue regarding Windows-1252 and UTF-8. ")
 class GenericWritingTest(unittest.TestCase):
     tempdir = None
     c = None
@@ -600,7 +596,7 @@ class GeoJSONCRSWritingTest(unittest.TestCase):
                 'geometry': 'Point',
                 'properties': [('title', 'str'), ('date', 'date')]},
             crs={'a': 6370997, 'lon_0': -100, 'y_0': 0, 'no_defs': True, 'proj': 'laea', 'x_0': 0, 'units': 'm', 'b': 6370997, 'lat_0': 45})
-        
+
 
     def tearDown(self):
         self.sink.close()
@@ -615,8 +611,7 @@ class GeoJSONCRSWritingTest(unittest.TestCase):
             'GEOGCS["WGS 84' in info.decode('utf-8'),
             info)
 
-@pytest.mark.skipif(FIXME_WINDOWS, 
-                 reason="FIXME on Windows. Test raises PermissionError.  Please look into why this test isn't working.")
+
 class DateTimeTest(unittest.TestCase):
 
     def setUp(self):
@@ -651,7 +646,7 @@ class DateTimeTest(unittest.TestCase):
             rf1, rf2 = list(c)
             self.assertEqual(rf1['properties']['date'], '2013-02-25')
             self.assertEqual(rf2['properties']['date'], '2014-02-03')
-        
+
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -664,7 +659,7 @@ class OpenKeywordArgsTest(unittest.TestCase):
 
     def test_kwargs(self):
         dstfile = os.path.join(self.tempdir, 'test.json')
-        with fiona.open('tests/data/coutwildrnp.shp') as src:
+        with fiona.open(os.path.join('tests', 'data', 'coutwildrnp.shp')) as src:
             kwds = src.profile
             kwds['driver'] = 'GeoJSON'
             kwds['coordinate_precision'] = 2

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -5,20 +5,13 @@ import logging
 import sys
 
 import pytest
-
+import os
 import fiona
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Raises PermissionError Please look into why "
-           "this test isn't working.")
 def test_options(tmpdir):
     """Test that setting CPL_DEBUG=ON works"""
     logfile = str(tmpdir.mkdir('tests').join('test_options.log'))
@@ -29,7 +22,8 @@ def test_options(tmpdir):
     logger.addHandler(fh)
 
     with fiona.drivers(CPL_DEBUG=True):
-        c = fiona.open("tests/data/coutwildrnp.shp")
+        path = os.path.join("tests", "data", "coutwildrnp.shp")
+        c = fiona.open(path)
         c.close()
         log = open(logfile).read()
         assert "Option CPL_DEBUG" in log

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -8,15 +8,10 @@ from click.testing import CliRunner
 
 from fiona.fio import cat
 
-
-WILDSHP = 'tests/data/coutwildrnp.shp'
-FIXME_WINDOWS = sys.platform.startswith('win')
 DATA_DIR = os.path.join('tests', 'data')
+WILDSHP = os.path.join(DATA_DIR, 'coutwildrnp.shp')
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_one():
     runner = CliRunner()
     result = runner.invoke(cat.cat, [WILDSHP])
@@ -24,9 +19,6 @@ def test_one():
     assert result.output.count('"Feature"') == 67
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_two():
     runner = CliRunner()
     result = runner.invoke(cat.cat, [WILDSHP, WILDSHP])
@@ -34,9 +26,6 @@ def test_two():
     assert result.output.count('"Feature"') == 134
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_bbox_no():
     runner = CliRunner()
     result = runner.invoke(
@@ -47,9 +36,7 @@ def test_bbox_no():
     assert result.output == ""
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
+
 def test_bbox_yes():
     runner = CliRunner()
     result = runner.invoke(
@@ -60,9 +47,6 @@ def test_bbox_yes():
     assert result.output.count('"Feature"') == 19
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_bbox_json_yes():
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_fio_collect.py
+++ b/tests/test_fio_collect.py
@@ -11,12 +11,6 @@ import pytest
 from fiona.fio import collect
 
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_collect_rs(feature_seq_pp_rs):
     runner = CliRunner()
     result = runner.invoke(
@@ -28,9 +22,6 @@ def test_collect_rs(feature_seq_pp_rs):
     assert result.output.count('"Feature"') == 2
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_collect_no_rs(feature_seq):
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_fio_dump.py
+++ b/tests/test_fio_dump.py
@@ -12,12 +12,6 @@ from fiona.fio import dump
 from fiona.fio.main import main_group
 
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_dump(path_coutwildrnp_shp):
     runner = CliRunner()
     result = runner.invoke(dump.dump, [path_coutwildrnp_shp])

--- a/tests/test_fio_info.py
+++ b/tests/test_fio_info.py
@@ -12,12 +12,6 @@ import pytest
 from fiona.fio.main import main_group
 
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
-@pytest.mark.skipif(
-    FIXME_WINDOWS, 
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_info_json(path_coutwildrnp_shp):
     runner = CliRunner()
     result = runner.invoke(main_group, ['info', path_coutwildrnp_shp])
@@ -27,9 +21,7 @@ def test_info_json(path_coutwildrnp_shp):
     assert '"driver": "ESRI Shapefile"' in result.output
     assert '"name": "coutwildrnp"' in result.output
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
+
 def test_info_count(path_coutwildrnp_shp):
     runner = CliRunner()
     result = runner.invoke(
@@ -37,9 +29,7 @@ def test_info_count(path_coutwildrnp_shp):
     assert result.exit_code == 0
     assert result.output == "67\n"
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
+
 def test_info_bounds(path_coutwildrnp_shp):
     runner = CliRunner()
     result = runner.invoke(
@@ -62,9 +52,6 @@ def _filter_info_warning(lines):
     return lines
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_info_no_count(path_gpx):
     """Make sure we can still get a `$ fio info` report on datasources that do
     not support feature counting, AKA `len(collection)`.
@@ -77,9 +64,6 @@ def test_info_no_count(path_gpx):
     assert json.loads(lines[0])['count'] is None
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_info_layer(path_gpx):
     for layer in ('routes', '1'):
         runner = CliRunner()

--- a/tests/test_fio_load.py
+++ b/tests/test_fio_load.py
@@ -12,9 +12,6 @@ import fiona
 from fiona.fio.main import main_group
 
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
-
 def test_err(runner):
     result = runner.invoke(
         main_group, ['load'], '', catch_exceptions=False)
@@ -29,9 +26,6 @@ def test_exception(tmpdir, runner):
     assert result.exit_code == 1
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_collection(tmpdir, feature_collection, runner):
     tmpfile = str(tmpdir.mkdir('tests').join('test_collection.shp'))
     result = runner.invoke(
@@ -40,9 +34,7 @@ def test_collection(tmpdir, feature_collection, runner):
     assert len(fiona.open(tmpfile)) == 2
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
+
 def test_seq_rs(feature_seq_pp_rs, tmpdir, runner):
     tmpfile = str(tmpdir.mkdir('tests').join('test_seq_rs.shp'))
     result = runner.invoke(
@@ -51,9 +43,6 @@ def test_seq_rs(feature_seq_pp_rs, tmpdir, runner):
     assert len(fiona.open(tmpfile)) == 2
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_seq_no_rs(tmpdir, runner, feature_seq):
     tmpfile = str(tmpdir.mkdir('tests').join('test_seq_no_rs.shp'))
     result = runner.invoke(main_group, [
@@ -62,9 +51,6 @@ def test_seq_no_rs(tmpdir, runner, feature_seq):
     assert len(fiona.open(tmpfile)) == 2
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_dst_crs_default_to_src_crs(tmpdir, runner, feature_seq):
     """When --dst-crs is not given default to --src-crs."""
     tmpfile = str(tmpdir.mkdir('tests').join('test_src_vs_dst_crs.shp'))
@@ -81,9 +67,6 @@ def test_dst_crs_default_to_src_crs(tmpdir, runner, feature_seq):
         assert len(src) == len(feature_seq.splitlines())
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_different_crs(tmpdir, runner, feature_seq):
     tmpfile = str(tmpdir.mkdir('tests').join('test_different_crs.shp'))
     result = runner.invoke(
@@ -97,9 +80,6 @@ def test_different_crs(tmpdir, runner, feature_seq):
         assert len(src) == len(feature_seq.splitlines())
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_dst_crs_no_src(tmpdir, runner, feature_seq):
     tmpfile = str(tmpdir.mkdir('tests').join('test_dst_crs_no_src.shp'))
     result = runner.invoke(main_group, [
@@ -115,9 +95,6 @@ def test_dst_crs_no_src(tmpdir, runner, feature_seq):
         assert len(src) == len(feature_seq.splitlines())
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_fio_load_layer(tmpdir, runner):
     outdir = str(tmpdir.mkdir('tests').mkdir('test_fio_load_layer'))
     try:

--- a/tests/test_fio_ls.py
+++ b/tests/test_fio_ls.py
@@ -3,31 +3,24 @@
 
 import json
 import sys
-
+import os
 from click.testing import CliRunner
 import pytest
-
 import fiona
 from fiona.fio.main import main_group
 
-FIXME_WINDOWS = sys.platform.startswith('win')
+DATA_DIR = os.path.join("tests", "data")
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_fio_ls_single_layer():
 
     result = CliRunner().invoke(main_group, [
         'ls',
-        'tests/data/'])
+        DATA_DIR])
     assert result.exit_code == 0
     assert len(result.output.splitlines()) == 1
     assert json.loads(result.output) == ['coutwildrnp']
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. Please look into why this test is not working.")
 def test_fio_ls_indent(path_coutwildrnp_shp):
 
     result = CliRunner().invoke(main_group, [

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -11,65 +11,68 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 from .test_collection import ReadingTest
 
+WILDSHP = os.path.join('tests', 'data','coutwildrnp.shp')
+DATA_DIR = os.path.join('tests', 'data')
+
 def test_index_selection():
-    with fiona.open('tests/data/coutwildrnp.shp', 'r', layer=0) as c:
+    with fiona.open(WILDSHP, 'r', layer=0) as c:
         assert len(c) == 67
 
 class FileReadingTest(ReadingTest):
-    
+
     def setUp(self):
-        self.c = fiona.open('tests/data/coutwildrnp.shp', 'r', layer='coutwildrnp')
-    
+        self.c = fiona.open(WILDSHP, 'r', layer='coutwildrnp')
+
     def tearDown(self):
         self.c.close()
 
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection 'tests/data/coutwildrnp.shp:coutwildrnp', mode 'r' "
-            "at %s>" % hex(id(self.c))))
+            ("<open Collection '{path}:coutwildrnp', mode 'r' "
+            "at {id}>".format(path=WILDSHP, id=hex(id(self.c)))))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection 'tests/data/coutwildrnp.shp:coutwildrnp', mode 'r' "
-            "at %s>" % hex(id(self.c))))
+            ("<closed Collection '{path}:coutwildrnp', mode 'r' "
+            "at {id}>".format(path=WILDSHP, id=hex(id(self.c)))))
 
     def test_name(self):
         self.assertEqual(self.c.name, 'coutwildrnp')
 
 class DirReadingTest(ReadingTest):
-    
+
     def setUp(self):
-        self.c = fiona.open("tests/data", "r", layer="coutwildrnp")
-    
+        self.c = fiona.open(DATA_DIR, "r", layer="coutwildrnp")
+
     def tearDown(self):
         self.c.close()
 
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection 'tests/data:coutwildrnp', mode 'r' "
-            "at %s>" % hex(id(self.c))))
+            ("<open Collection '{path}:coutwildrnp', mode 'r' "
+            "at {id}>".format(path=DATA_DIR, id=hex(id(self.c)))))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection 'tests/data:coutwildrnp', mode 'r' "
-            "at %s>" % hex(id(self.c))))
+            ("<closed Collection '{path}:coutwildrnp', mode 'r' "
+            "at {id}>".format(path=DATA_DIR, id=hex(id(self.c)))))
 
     def test_name(self):
         self.assertEqual(self.c.name, 'coutwildrnp')
 
     def test_path(self):
-        self.assertEqual(self.c.path, "tests/data")
+        self.assertEqual(self.c.path, DATA_DIR)
 
 class InvalidLayerTest(unittest.TestCase):
 
     def test_invalid(self):
-        self.assertRaises(ValueError, fiona.open, ("tests/data/coutwildrnp.shp"), layer="foo")
+        self.assertRaises(ValueError, fiona.open, (WILDSHP), layer="foo")
 
     def test_write_numeric_layer(self):
         self.assertRaises(ValueError, fiona.open,

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -10,9 +10,6 @@ import fiona
 import fiona.ogrext
 
 
-FIXME_WINDOWS = sys.platform.startswith("win")
-
-
 def test_single_file_private(path_coutwildrnp_shp):
     with fiona.drivers():
         assert fiona.ogrext._listlayers(path_coutwildrnp_shp) == ['coutwildrnp']
@@ -26,10 +23,6 @@ def test_directory(data_dir):
     assert fiona.listlayers(data_dir) == ['coutwildrnp']
 
 
-@pytest.mark.skipif(
-    FIXME_WINDOWS,
-    reason="FIXME on Windows. ValueError raised. Please look into why this "
-           "test isn't working.")
 def test_directory_trailing_slash(data_dir):
     assert fiona.listlayers(data_dir) == ['coutwildrnp']
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -14,8 +14,6 @@ import fiona
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-FIXME_WINDOWS = sys.platform.startswith('win')
-
 class UnicodePathTest(unittest.TestCase):
 
     def setUp(self):
@@ -48,8 +46,6 @@ class UnicodePathTest(unittest.TestCase):
             with fiona.open(path) as c:
                 assert len(c) == 67
 
-@pytest.mark.skipif(FIXME_WINDOWS, 
-                 reason="FIXME on Windows. Please look into why these tests are not working. Note: test_write_utf8 works.")
 class UnicodeStringFieldTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-
+import os
 import pytest
 
 import fiona
@@ -33,6 +33,7 @@ class ZipReadingTest(VsiReadingTest):
     
     def setUp(self):
         self.c = fiona.open("zip://{}".format(self.path_coutwildrnp_zip, "r"))
+        self.path = os.path.join(self.data_dir, 'coutwildrnp.zip')
     
     def tearDown(self):
         self.c.close()
@@ -40,24 +41,24 @@ class ZipReadingTest(VsiReadingTest):
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection '/vsizip/{data_dir}/coutwildrnp.zip:coutwildrnp', mode 'r' "
+            ("<open Collection '/vsizip/{path}:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection '/vsizip/{data_dir}/coutwildrnp.zip:coutwildrnp', mode 'r' "
+            ("<closed Collection '/vsizip/{path}:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_path(self):
         self.assertEqual(
-            self.c.path, '/vsizip/{data_dir}/coutwildrnp.zip'.format(
-                data_dir=self.data_dir))
+            self.c.path, '/vsizip/{path}'.format(
+                path=self.path))
 
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_zip')
@@ -66,6 +67,7 @@ class ZipArchiveReadingTest(VsiReadingTest):
     def setUp(self):
         vfs = 'zip://{}'.format(self.path_coutwildrnp_zip)
         self.c = fiona.open("/coutwildrnp.shp", "r", vfs=vfs)
+        self.path = os.path.join(self.data_dir, 'coutwildrnp.zip')
     
     def tearDown(self):
         self.c.close()
@@ -73,25 +75,25 @@ class ZipArchiveReadingTest(VsiReadingTest):
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection '/vsizip/{data_dir}/coutwildrnp.zip/coutwildrnp.shp:coutwildrnp', mode 'r' "
+            ("<open Collection '/vsizip/{path}/coutwildrnp.shp:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection '/vsizip/{data_dir}/coutwildrnp.zip/coutwildrnp.shp:coutwildrnp', mode 'r' "
+            ("<closed Collection '/vsizip/{path}/coutwildrnp.shp:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_path(self):
         self.assertEqual(
             self.c.path,
-            '/vsizip/{data_dir}/coutwildrnp.zip/coutwildrnp.shp'.format(
-                data_dir=self.data_dir))
+            '/vsizip/{path}/coutwildrnp.shp'.format(
+                path=self.path))
 
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_tar', 'uttc_data_dir')
@@ -100,6 +102,7 @@ class TarArchiveReadingTest(VsiReadingTest):
     def setUp(self):
         vfs = "tar://{}".format(self.path_coutwildrnp_tar)
         self.c = fiona.open("/testing/coutwildrnp.shp", "r", vfs=vfs)
+        self.path = os.path.join(self.data_dir, 'coutwildrnp.tar')
     
     def tearDown(self):
         self.c.close()
@@ -107,22 +110,22 @@ class TarArchiveReadingTest(VsiReadingTest):
     def test_open_repr(self):
         self.assertEqual(
             repr(self.c),
-            ("<open Collection '/vsitar/{data_dir}/coutwildrnp.tar/testing/coutwildrnp.shp:coutwildrnp', mode 'r' "
+            ("<open Collection '/vsitar/{path}/testing/coutwildrnp.shp:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_closed_repr(self):
         self.c.close()
         self.assertEqual(
             repr(self.c),
-            ("<closed Collection '/vsitar/{data_dir}/coutwildrnp.tar/testing/coutwildrnp.shp:coutwildrnp', mode 'r' "
+            ("<closed Collection '/vsitar/{path}/testing/coutwildrnp.shp:coutwildrnp', mode 'r' "
             "at {id}>".format(
                 id=hex(id(self.c)),
-                data_dir=self.data_dir)))
+                path=self.path)))
 
     def test_path(self):
         self.assertEqual(
             self.c.path,
-            '/vsitar/{data_dir}/coutwildrnp.tar/testing/coutwildrnp.shp'.format(
-                data_dir=self.data_dir))
+            '/vsitar/{path}/testing/coutwildrnp.shp'.format(
+                path=self.path))


### PR DESCRIPTION
This is a PR for https://github.com/Toblerity/Fiona/issues/414

Especially two of the commits should be reviewed:

In 90846683f8cfe35103a193e31367d990f10a43ab, / is used a path separator for /vsimem/ paths. Unfortunately my editor removed some whitespace, only line `vsi_filename = os.path.join('/vsimem', uuid.uuid4().hex)` changed to `vsi_filename = '/vsimem/{}'.format(uuid.uuid4().hex)`. 

In 9c1b59ac2b83d77a9cc2120164acff8d9059d709, the encoding of a bytescollection is fixed to utf8 instead of  the encoding of the current session. 

There are still FIXME Windows in test_multiconxn.py. 
Currently a lot of tests use the same "hardcoded" path. This could be refactored in a future step.
 