### PR TITLE
First attempt at ignoring fields

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -31,7 +31,8 @@ class Collection(object):
 
     def __init__(self, path, mode='r', driver=None, schema=None, crs=None,
                  encoding=None, layer=None, vsi=None, archive=None,
-                 enabled_drivers=None, crs_wkt=None, **kwargs):
+                 enabled_drivers=None, crs_wkt=None, ignore_fields=None,
+                 **kwargs):
 
         """The required ``path`` is the absolute or relative path to
         a file, such as '/data/test_uk.shp'. In ``mode`` 'r', data can
@@ -87,6 +88,7 @@ class Collection(object):
         self._crs_wkt = None
         self.env = None
         self.enabled_drivers = enabled_drivers
+        self.ignore_fields = ignore_fields
 
         self.path = vfs.vsi_path(path, vsi, archive)
 

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -32,6 +32,7 @@ class Collection(object):
     def __init__(self, path, mode='r', driver=None, schema=None, crs=None,
                  encoding=None, layer=None, vsi=None, archive=None,
                  enabled_drivers=None, crs_wkt=None, ignore_fields=None,
+                 ignore_geometry=False,
                  **kwargs):
 
         """The required ``path`` is the absolute or relative path to
@@ -89,6 +90,7 @@ class Collection(object):
         self.env = None
         self.enabled_drivers = enabled_drivers
         self.ignore_fields = ignore_fields
+        self.ignore_geometry = bool(ignore_geometry)
 
         self.path = vfs.vsi_path(path, vsi, archive)
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -152,7 +152,7 @@ cdef class FeatureBuilder:
     argument is not destroyed.
     """
 
-    cdef build(self, void *feature, encoding='utf-8', bbox=False, driver=None):
+    cdef build(self, void *feature, encoding='utf-8', bbox=False, driver=None, ignore_geometry=False):
         # The only method anyone ever needs to call
         cdef void *fdefn
         cdef int i
@@ -242,7 +242,7 @@ cdef class FeatureBuilder:
                 props[key] = None
 
         cdef void *cogr_geometry = OGR_F_GetGeometryRef(feature)
-        if cogr_geometry is not NULL:
+        if cogr_geometry is not NULL and not ignore_geometry:
             geom = GeomBuilder().build(cogr_geometry)
         else:
             geom = None
@@ -703,7 +703,8 @@ cdef class Session:
                 cogr_feature,
                 bbox=False,
                 encoding=self.get_internalencoding(),
-                driver=self.collection.driver
+                driver=self.collection.driver,
+                ignore_geometry=self.collection.ignore_geometry,
             )
             _deleteOgrFeature(cogr_feature)
             return feature
@@ -1217,7 +1218,8 @@ cdef class Iterator:
             cogr_feature,
             bbox=False,
             encoding=self.encoding,
-            driver=self.collection.driver
+            driver=self.collection.driver,
+            ignore_geometry=self.collection.ignore_geometry,
         )
         _deleteOgrFeature(cogr_feature)
         return feature
@@ -1246,7 +1248,8 @@ cdef class ItemsIterator(Iterator):
             cogr_feature,
             bbox=False,
             encoding=self.encoding,
-            driver=self.collection.driver
+            driver=self.collection.driver,
+            ignore_geometry=self.collection.ignore_geometry,
         )
         _deleteOgrFeature(cogr_feature)
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -241,8 +241,9 @@ cdef class FeatureBuilder:
                 log.debug("%s: None, fieldtype: %r, %r" % (key, fieldtype, fieldtype in string_types))
                 props[key] = None
 
-        cdef void *cogr_geometry = OGR_F_GetGeometryRef(feature)
+        cdef void *cogr_geometry
         if cogr_geometry is not NULL and not ignore_geometry:
+            cogr_geometry = OGR_F_GetGeometryRef(feature)
             geom = GeomBuilder().build(cogr_geometry)
         else:
             geom = None

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -405,7 +405,7 @@ cdef class Session:
         cdef const char *name_c = NULL
         cdef void *drv = NULL
         cdef void *ds = NULL
-        cdef char **drvs = NULL
+        cdef char **ignore_fields = NULL
 
         if collection.path == '-':
             path = '/vsistdin/'
@@ -464,6 +464,17 @@ cdef class Session:
             'ISO-8859-1') or locale.getpreferredencoding().upper()
 
         self.collection = collection
+
+        if self.collection.ignore_fields:
+            ignore_fields = <char **>malloc((len(self.collection.ignore_fields)+1) * sizeof(char **))
+            ignore_fields_bytes = []
+            for n in range(len(self.collection.ignore_fields)):
+                ignore_fields_bytes.append(self.collection.ignore_fields[n].encode("utf-8"))
+                ignore_fields[n] = ignore_fields_bytes[n]
+            ignore_fields[n+1] = NULL  # array must be NULL-terminated
+            OGR_L_SetIgnoredFields(self.cogr_layer, ignore_fields)
+            free(ignore_fields)
+            del(ignore_fields_bytes)
 
     def stop(self):
         self.cogr_layer = NULL

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -149,4 +149,5 @@ cdef extern from "ogr_api.h":
     void *  OGROpen (char *path, int mode, void *x)
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
+    OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -149,5 +149,5 @@ cdef extern from "ogr_api.h":
     void *  OGROpen (char *path, int mode, void *x)
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
-    OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields
+    OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -19,6 +19,7 @@ cdef extern from "cpl_string.h":
     char ** CSLAddNameValue (char **list, char *name, char *value)
     char ** CSLSetNameValue (char **list, char *name, char *value)
     void    CSLDestroy (char **list)
+    char ** CSLAddString(char **list, const char *string)
 
 cdef extern from "cpl_vsi.h":
     ctypedef struct VSILFILE:

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -207,6 +207,7 @@ cdef extern from "ogr_api.h":
     void *  OGROpen (char *path, int mode, void *x)
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
+    OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
     long long OGR_F_GetFieldAsInteger64 (void *feature, int n)
     void    OGR_F_SetFieldInteger64 (void *feature, int n, long long value)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -302,11 +302,9 @@ class IgnoreFieldsAndGeometryTest(unittest.TestCase):
             pass
 
     def test_ignore_invalid_field_not_string(self):
-        self.assertRaises(
-            AttributeError,
-            fiona.open,
-            {"path": WILDSHP, "mode": "r", "ignore_fields": [42]}
-        )
+        with self.assertRaises(TypeError):
+            with fiona.open(WILDSHP, "r", ignore_fields=[42]) as collection:
+                pass
 
     def test_ignore_geometry(self):
         with fiona.open(WILDSHP, "r", ignore_geometry=True) as collection:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -282,23 +282,24 @@ class ReadingTest(unittest.TestCase):
 class IgnoreFieldsTest(unittest.TestCase):
 
     def test_without_ignore(self):
-        collection = fiona.open(WILDSHP, "r")
-        assert("AREA" in collection.schema["properties"].keys())
-        feature = next(collection)
-        assert(feature["properties"]["AREA"] is not None)
-        assert(feature["properties"]["STATE"] is not None)
-        assert(feature["properties"]["NAME"] is not None)
+        with fiona.open(WILDSHP, "r") as collection:
+            assert("AREA" in collection.schema["properties"].keys())
+            feature = next(collection)
+            assert(feature["properties"]["AREA"] is not None)
+            assert(feature["properties"]["STATE"] is not None)
+            assert(feature["properties"]["NAME"] is not None)
 
     def test_ignore_fields(self):
-        collection = fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"])
-        assert("AREA" in collection.schema["properties"].keys())
-        feature = next(collection)
-        assert(feature["properties"]["AREA"] is None)
-        assert(feature["properties"]["STATE"] is None)
-        assert(feature["properties"]["NAME"] is not None)
+        with fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"]) as collection:
+            assert("AREA" in collection.schema["properties"].keys())
+            feature = next(collection)
+            assert(feature["properties"]["AREA"] is None)
+            assert(feature["properties"]["STATE"] is None)
+            assert(feature["properties"]["NAME"] is not None)
 
     def test_ignore_invalid_field_missing(self):
-        collection = fiona.open(WILDSHP, "r", ignore_fields=["DOES_NOT_EXIST"])
+        with fiona.open(WILDSHP, "r", ignore_fields=["DOES_NOT_EXIST"]) as collection:
+            pass
 
     def test_ignore_invalid_field_not_string(self):
         self.assertRaises(

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -284,18 +284,28 @@ class IgnoreFieldsAndGeometryTest(unittest.TestCase):
     def test_without_ignore(self):
         with fiona.open(WILDSHP, "r") as collection:
             assert("AREA" in collection.schema["properties"].keys())
+            assert("STATE" in collection.schema["properties"].keys())
+            assert("NAME" in collection.schema["properties"].keys())
+            assert("geometry" in collection.schema.keys())
+
             feature = next(iter(collection))
             assert(feature["properties"]["AREA"] is not None)
             assert(feature["properties"]["STATE"] is not None)
             assert(feature["properties"]["NAME"] is not None)
+            assert(feature["geometry"] is not None)
 
     def test_ignore_fields(self):
         with fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"]) as collection:
-            assert("AREA" in collection.schema["properties"].keys())
+            assert("AREA" not in collection.schema["properties"].keys())
+            assert("STATE" not in collection.schema["properties"].keys())
+            assert("NAME" in collection.schema["properties"].keys())
+            assert("geometry" in collection.schema.keys())
+
             feature = next(iter(collection))
-            assert(feature["properties"]["AREA"] is None)
-            assert(feature["properties"]["STATE"] is None)
+            assert("AREA" not in feature["properties"].keys())
+            assert("STATE" not in feature["properties"].keys())
             assert(feature["properties"]["NAME"] is not None)
+            assert(feature["geometry"] is not None)
 
     def test_ignore_invalid_field_missing(self):
         with fiona.open(WILDSHP, "r", ignore_fields=["DOES_NOT_EXIST"]) as collection:
@@ -308,8 +318,16 @@ class IgnoreFieldsAndGeometryTest(unittest.TestCase):
 
     def test_ignore_geometry(self):
         with fiona.open(WILDSHP, "r", ignore_geometry=True) as collection:
+            assert("AREA" in collection.schema["properties"].keys())
+            assert("STATE" in collection.schema["properties"].keys())
+            assert("NAME" in collection.schema["properties"].keys())
+            assert("geometry" not in collection.schema.keys())
+
             feature = next(iter(collection))
-            assert(feature["geometry"] is None)
+            assert(feature["properties"]["AREA"] is not None)
+            assert(feature["properties"]["STATE"] is not None)
+            assert(feature["properties"]["NAME"] is not None)
+            assert("geometry" not in feature.keys())
 
 
 class FilterReadingTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -279,6 +279,35 @@ class ReadingTest(unittest.TestCase):
         self.assertTrue(0 in self.c)
 
 
+class IgnoreFieldsTest(unittest.TestCase):
+
+    def test_without_ignore(self):
+        collection = fiona.open(WILDSHP, "r")
+        assert("AREA" in collection.schema["properties"].keys())
+        feature = next(collection)
+        assert(feature["properties"]["AREA"] is not None)
+        assert(feature["properties"]["STATE"] is not None)
+        assert(feature["properties"]["NAME"] is not None)
+
+    def test_ignore_fields(self):
+        collection = fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"])
+        assert("AREA" in collection.schema["properties"].keys())
+        feature = next(collection)
+        assert(feature["properties"]["AREA"] is None)
+        assert(feature["properties"]["STATE"] is None)
+        assert(feature["properties"]["NAME"] is not None)
+
+    def test_ignore_invalid_field_missing(self):
+        collection = fiona.open(WILDSHP, "r", ignore_fields=["DOES_NOT_EXIST"])
+
+    def test_ignore_invalid_field_not_string(self):
+        self.assertRaises(
+            AttributeError,
+            fiona.open,
+            {"path": WILDSHP, "mode": "r", "ignore_fields": [42]}
+        )
+
+
 class FilterReadingTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -279,12 +279,12 @@ class ReadingTest(unittest.TestCase):
         self.assertTrue(0 in self.c)
 
 
-class IgnoreFieldsTest(unittest.TestCase):
+class IgnoreFieldsAndGeometryTest(unittest.TestCase):
 
     def test_without_ignore(self):
         with fiona.open(WILDSHP, "r") as collection:
             assert("AREA" in collection.schema["properties"].keys())
-            feature = next(collection)
+            feature = next(iter(collection))
             assert(feature["properties"]["AREA"] is not None)
             assert(feature["properties"]["STATE"] is not None)
             assert(feature["properties"]["NAME"] is not None)
@@ -292,7 +292,7 @@ class IgnoreFieldsTest(unittest.TestCase):
     def test_ignore_fields(self):
         with fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"]) as collection:
             assert("AREA" in collection.schema["properties"].keys())
-            feature = next(collection)
+            feature = next(iter(collection))
             assert(feature["properties"]["AREA"] is None)
             assert(feature["properties"]["STATE"] is None)
             assert(feature["properties"]["NAME"] is not None)
@@ -307,6 +307,11 @@ class IgnoreFieldsTest(unittest.TestCase):
             fiona.open,
             {"path": WILDSHP, "mode": "r", "ignore_fields": [42]}
         )
+
+    def test_ignore_geometry(self):
+        with fiona.open(WILDSHP, "r", ignore_geometry=True) as collection:
+            feature = next(iter(collection))
+            assert(feature["geometry"] is None)
 
 
 class FilterReadingTest(unittest.TestCase):


### PR DESCRIPTION
This PR is my first attempt at ignoring fields using the OGR API, as discussed in #429.

Is there a better way to create a `NULL` terminated `char **` array?

The feature is exposed as a keyword argument on `fiona.open`, e.g.

```
collection = fiona.open(WILDSHP, "r", ignore_fields=["AREA", "STATE"])
```

I don't think it would be to difficult to implement a `usecols` option for whitelisting, as the OGR layer is already open by the time the API method is called.

The fields are not *hidden* from the user, but their values are not returned. Instead the fields are populated with `None`. This isn't something I've decided - it's just what it's doing.

I haven't done any benchmarking on this to see if it actually makes a difference for large datasets.