### PR TITLE
Add note about some possible unexpected indexing behaviour

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -301,6 +301,8 @@ Features of a collection may also be accessed by index.
      'properties': OrderedDict([(u'CAT', 232.0), (u'FIPS_CNTRY', u'UK'), (u'CNTRY_NAME', u'United Kingdom'), (u'AREA', 244820.0), (u'POP_CNTRY', 60270708.0)]),
      'type': 'Feature'}
 
+Note that these indices are controlled by GDAL, and do not always follow Python conventions. They can start from 0, 1 (e.g. geopackages), or even other values, and have no guarantee of contiguity. Negative indices will only function correctly if indices start from 0 and are contiguous.
+
 Closing Files
 -------------
 


### PR DESCRIPTION
Geopackages start indexing at 1, as this is the default auto-increment id behaviour. Asking for a `geopackage_file[0]` will return `None`. Apparently, GDAL indices have [no guarantee of start values of contiguity](https://trac.osgeo.org/gdal/ticket/356). This makes for interesting errors in retrieving indices from spatial indexes, for example. It can also produce incorrect values with negative indexing.

This PR adds this information to the manual.

In my specific case, I decided to construct a [mapping dictionary from indices I get from ``enumerate()`` to what GDAL expects](https://github.com/cmutel/pandarus/commit/0b0915b1f7ff2dc7344639986ba4294187cf313b#diff-b5068aab3983338209fe38d1ae80bb02), but this is obviously not a general solution for Fiona.