### PR TITLE
Added `fio rm` command

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -10,23 +10,27 @@ Fiona's new command line interface is a program named "fio".
       Fiona command line interface.
 
     Options:
-      -v, --verbose  Increase verbosity.
-      -q, --quiet    Decrease verbosity.
-      --version      Show the version and exit.
-      --help         Show this message and exit.
+      -v, --verbose     Increase verbosity.
+      -q, --quiet       Decrease verbosity.
+      --version         Show the version and exit.
+      --gdal-version    Show the version and exit.
+      --python-version  Show the version and exit.
+      --help            Show this message and exit.
 
     Commands:
       bounds   Print the extent of GeoJSON objects
-      buffer   Buffer geometries on all sides by a fixed distance.
+      calc     Calculate GeoJSON property by Python expression
       cat      Concatenate and print the features of datasets
       collect  Collect a sequence of features.
-      distrib  Distribute features from a collection
+      distrib  Distribute features from a collection.
       dump     Dump a dataset to GeoJSON.
       env      Print information about the fio environment.
-      filter   Filter GeoJSON features by python expression
+      filter   Filter GeoJSON features by python expression.
       info     Print information about a dataset.
       insp     Open a dataset and start an interpreter.
       load     Load GeoJSON to a dataset in another format.
+      ls       List layers in a datasource.
+      rm       Remove a datasource or an individual layer.
 
 It is developed using the ``click`` package and is new in 1.1.6.
 
@@ -259,6 +263,19 @@ For example
 
 Would create a geojson file with only those features from `data.shp` where the
 area was over a given threshold.
+
+rm
+--
+The ``fio rm`` command deletes an entire datasource or a single layer in a
+multi-layer datasource. If the datasource is composed of multiple files
+(e.g. an ESRI Shapefile) all of the files will be removed.
+
+.. code-block:: console
+
+    $ fio rm countries.shp
+    $ fio rm --layer forests land_cover.gpkg
+
+New in 1.8.0.
 
 Coordinate Reference System Transformations
 -------------------------------------------

--- a/docs/fiona.fio.rst
+++ b/docs/fiona.fio.rst
@@ -124,6 +124,14 @@ fiona.fio.options module
     :undoc-members:
     :show-inheritance:
 
+fiona.fio.rm module
+-------------------
+
+.. automodule:: fiona.fio.rm
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -73,7 +73,7 @@ from fiona._drivers import driver_count, GDALEnv
 from fiona.drvsupport import supported_drivers
 from fiona.compat import OrderedDict
 from fiona.io import MemoryFile
-from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP, _remove
+from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP, _remove, _remove_layer
 from fiona.ogrext import (
     calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
 
@@ -249,7 +249,7 @@ def open(fp, mode='r', driver=None, schema=None, crs=None, encoding=None,
 collection = open
 
 
-def remove(path_or_collection, driver=None):
+def remove(path_or_collection, driver=None, layer=None):
     """Deletes an OGR data source
 
     The required ``path`` argument may be an absolute or relative file path.
@@ -271,9 +271,10 @@ def remove(path_or_collection, driver=None):
         collection.close()
     else:
         path = path_or_collection
-        if driver is None:
-            raise ValueError("The driver argument is required when removing a path")
-    _remove(path, driver)
+    if layer is None:
+        _remove(path, driver)
+    else:
+        _remove_layer(path, layer, driver)
 
 
 def listlayers(path, vfs=None):

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -25,6 +25,10 @@ class DriverIOError(IOError):
     """A format specific driver error."""
 
 
+class DatasetDeleteError(IOError):
+    """Failure to delete a dataset"""
+
+
 class FieldNameEncodeError(UnicodeEncodeError):
     """Failure to encode a field name."""
 

--- a/fiona/fio/rm.py
+++ b/fiona/fio/rm.py
@@ -1,0 +1,25 @@
+import click
+import fiona
+import logging
+
+logger = logging.getLogger('fio')
+
+@click.command(help="Remove a datasource or an individual layer.")
+@click.argument("input", required=True)
+@click.option("--layer", type=str, default=None, required=False, help="Name of layer to remove.")
+@click.option("--yes", is_flag=True)
+@click.pass_context
+def rm(ctx, input, layer, yes):
+    if layer is None:
+        kind = "datasource"
+    else:
+        kind = "layer"
+
+    if not yes:
+        click.confirm("The {} will be removed. Are you sure?".format(kind), abort=True)
+
+    try:
+        fiona.remove(input, layer=layer)
+    except Exception:
+        logger.exception("Failed to remove {}.".format(kind))
+        raise click.Abort()

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -152,6 +152,7 @@ cdef extern from "ogr_api.h":
     int     OGR_Dr_DeleteDataSource (void *driver, char *)
     void *  OGR_Dr_Open (void *driver, const char *path, int bupdate)
     int     OGR_Dr_TestCapability (void *driver, const char *)
+    int     OGR_DS_DeleteLayer (void *datasource, int n)
     void *  OGR_F_Create (void *featuredefn)
     void    OGR_F_Destroy (void *feature)
     long    OGR_F_GetFID (void *feature)

--- a/setup.py
+++ b/setup.py
@@ -303,6 +303,7 @@ setup_args = dict(
         insp=fiona.fio.insp:insp
         load=fiona.fio.load:load
         ls=fiona.fio.ls:ls
+        rm=fiona.fio.rm:rm
         ''',
     install_requires=requirements,
     extras_require=extras_require,

--- a/tests/test_fio_rm.py
+++ b/tests/test_fio_rm.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+import fiona
+from click.testing import CliRunner
+from fiona.fio.main import main_group
+
+def create_sample_data(filename, driver, **extra_meta):
+    meta = {
+        'driver': driver,
+        'schema': {
+            'geometry': 'Point',
+            'properties': {}
+        }
+    }
+    meta.update(extra_meta)
+    with fiona.open(filename, 'w', **meta) as dst:
+        dst.write({
+            'geometry': {
+                'type': 'Point',
+                'coordinates': (0, 0),
+            },
+            'properties': {},
+        })
+    assert(os.path.exists(filename))
+
+drivers = ["ESRI Shapefile", "GeoJSON"]
+@pytest.mark.parametrize("driver", drivers)
+def test_remove(tmpdir, driver):
+    extension = {"ESRI Shapefile": "shp", "GeoJSON": "json"}[driver]
+    filename = "delete_me.{extension}".format(extension=extension)
+    filename = str(tmpdir.join(filename))
+    create_sample_data(filename, driver)
+    
+    result = CliRunner().invoke(main_group, [
+        "rm",
+        filename,
+        "--yes"
+    ])
+    print(result.output)
+    assert result.exit_code == 0
+    assert not os.path.exists(filename)
+
+
+has_gpkg = "GPKG" in fiona.supported_drivers.keys()
+@pytest.mark.skipif(not has_gpkg, reason="Requires GPKG driver")
+def test_remove_layer(tmpdir):
+    filename = str(tmpdir.join("a_filename.gpkg"))
+    create_sample_data(filename, "GPKG", layer="layer1")
+    create_sample_data(filename, "GPKG", layer="layer2")
+    assert fiona.listlayers(filename) == ["layer1", "layer2"]
+
+    result = CliRunner().invoke(main_group, [
+        "rm",
+        filename,
+        "--layer", "layer2",
+        "--yes"
+    ])
+    print(result.output)
+    assert result.exit_code == 0
+    assert os.path.exists(filename)
+    assert fiona.listlayers(filename) == ["layer1"]

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,16 +1,19 @@
 import logging
 import sys
 import os
+import itertools
+from .conftest import requires_gpkg
 
 import pytest
 
 import fiona
+from fiona.errors import DatasetDeleteError
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
 
-def create_sample_data(filename, driver):
+def create_sample_data(filename, driver, **extra_meta):
     meta = {
         'driver': driver,
         'schema': {
@@ -18,6 +21,7 @@ def create_sample_data(filename, driver):
             'properties': {}
         }
     }
+    meta.update(extra_meta)
     with fiona.open(filename, 'w', **meta) as dst:
         dst.write({
             'geometry': {
@@ -28,48 +32,86 @@ def create_sample_data(filename, driver):
         })
     assert(os.path.exists(filename))
 
-
-def test_remove(tmpdir):
-    outdir = str(tmpdir.mkdir('test_remove'))
-    filename_shp = os.path.join(outdir, 'test.shp')
+drivers = ["ESRI Shapefile", "GeoJSON"]
+kinds = ["path", "collection"]
+specify_drivers = [True, False]
+test_data = itertools.product(drivers, kinds, specify_drivers)
+@pytest.mark.parametrize("driver, kind, specify_driver", test_data)
+def test_remove(tmpdir, kind, driver, specify_driver):
+    """Test various dataset removal operations"""
+    extension = {"ESRI Shapefile": "shp", "GeoJSON": "json"}[driver]
+    filename = "delete_me.{extension}".format(extension=extension)
+    output_filename = str(tmpdir.join(filename))
     
-    create_sample_data(filename_shp, driver='ESRI Shapefile')
-    fiona.remove(filename_shp, driver='ESRI Shapefile')
-    assert(not os.path.exists(filename_shp))
+    create_sample_data(output_filename, driver=driver)
+    if kind == "collection":
+        to_delete = fiona.open(output_filename, "r")
+    else:
+        to_delete = output_filename
     
-    with pytest.raises(RuntimeError):
-        fiona.remove(filename_shp, driver='ESRI Shapefile')
+    assert os.path.exists(output_filename)
+    if specify_driver:
+        fiona.remove(to_delete, driver=driver)
+    else:
+        fiona.remove(to_delete)
+    assert not os.path.exists(output_filename)
 
 
-def test_remove_driver(tmpdir):
-    outdir = str(tmpdir.mkdir('test_remove_driver'))
-    filename_shp = os.path.join(outdir, 'test.shp')
-    filename_json = os.path.join(outdir, 'test.json')
-        
-    create_sample_data(filename_shp, driver='ESRI Shapefile')
-    create_sample_data(filename_json, driver='GeoJSON')
-    fiona.remove(filename_json, driver='GeoJSON')
-    assert(not os.path.exists(filename_json))
-    assert(os.path.exists(filename_shp))
+def test_remove_nonexistent(tmpdir):
+    """Attempting to remove a file that does not exist results in an IOError"""
+    filename = str(tmpdir.join("does_not_exist.shp"))
+    assert not os.path.exists(filename)
+    with pytest.raises(IOError):
+        fiona.remove(filename)
 
-
-def test_remove_collection(tmpdir):
-    outdir = str(tmpdir.mkdir('test_remove_collection'))
-    filename_shp = os.path.join(outdir, 'test.shp')
+@requires_gpkg
+def test_remove_layer(tmpdir):
+    filename = str(tmpdir.join("a_filename.gpkg"))
+    create_sample_data(filename, "GPKG", layer="layer1")
+    create_sample_data(filename, "GPKG", layer="layer2")
+    create_sample_data(filename, "GPKG", layer="layer3")
+    create_sample_data(filename, "GPKG", layer="layer4")
+    assert fiona.listlayers(filename) == ["layer1", "layer2", "layer3", "layer4"]
     
-    create_sample_data(filename_shp, driver='ESRI Shapefile')
-    collection = fiona.open(filename_shp, 'r')
-    fiona.remove(collection)
-    assert(not os.path.exists(filename_shp))
+    # remove by index
+    fiona.remove(filename, layer=2)
+    assert fiona.listlayers(filename) == ["layer1", "layer2", "layer4"]
+    
+    # remove by name
+    fiona.remove(filename, layer="layer2")
+    assert fiona.listlayers(filename) == ["layer1", "layer4"]
+    
+    # remove by negative index
+    fiona.remove(filename, layer=-1)
+    assert fiona.listlayers(filename) == ["layer1"]
+    
+    # invalid layer name
+    with pytest.raises(ValueError):
+        fiona.remove(filename, layer="invalid_layer_name")
+    
+    # invalid layer index
+    with pytest.raises(DatasetDeleteError):
+        fiona.remove(filename, layer=999)
 
 
-def test_remove_path_without_driver(tmpdir):
-    outdir = str(tmpdir.mkdir('test_remove_path_without_driver'))
-    filename_shp = os.path.join(outdir, 'test.shp')
+def test_remove_layer_shapefile(tmpdir):
+    """Removal of layer in shapefile actually deletes the datasource"""
+    filename = str(tmpdir.join("a_filename.shp"))
+    create_sample_data(filename, "ESRI Shapefile")
+    fiona.remove(filename, layer=0)
+    assert not os.path.exists(filename)
 
-    create_sample_data(filename_shp, driver='ESRI Shapefile')
 
-    with pytest.raises(Exception):
-        fiona.remove(filename_shp)
-
-    assert(os.path.exists(filename_shp))
+def test_remove_layer_geojson(tmpdir):
+    """Removal of layers is not supported by GeoJSON driver
+    
+    The reason for failure is slightly different between GDAL 2.2+ and < 2.2.
+    With < 2.2 the datasource will fail to open in write mode (IOError), while
+    with 2.2+ the datasource will open but the removal operation will fail (not
+    supported).
+    """
+    filename = str(tmpdir.join("a_filename.geojson"))
+    create_sample_data(filename, "GeoJSON")
+    with pytest.raises((RuntimeError, IOError)):
+        fiona.remove(filename, layer=0)
+    assert os.path.exists(filename)


### PR DESCRIPTION
This PR adds the `rm` command to `fio`, which can be used to delete a datasource or a specific layer in a multi-layer datasource.

```
$ fio rm countries.shp
$ fio rm --layer forests land_cover.gpkg
```

The `fiona.remove` function has been extended to support a `layer` keyword argument.

Closes #401.