### PR TITLE
TST: Fix flaky ls test.

### DIFF
--- a/tests/test_fio_ls.py
+++ b/tests/test_fio_ls.py
@@ -49,7 +49,7 @@ def test_fio_ls_multi_layer(path_coutwildrnp_shp, tmpdir):
     result = CliRunner().invoke(main_group, [
         'ls', outdir])
     assert result.exit_code == 0
-    assert json.loads(result.output) == layer_names
+    assert sorted(json.loads(result.output)) == layer_names
 
 
 def test_fio_ls_vfs(path_coutwildrnp_zip):


### PR DESCRIPTION
Since this reads layer names from multiple files, there's no guarantee that they will be in order since the filesystem can iterate in any order.

I hope I've diagnosed this correctly, but I've hit this same failure in more than one build on multiple systems ([Fedora 25](https://copr-be.cloud.fedoraproject.org/results/qulogic/geopy/fedora-25-x86_64/00521997-python-fiona/build.log.gz), [Fedora 26](https://copr-be.cloud.fedoraproject.org/results/qulogic/geopy/fedora-26-x86_64/00521997-python-fiona/build.log.gz), [Fedora Rawhide](https://copr-be.cloud.fedoraproject.org/results/qulogic/geopy/fedora-rawhide-x86_64/00521997-python-fiona/build.log.gz)) which went away after this patch ([builds](https://copr.fedorainfracloud.org/coprs/qulogic/geopy/build/522001/)).