### PR TITLE
Don’t set PROJ_LIB to a non-existing directory

### DIFF
--- a/fiona/_drivers.pyx
+++ b/fiona/_drivers.pyx
@@ -117,7 +117,11 @@ cdef class GDALEnv(object):
         if 'PROJ_LIB' not in os.environ:
             whl_datadir = os.path.abspath(
                 os.path.join(os.path.dirname(__file__), "proj_data"))
-            os.environ['PROJ_LIB'] = whl_datadir
+            share_datadir = os.path.join(sys.prefix, 'share/proj')
+            if os.path.exists(whl_datadir):
+                os.environ['PROJ_LIB'] = whl_datadir
+            elif os.path.exists(share_datadir):
+                os.environ['PROJ_LIB'] = share_datadir
 
         for key, val in self.options.items():
             key_b = key.upper().encode('utf-8')


### PR DESCRIPTION
Better to not have it set than set to a non-existing directory.  Fixes #439 