### PR TITLE
Fix handling of paths on Windows. Closes #505.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,12 +21,14 @@ environment:
         - PYTHON: "C:\\Python34-x64"
           PYTHON_VERSION: "3.4.3"
           PYTHON_ARCH: "64"
+          GDAL_VERSION: "1.11.4"
           GIS_INTERNALS: "release-1600-x64-gdal-1-11-4-mapserver-6-4-3.zip"
           GIS_INTERNALS_LIBS: "release-1600-x64-gdal-1-11-4-mapserver-6-4-3-libs.zip"
           
         - PYTHON: "C:\\Python34-x64"
           PYTHON_VERSION: "3.4.3"
           PYTHON_ARCH: "64"
+          GDAL_VERSION: "2.2.1"
           GIS_INTERNALS: "release-1600-x64-gdal-2-2-1-mapserver-7-0-6.zip"
           GIS_INTERNALS_LIBS: "release-1600-x64-gdal-2-2-1-mapserver-7-0-6-libs.zip"
 
@@ -97,7 +99,7 @@ build_script:
 
   - cmd: echo %PYTHONPATH%
 
-  - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib develop --gdalversion 1.11.4"
+  - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib develop --gdalversion %GDAL_VERSION%"
 
 
 test_script:

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -1,6 +1,8 @@
 """Implementation of Apache VFS schemes and URLs."""
 
 import os
+import sys
+import re
 from fiona.compat import urlparse
 
 # Supported URI schemes and their mapping to GDAL's VSI suffix. 
@@ -40,6 +42,10 @@ def parse_paths(uri, vfs=None):
     """
     archive = scheme = None
     path = uri
+    # Windows drive letters (e.g. "C:\") confuse `urlparse` as they look like
+    # URL schemes
+    if sys.platform == "win32" and re.match("^[a-zA-Z]\\:", path):
+        return path, None, None
     if vfs:
         parts = urlparse(vfs)
         scheme = parts.scheme


### PR DESCRIPTION
This PR fixes a regression introduced in the handling of paths beginning with a drive letter on Windows. Previously a path like `"C:\hello\world.shp"` would be interpreted as a URL with scheme `"C"` and a path `"/hello/world"`, which is incorrect. This type of path is now detected on Windows and handled correctly. True VFS paths should still work as expected.

Closes #505.