### PR TITLE
Added support for bool field subtype in GDAL 2.x

### DIFF
--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -1,5 +1,12 @@
 include "ogrext1.pxd"
 
+ctypedef enum OGRFieldSubType:
+    OFSTNone = 0
+    OFSTBoolean = 1
+    OFSTInt16 = 2
+    OFSTFloat32 = 3
+    OFSTMaxSubType = 3
+
 cdef bint is_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers, options)
@@ -7,6 +14,8 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)
+cdef OGRFieldSubType get_field_subtype(void *fielddefn)
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype)
 
 from fiona._shim cimport OGR_F_GetFieldAsInteger as OGR_F_GetFieldAsInteger64
 from fiona._shim cimport OGR_F_SetFieldInteger as OGR_F_SetFieldInteger64

--- a/fiona/_shim1.pyx
+++ b/fiona/_shim1.pyx
@@ -91,3 +91,9 @@ cdef OGRErr gdal_commit_transaction(void* cogr_ds):
     return OGRERR_NONE
 cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
     return OGRERR_NONE
+
+# field subtypes are not supported in GDAL 1.x
+cdef OGRFieldSubType get_field_subtype(void *fielddefn):
+    return OFSTNone
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype):
+    pass

--- a/fiona/_shim2.pxd
+++ b/fiona/_shim2.pxd
@@ -7,3 +7,5 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)
+cdef OGRFieldSubType get_field_subtype(void *fielddefn)
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype)

--- a/fiona/_shim2.pyx
+++ b/fiona/_shim2.pyx
@@ -85,3 +85,9 @@ cdef OGRErr gdal_commit_transaction(void* cogr_ds):
 
 cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
     return GDALDatasetRollbackTransaction(cogr_ds)
+
+cdef OGRFieldSubType get_field_subtype(void *fielddefn):
+    return OGR_Fld_GetSubType(fielddefn)
+
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype):
+    OGR_Fld_SetSubType(fielddefn, subtype)

--- a/fiona/_shim22.pxd
+++ b/fiona/_shim22.pxd
@@ -7,3 +7,5 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)
+cdef OGRFieldSubType get_field_subtype(void *fielddefn)
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype)

--- a/fiona/_shim22.pyx
+++ b/fiona/_shim22.pyx
@@ -94,3 +94,9 @@ cdef OGRErr gdal_commit_transaction(void* cogr_ds):
 
 cdef OGRErr gdal_rollback_transaction(void* cogr_ds):
     return GDALDatasetRollbackTransaction(cogr_ds)
+    
+cdef OGRFieldSubType get_field_subtype(void *fielddefn):
+    return OGR_Fld_GetSubType(fielddefn)
+
+cdef void set_field_subtype(void *fielddefn, OGRFieldSubType subtype):
+    OGR_Fld_SetSubType(fielddefn, subtype)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -6,6 +6,14 @@ cdef extern from "ogr_core.h":
 
     ctypedef int OGRErr
 
+    ctypedef int OGRFieldSubType
+    ctypedef enum OGRFieldSubType:
+        OFSTNone = 0
+        OFSTBoolean = 1
+        OFSTInt16 = 2
+        OFSTFloat32 = 3
+        OFSTMaxSubType = 3
+
     ctypedef struct OGREnvelope:
         double MinX
         double MaxX
@@ -158,6 +166,8 @@ cdef extern from "ogr_api.h":
     void    OGR_Fld_Set (void *fielddefn, char *name, int fieldtype, int width, int precision, int justification)
     void    OGR_Fld_SetPrecision (void *fielddefn, int n)
     void    OGR_Fld_SetWidth (void *fielddefn, int n)
+    OGRFieldSubType OGR_Fld_GetSubType(void *fielddefn)
+    void    OGR_Fld_SetSubType(void *fielddefn, OGRFieldSubType subtype)
     OGRErr  OGR_G_AddGeometryDirectly (void *geometry, void *part)
     void    OGR_G_AddPoint (void *geometry, double x, double y, double z)
     void    OGR_G_AddPoint_2D (void *geometry, double x, double y)

--- a/tests/test_subtypes.py
+++ b/tests/test_subtypes.py
@@ -1,0 +1,52 @@
+import fiona
+
+GDAL_MAJOR_VER = fiona.get_gdal_version_num() // 1000000
+
+def test_read_bool_subtype(tmpdir):
+    test_data = """{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"bool": true, "not_bool": 1, "float": 42.5}, "geometry": null}]}"""
+    path = tmpdir.join("test_read_bool_subtype.geojson")
+    with open(str(path), "w") as f:
+        f.write(test_data)
+    
+    with fiona.open(str(path), "r") as src:
+        feature = next(iter(src))
+    
+    if GDAL_MAJOR_VER >= 2:
+        assert type(feature["properties"]["bool"]) is bool
+    else:
+        assert type(feature["properties"]["bool"]) is int
+    assert type(feature["properties"]["not_bool"]) is int
+    assert type(feature["properties"]["float"]) is float
+
+def test_write_bool_subtype(tmpdir):
+    path = tmpdir.join("test_write_bool_subtype.geojson")
+    
+    schema = {
+        "geometry": "Point",
+        "properties": {
+            "bool": "bool",
+            "not_bool": "int",
+            "float": "float",
+        }
+    }
+    
+    feature = {
+        "geometry": None,
+        "properties": {
+            "bool": True,
+            "not_bool": 1,
+            "float": 42.5,
+        }
+    }
+
+    with fiona.open(str(path), "w", driver="GeoJSON", schema=schema) as dst:
+        dst.write(feature)
+    
+    with open(str(path), "r") as f:
+        data = f.read()
+    
+    if GDAL_MAJOR_VER >= 2:
+        assert """"bool": true""" in data
+    else:
+        assert """"bool": 1""" in data
+    assert """"not_bool": 1""" in data


### PR DESCRIPTION
This PR adds support for the "bool" field subtype when using GDAL 2.x. When using GDAL 1.x the subtype is simply ignored - you can still pass "bool" in the schema but an "int" will be written.

Closes #524.