### PR TITLE
Remove unnecessary if/else

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -137,11 +137,8 @@ class Collection(object):
                 else:
                     raise CRSError("crs lacks init or proj parameter")
 
-        if driver_count == 0:
-            # create a local manager and enter
-            self.env = AWSGDALEnv()
-        else:
-            self.env = AWSGDALEnv()
+        # create a local manager and enter
+        self.env = AWSGDALEnv()
         self.env.__enter__()
 
         self._driver = driver


### PR DESCRIPTION
Though in looking at the blame, this was just edited/reviewed, so
perhaps I'm just missing some black magic beyond my understanding.

This caught my eye while trying to see if I could fathom any explanation for the behavior I mentioned in #510 regarding different behavior in opening a file using `encoding='utf-8'`.