### PR TITLE
GDAL 2.3.x silently converts ESRI WKT to OGC WKT.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,3 +181,9 @@ def uttc_path_gpx(path_gpx, request):
     """Make the ``path_gpx`` fixture work with a ``unittest.TestCase()``.
     ``uttc`` stands for unittest test case."""
     request.cls.path_gpx = path_gpx
+
+"""
+GDAL 2.3.x silently converts ESRI WKT to OGC WKT
+The regular expression below will match against either
+"""
+WGS84PATTERN = 'GEOGCS\["(?:GCS_WGS_1984|WGS 84)",DATUM\["WGS_1984",SPHEROID\["WGS_84"'

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -8,12 +8,15 @@ import sys
 import subprocess
 import tempfile
 import unittest
+import re
 
 import pytest
 
 import fiona
 from fiona.collection import Collection, supported_drivers
 from fiona.errors import FionaValueError, DriverError
+
+from .conftest import WGS84PATTERN
 
 
 OGRINFO_TOOL = "ogrinfo"
@@ -190,7 +193,7 @@ class ReadingTest(unittest.TestCase):
 
     def test_crs_wkt(self):
         crs = self.c.crs_wkt
-        self.assertTrue(crs.startswith('GEOGCS["GCS_WGS_1984"'))
+        assert re.match(WGS84PATTERN, crs)
 
     def test_closed_crs(self):
         # Crs is lazy too, never computed in this case. TODO?

--- a/tests/test_collection_crs.py
+++ b/tests/test_collection_crs.py
@@ -1,21 +1,20 @@
 import os
-import tempfile
+import re
 
 import fiona
 import fiona.crs
 
+from .conftest import WGS84PATTERN
 
-def test_collection_crs_wkt():
-    with fiona.open('tests/data/coutwildrnp.shp') as src:
-        assert src.crs_wkt.startswith(
-            'GEOGCS["GCS_WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_84"')
+def test_collection_crs_wkt(path_coutwildrnp_shp):
+    with fiona.open(path_coutwildrnp_shp) as src:
+        assert re.match(WGS84PATTERN, src.crs_wkt)
 
 
-def test_collection_no_crs_wkt():
+def test_collection_no_crs_wkt(tmpdir, path_coutwildrnp_shp):
     """crs members of a dataset with no crs can be accessed safely."""
-    tmpdir = tempfile.gettempdir()
-    filename = os.path.join(tmpdir, 'test.shp')
-    with fiona.open('tests/data/coutwildrnp.shp') as src:
+    filename = str(tmpdir.join("test.shp"))
+    with fiona.open(path_coutwildrnp_shp) as src:
         profile = src.meta
     del profile['crs']
     del profile['crs_wkt']

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,20 +1,20 @@
 import os
-import tempfile
+import re
 
 import fiona
 
+from .conftest import WGS84PATTERN
 
-def test_profile():
-    with fiona.open('tests/data/coutwildrnp.shp') as src:
-        assert src.meta['crs_wkt'] == 'GEOGCS["GCS_WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295],AUTHORITY["EPSG","4326"]]'
+def test_profile(path_coutwildrnp_shp):
+    with fiona.open(path_coutwildrnp_shp) as src:
+        assert re.match(WGS84PATTERN, src.crs_wkt)
 
 
-def test_profile_creation_wkt():
-    tmpdir = tempfile.mkdtemp()
-    outfilename = os.path.join(tmpdir, 'test.shp')
-    with fiona.open('tests/data/coutwildrnp.shp') as src:
+def test_profile_creation_wkt(tmpdir, path_coutwildrnp_shp):
+    outfilename = str(tmpdir.join("test.shp"))
+    with fiona.open(path_coutwildrnp_shp) as src:
         profile = src.meta
         profile['crs'] = 'bogus'
         with fiona.open(outfilename, 'w', **profile) as dst:
             assert dst.crs == {'init': 'epsg:4326'}
-            assert dst.crs_wkt == 'GEOGCS["GCS_WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295],AUTHORITY["EPSG","4326"]]'
+            assert re.match(WGS84PATTERN, dst.crs_wkt)


### PR DESCRIPTION
This PR fixes the WKT CRS errors we're getting with GDAL trunk, e.g.:

https://travis-ci.org/Toblerity/Fiona/jobs/297667083

It looks like GDAL is converting the CRS from ESRI WKT to OGC WKT. Older versions don't do this so we need to handle both in the tests.

https://gis.stackexchange.com/a/70286/12420