### PR TITLE
Initial implementation of transactions in writerecords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ venv2/
 
 # fiona
 VERSION.txt
+fiona/_shim.c
 fiona/ogrext.c
 fiona/_crs.c
 fiona/_drivers.c
@@ -78,3 +79,4 @@ fiona/_shim.pyx
 tests/data/coutwildrnp.json
 tests/data/coutwildrnp.tar
 tests/data/coutwildrnp.zip
+tests/data/coutwildrnp.gpkg

--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -4,6 +4,9 @@ cdef bint is_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers)
 cdef void* gdal_create(void* cogr_driver, const char *path_c) except *
+cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
+cdef OGRErr gdal_commit_transaction(void *cogr_ds)
+cdef OGRErr gdal_rollback_transaction(void *cogr_ds)
 
 from fiona._shim cimport OGR_F_GetFieldAsInteger as OGR_F_GetFieldAsInteger64
 from fiona._shim cimport OGR_F_SetFieldInteger as OGR_F_SetFieldInteger64

--- a/fiona/_shim1.pyx
+++ b/fiona/_shim1.pyx
@@ -46,3 +46,11 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c) except *:
     except Exception as exc:
         raise DriverIOError(str(exc))
     return cogr_ds
+
+# transactions are not supported in GDAL 1.x
+cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
+    return OGRERR_NONE
+cdef OGRErr gdal_commit_transaction(void* cogr_ds):
+    return OGRERR_NONE
+cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
+    return OGRERR_NONE

--- a/fiona/_shim2.pxd
+++ b/fiona/_shim2.pxd
@@ -4,3 +4,6 @@ cdef bint is_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers)
 cdef void* gdal_create(void* cogr_driver, const char *path_c) except *
+cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
+cdef OGRErr gdal_commit_transaction(void *cogr_ds)
+cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim2.pyx
+++ b/fiona/_shim2.pyx
@@ -44,3 +44,12 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c) except *:
         0,
         GDT_Unknown,
     NULL)
+
+cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
+    return GDALDatasetStartTransaction(cogr_ds, force)
+
+cdef OGRErr gdal_commit_transaction(void* cogr_ds):
+    return GDALDatasetCommitTransaction(cogr_ds)
+
+cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
+    return GDALDatasetRollbackTransaction(cogr_ds)

--- a/fiona/_shim22.pxd
+++ b/fiona/_shim22.pxd
@@ -4,3 +4,6 @@ cdef bint is_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers)
 cdef void* gdal_create(void* cogr_driver, const char *path_c) except *
+cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
+cdef OGRErr gdal_commit_transaction(void *cogr_ds)
+cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim22.pyx
+++ b/fiona/_shim22.pyx
@@ -53,3 +53,12 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c) except *:
         0,
         GDT_Unknown,
     NULL)
+
+cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
+    return GDALDatasetStartTransaction(cogr_ds, force)
+
+cdef OGRErr gdal_commit_transaction(void* cogr_ds):
+    return GDALDatasetCommitTransaction(cogr_ds)
+
+cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
+    return GDALDatasetRollbackTransaction(cogr_ds)

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -31,3 +31,7 @@ class FieldNameEncodeError(UnicodeEncodeError):
 
 class UnsupportedGeometryTypeError(KeyError):
     """When a OGR geometry type isn't supported by Fiona."""
+
+
+class TransactionError(RuntimeError):
+    """Failure relating to GDAL transactions"""

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -2,6 +2,19 @@
 # All rights reserved.
 # See ../LICENSE.txt
 
+cdef extern from "ogr_core.h":
+
+    ctypedef int OGRErr
+
+    ctypedef struct OGREnvelope:
+        double MinX
+        double MaxX
+        double MinY
+        double MaxY
+
+    char *  OGRGeometryTypeToName(int)
+
+
 cdef extern from "gdal.h":
     char * GDALVersionInfo (char *pszRequest)
     void * GDALGetDriverByName(const char * pszName)
@@ -36,6 +49,9 @@ cdef extern from "gdal.h":
     char * GDALGetDriverShortName(void * hDriver)
     char * GDALGetDatasetDriver (void * hDataset)
     int GDALDeleteDataset(void * hDriver, const char * pszFilename)
+    OGRErr GDALDatasetStartTransaction (void * hDataset, int bForce)
+    OGRErr GDALDatasetCommitTransaction (void * hDataset)
+    OGRErr GDALDatasetRollbackTransaction (void * hDataset)
 
 
     ctypedef enum GDALDataType:
@@ -78,19 +94,6 @@ cdef extern from "cpl_vsi.h":
                                      int data_len,
                                      int take_ownership)
     int VSIUnlink (const char * pathname)
-
-
-cdef extern from "ogr_core.h":
-
-    ctypedef int OGRErr
-
-    ctypedef struct OGREnvelope:
-        double MinX
-        double MaxX
-        double MinY
-        double MaxY
-
-    char *  OGRGeometryTypeToName(int)
 
 
 cdef extern from "ogr_srs_api.h":

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -33,7 +33,7 @@ GDALOPTS="  --with-ogr \
             --without-xerces \
             --without-odbc \
             --without-curl \
-            --without-sqlite3 \
+            --with-sqlite3 \
             --without-dwgdirect \
             --without-idb \
             --without-sde \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import json
 import os.path
 import tarfile
 import zipfile
+import copy
 
 from click.testing import CliRunner
 import pytest

--- a/tests/test_geopackage.py
+++ b/tests/test_geopackage.py
@@ -1,86 +1,55 @@
-
-import logging
 import os
-import os.path
-import shutil
-import sys
-import tempfile
-import unittest
-
 import pytest
-
 import fiona
-from fiona.collection import supported_drivers
-from fiona.errors import FionaValueError, DriverError, SchemaError, CRSError
-from fiona.ogrext import calc_gdal_version_num, get_gdal_version_num
 
+has_gpkg = "GPKG" in fiona.supported_drivers.keys()
 
-logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+@pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
+def test_read_gpkg(path_coutwildrnp_gpkg):
+    """
+    Implicitly tests writing gpkg as the fixture will create the data source on
+    first request
+    """
+    with fiona.open(path_coutwildrnp_gpkg, "r") as src:
+        assert len(src) == 67
+        feature = next(src)
+        assert feature["geometry"]["type"] == "Polygon"
+        assert feature["properties"]["NAME"] == "Mount Naomi Wilderness"
 
+@pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
+def test_write_gpkg(tmpdir):
+    schema = {
+        'geometry': 'Point',
+        'properties': [('title', 'str')],
+    }
+    crs = {
+        'a': 6370997,
+        'lon_0': -100,
+        'y_0': 0,
+        'no_defs': True,
+        'proj': 'laea',
+        'x_0': 0,
+        'units': 'm',
+        'b': 6370997,
+        'lat_0': 45,
+    }
 
-class ReadingTest(unittest.TestCase):
+    path = str(tmpdir.join('foo.gpkg'))
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    @pytest.mark.skipif(not os.path.exists('tests/data/coutwildrnp.gpkg'),
-                        reason="Requires geopackage fixture")
-    def test_gpkg(self):
-        if get_gdal_version_num() < calc_gdal_version_num(1, 11, 0):
-            self.assertRaises(DriverError, fiona.open, 'tests/data/coutwildrnp.gpkg', 'r', driver="GPKG")
-        else:
-            with fiona.open('tests/data/coutwildrnp.gpkg', 'r', driver="GPKG") as c:
-                self.assertEquals(len(c), 48)
-
-
-class WritingTest(unittest.TestCase):
-
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    @pytest.mark.skipif(not os.path.exists('tests/data/coutwildrnp.gpkg'),
-                        reason="Requires geopackage fixture")
-    def test_gpkg(self):
-        schema = {'geometry': 'Point',
-                  'properties': [('title', 'str')]}
-        crs = {
-            'a': 6370997,
-            'lon_0': -100,
-            'y_0': 0,
-            'no_defs': True,
-            'proj': 'laea',
-            'x_0': 0,
-            'units': 'm',
-            'b': 6370997,
-            'lat_0': 45}
-
-        path = os.path.join(self.tempdir, 'foo.gpkg')
-        
-        if get_gdal_version_num() < calc_gdal_version_num(1, 11, 0):
-            self.assertRaises(DriverError,
-                        fiona.open,
-                        path,
-                        'w',
-                        driver='GPKG',
-                        schema=schema,
-                        crs=crs)
-        else:
-            with fiona.open(path, 'w',
-                            driver='GPKG',
-                            schema=schema,
-                            crs=crs) as c:
-                c.writerecords([{
-                    'geometry': {'type': 'Point', 'coordinates': [0.0, 0.0]},
-                    'properties': {'title': 'One'}}])
-                c.writerecords([{
-                    'geometry': {'type': 'Point', 'coordinates': [2.0, 3.0]},
-                    'properties': {'title': 'Two'}}])
-            with fiona.open(path) as c:
-                self.assertEquals(c.schema['geometry'], 'Point')
-                self.assertEquals(len(c), 2)
+    with fiona.open(path, 'w',
+                    driver='GPKG',
+                    schema=schema,
+                    crs=crs) as dst:
+        dst.writerecords([{
+            'geometry': {'type': 'Point', 'coordinates': [0.0, 0.0]},
+            'properties': {'title': 'One'}}])
+        dst.writerecords([{
+            'geometry': {'type': 'Point', 'coordinates': [2.0, 3.0]},
+            'properties': {'title': 'Two'}}])
+        dst.write({
+            'geometry': {'type': 'Point', 'coordinates': [20.0, 30.0]},
+            'properties': {'title': 'Three'}})
+    with fiona.open(path) as src:
+        assert src.schema['geometry'] == 'Point'
+        assert src.crs == crs
+        assert len(src) == 3

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 import pytest
 
 has_gpkg = "GPKG" in fiona.supported_drivers.keys()
-has_gdal2 = fiona.ogrext.get_gdal_version_num() >= 2000000
 
 def create_records(count):
     for n in range(count):
@@ -29,7 +28,7 @@ class DebugHandler(logging.Handler):
 
 log = logging.getLogger("Fiona")
 
-@pytest.mark.skipif(not (has_gpkg & has_gdal2), reason="Requires geopackage and GDAL 2.x")
+@pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
 class TestTransaction:
     def setup_method(self):
         self.handler = DebugHandler(pattern="transaction")


### PR DESCRIPTION
This PR implements transactions when using `collection.writerecords` in GDAL 2.x, as discussed in #476. Currently it's hard-coded to use a transaction size of 20,000 (the same as `ogr2ogr`). This significantly speeds up writing GPKG files.

I'm not sure of the best way to expose the transaction size to the user. Is it a property of the collection, or an argument to the `writerecords` call?

This should have no impact on drivers which don't support transactions.