### PR TITLE
[WIP] Use C++11. Closes #514.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,11 @@ ext_options = dict(
     libraries=libraries,
     extra_link_args=extra_link_args)
 
+ext_options_cpp = ext_options.copy()
+# GDAL 2.3+ requires C++11
+ext_options_cpp["extra_compile_args"] = ["-std=c++11"]
+
+
 # Define the extension modules.
 ext_modules = []
 
@@ -206,7 +211,7 @@ if source_is_repo and "clean" not in sys.argv:
 
     ext_modules = cythonize([
         Extension('fiona._geometry', ['fiona/_geometry.pyx'], **ext_options),
-        Extension('fiona._transform', ['fiona/_transform.pyx'], **ext_options),
+        Extension('fiona._transform', ['fiona/_transform.pyx'], **ext_options_cpp),
         Extension('fiona._crs', ['fiona/_crs.pyx'], **ext_options),
         Extension('fiona._drivers', ['fiona/_drivers.pyx'], **ext_options),
         Extension('fiona._err', ['fiona/_err.pyx'], **ext_options),
@@ -216,7 +221,7 @@ if source_is_repo and "clean" not in sys.argv:
 # If there's no manifest template, as in an sdist, we just specify .c files.
 elif "clean" not in sys.argv:
     ext_modules = [
-        Extension('fiona._transform', ['fiona/_transform.cpp'], **ext_options),
+        Extension('fiona._transform', ['fiona/_transform.cpp'], **ext_options_cpp),
         Extension('fiona._geometry', ['fiona/_geometry.c'], **ext_options),
         Extension('fiona._crs', ['fiona/_crs.c'], **ext_options),
         Extension('fiona._drivers', ['fiona/_drivers.c'], **ext_options),

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,10 @@ ext_options = dict(
 
 ext_options_cpp = ext_options.copy()
 # GDAL 2.3+ requires C++11
-ext_options_cpp["extra_compile_args"] = ["-std=c++11"]
+if sys.platform == "win32":
+    ext_options_cpp["extra_compile_args"] = ["/std:c++11"]
+else:
+    ext_options_cpp["extra_compile_args"] = ["-std=c++11"]
 
 
 # Define the extension modules.


### PR DESCRIPTION
This PR builds the `_transform` module using the C++11 standard.

I've not tested this on Windows. I suspect it will break, as MSVC uses a different flag? `/std:c++11`?

Also, VS2008 (which must be used to build Python 2.7 modules) does not support C++11. If I understand this correctly, this means a Python 2.7 + GDAL 2.3 build will be impossible. If we include this, it will also mean the .cpp source distribution wont work for Python 2.x. https://stackoverflow.com/questions/20302891/visual-studio-2008-with-c11