### PR TITLE
Add head option to 'fio cat'

### DIFF
--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -33,9 +33,11 @@ warnings.simplefilter('default')
 @cligj.use_rs_opt
 @click.option('--bbox', default=None, metavar="w,s,e,n",
               help="filter for features intersecting a bounding box")
+@click.option('--head', default=None, type=click.INT,
+              help="limit each input to given amount of features")
 @click.pass_context
 def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
-        use_rs, bbox, layer):
+        use_rs, bbox, layer, head):
 
     """
     Concatenate and print the features of input datasets as a sequence of
@@ -73,7 +75,7 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
                                 bbox = tuple(map(float, bbox.split(',')))
                             except ValueError:
                                 bbox = json.loads(bbox)
-                        for i, feat in src.items(bbox=bbox):
+                        for i, feat in src.items(head, bbox=bbox):
                             if dst_crs or precision >= 0:
                                 g = transform_geom(
                                     src.crs, dst_crs, feat['geometry'],

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -77,3 +77,10 @@ def test_vfs(path_coutwildrnp_zip):
         'zip://{}'.format(path_coutwildrnp_zip)])
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 67
+
+
+def test_head():
+    runner = CliRunner()
+    result = runner.invoke(cat.cat, [WILDSHP, '--head', '10'])
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 10


### PR DESCRIPTION
This is something rather useful to me and so I thought it might be worth sharing: It limits the number of features returned by `fio cat`. When dealing with large datasets that is helpful.