### PR TITLE
Fixed WGS 84 CRS regular expression.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,4 +195,4 @@ def uttc_path_gpx(path_gpx, request):
 GDAL 2.3.x silently converts ESRI WKT to OGC WKT
 The regular expression below will match against either
 """
-WGS84PATTERN = 'GEOGCS\["(?:GCS_WGS_1984|WGS 84)",DATUM\["WGS_1984",SPHEROID\["WGS_84"'
+WGS84PATTERN = 'GEOGCS\["(?:GCS_WGS_1984|WGS 84)",DATUM\["WGS_1984",SPHEROID\["WGS[_ ]84"'


### PR DESCRIPTION
This PR corrects a mistake in #495. The regex wasn't actually matching the new CRS in GDAL 2.3 - there are other issues still causing tests to fail in trunk, so it's difficult to spot.