### PR TITLE
fix OrderedDict import on py27

### DIFF
--- a/fiona/compat.py
+++ b/fiona/compat.py
@@ -9,14 +9,13 @@ except ImportError:
 
 if sys.version_info[0] >= 3:
     from urllib.parse import urlparse
-    from collections import UserDict, OrderedDict
+    from collections import UserDict
 else:
     from urlparse import urlparse
     from UserDict import UserDict
-    from ordereddict import OrderedDict
 
 # Users can pass in objects that subclass a few different objects
 # More specifically, rasterio has a CRS() class that subclasses UserDict()
 # In Python 2 UserDict() is in its own module and does not subclass Mapping()
 DICT_TYPES = (dict, collections.Mapping, UserDict)
-    
+


### PR DESCRIPTION
Line 16 prevent us from using fiona on Python 2.7 and `OrderedDict` is already handled correctly via the try-except clause in lines 6-8.