### PR TITLE
Fix for GDAL Error handling

### DIFF
--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -182,7 +182,7 @@ cdef class GDALErrCtxManager:
         cdef const char *msg = CPLGetLastErrorMsg()
         # TODO: warn for err_type 2?
         if err_type >= 2:
-            raise exception_map[err_no](msg)
+            raise exception_map[err_no](err_type, err_no, msg)
 
 
 cdef inline object exc_check():


### PR DESCRIPTION
fix for Fiona exceptions generated from GDAL's Error handling, from #455 

This doesn't entirely resolve #455 because `fio info` will raise and exception an terminate because of a GDALError that is a CE_Warning (err_type = 2).  This merely provides better information for the cause of the Error (or Warning).