### PR TITLE
Add Appveyor badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ Fiona is OGR's neat and nimble API for Python programmers.
 .. image:: https://travis-ci.org/Toblerity/Fiona.png?branch=master   
    :target: https://travis-ci.org/Toblerity/Fiona
 
+.. image:: https://ci.appveyor.com/api/projects/status/github/Toblerity/Fiona?svg=true
+   :target: https://ci.appveyor.com/project/sgillies/fiona/branch/master
+
 .. image:: https://coveralls.io/repos/Toblerity/Fiona/badge.png
    :target: https://coveralls.io/r/Toblerity/Fiona
 


### PR DESCRIPTION
Add a badge to the README to show Windows build status on the front page.