### PR TITLE
Geometry type schema is now more flexible

### DIFF
--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -65,5 +65,5 @@ cdef class OGRGeomBuilder:
     cdef void * build(self, object geom) except NULL
 
 
-cdef unsigned int geometry_type_code(object name)
+cdef unsigned int geometry_type_code(object name) except? 9999
 cdef object normalize_geometry_type_code(unsigned int code)

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -49,7 +49,7 @@ GEOMETRY_TYPES = {
 GEOJSON2OGR_GEOMETRY_TYPES = dict((v, k) for k, v in GEOMETRY_TYPES.iteritems())
 
 
-cdef unsigned int geometry_type_code(name):
+cdef unsigned int geometry_type_code(name) except? 9999:
     """Map OGC geometry type names to integer codes."""
     offset = 0
     if name.endswith('ZM'):

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -11,7 +11,7 @@ from fiona.ogrext import Session, WritingSession
 from fiona.ogrext import (
     calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
 from fiona.ogrext import buffer_to_virtual_file, remove_virtual_file, GEOMETRY_TYPES
-from fiona.errors import DriverError, SchemaError, CRSError
+from fiona.errors import DriverError, SchemaError, CRSError, UnsupportedGeometryTypeError
 from fiona._drivers import driver_count, GDALEnv
 from fiona.drvsupport import supported_drivers, AWSGDALEnv
 from six import string_types, binary_type
@@ -406,7 +406,7 @@ class Collection(object):
     def close(self):
         """In append or write mode, flushes data to disk, then ends
         access."""
-        if self.session is not None:
+        if self.session is not None and self.session.isactive():
             if self.mode in ('a', 'w'):
                 self.flush()
             log.debug("Flushed buffer")
@@ -434,23 +434,29 @@ class Collection(object):
         self.close()
 
 
+ALL_GEOMETRY_TYPES = set([
+    geom_type for geom_type in GEOMETRY_TYPES.values()
+    if "3D " not in geom_type and geom_type != "None"])
+ALL_GEOMETRY_TYPES.add("None")
+
+
 def _get_valid_geom_types(schema, driver):
+    """Returns a set of geometry types the schema will accept"""
     schema_geom_type = schema["geometry"]
     if isinstance(schema_geom_type, string_types) or schema_geom_type is None:
         schema_geom_type = (schema_geom_type,)
     valid_types = set()
     for geom_type in schema_geom_type:
-        valid_types.add(str(geom_type).lstrip("3D "))
+        geom_type = str(geom_type).lstrip("3D ")
+        if geom_type == "Unknown" or geom_type == "Any":
+            valid_types.update(ALL_GEOMETRY_TYPES)
+        else:
+            if geom_type not in ALL_GEOMETRY_TYPES:
+                raise UnsupportedGeometryTypeError(geom_type)
+            valid_types.add(geom_type)
 
-    if "Unknown" in valid_types:
-        ALL_GEOMETRY_TYPES = set([
-            geom_type for geom_type in GEOMETRY_TYPES.values()
-            if "3D " not in geom_type and geom_type != "None"])
-        valid_types.update(ALL_GEOMETRY_TYPES)
-        valid_types.remove("Unknown")
-
+    # shapefiles don't differentiate between single/multi geometries, except points
     if driver == "ESRI Shapefile" and "Point" not in valid_types:
-        print("OMG")
         for geom_type in list(valid_types):
             if not geom_type.startswith("Multi"):
                 valid_types.add("Multi"+geom_type)

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -33,5 +33,9 @@ class UnsupportedGeometryTypeError(KeyError):
     """When a OGR geometry type isn't supported by Fiona."""
 
 
+class GeometryTypeValidationError(FionaValueError):
+    """Tried to write a geometry type not specified in the schema"""
+
+
 class TransactionError(RuntimeError):
     """Failure relating to GDAL transactions"""

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -260,6 +260,8 @@ cdef class FeatureBuilder:
             if cogr_geometry is not NULL:
                 geom = GeomBuilder().build(cogr_geometry)
                 fiona_feature["geometry"] = geom
+            else:
+                fiona_feature["geometry"] = None
 
         return fiona_feature
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -939,6 +939,8 @@ cdef class WritingSession(Session):
                     geometry_type = "Unknown"
                 else:
                     geometry_type = geometry_types.pop()
+            if geometry_type == "Any" or geometry_type is None:
+                geometry_type = "Unknown"
             geometry_code = geometry_type_code(geometry_type)
 
             try:

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -25,7 +25,7 @@ from fiona._geometry import GEOMETRY_TYPES
 from fiona import compat
 from fiona.errors import (
     DriverError, DriverIOError, SchemaError, CRSError, FionaValueError,
-    TransactionError)
+    TransactionError, GeometryTypeValidationError)
 from fiona.compat import OrderedDict
 from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
@@ -932,13 +932,20 @@ cdef class WritingSession(Session):
                 log.debug("Set option %r: %r", k, v)
                 options = CSLAddNameValue(options, <const char *>k, <const char *>v)
 
+            geometry_type = collection.schema.get("geometry", "Unknown")
+            if not isinstance(geometry_type, string_types) and geometry_type is not None:
+                geometry_types = set(geometry_type)
+                if len(geometry_types) > 1:
+                    geometry_type = "Unknown"
+                else:
+                    geometry_type = geometry_types.pop()
+            geometry_code = geometry_type_code(geometry_type)
+
             try:
                 self.cogr_layer = exc_wrap_pointer(
                     GDALDatasetCreateLayer(
                         self.cogr_ds, name_c, cogr_srs,
-                        geometry_type_code(
-                            collection.schema.get('geometry', 'Unknown')),
-                        options))
+                        geometry_code, options))
             except Exception as exc:
                 raise DriverIOError(str(exc))
             finally:
@@ -1028,22 +1035,13 @@ cdef class WritingSession(Session):
 
         schema_geom_type = collection.schema['geometry']
         cogr_driver = GDALGetDatasetDriver(self.cogr_ds)
-        if OGR_Dr_GetName(cogr_driver) == b"GeoJSON":
-            def validate_geometry_type(rec):
+        driver_name = OGR_Dr_GetName(cogr_driver).decode("utf-8")
+
+        valid_geom_types = collection._valid_geom_types
+        def validate_geometry_type(record):
+            if record["geometry"] is None:
                 return True
-        elif OGR_Dr_GetName(cogr_driver) == b"ESRI Shapefile" \
-                and "Point" not in collection.schema['geometry']:
-            schema_geom_type = collection.schema['geometry'].lstrip(
-                "3D ").lstrip("Multi")
-            def validate_geometry_type(rec):
-                return rec['geometry'] is None or \
-                rec['geometry']['type'].lstrip(
-                    "3D ").lstrip("Multi") == schema_geom_type
-        else:
-            schema_geom_type = collection.schema['geometry'].lstrip("3D ")
-            def validate_geometry_type(rec):
-                return rec['geometry'] is None or \
-                       rec['geometry']['type'].lstrip("3D ") == schema_geom_type
+            return record["geometry"]["type"].lstrip("3D ") in valid_geom_types
 
         log.debug("Starting transaction (initial)")
         result = gdal_start_transaction(self.cogr_ds, 0)
@@ -1060,7 +1058,7 @@ cdef class WritingSession(Session):
                         record['properties'].keys(),
                         list(schema_props_keys) ))
             if not validate_geometry_type(record):
-                raise ValueError(
+                raise GeometryTypeValidationError(
                     "Record's geometry type does not match "
                     "collection schema's geometry type: %r != %r" % (
                          record['geometry']['type'],

--- a/tests/test_schema_geom.py
+++ b/tests/test_schema_geom.py
@@ -1,0 +1,137 @@
+"""
+Tests related to the validation of feature geometry types against the schema.
+"""
+
+import fiona
+import pytest
+
+from fiona.errors import GeometryTypeValidationError
+
+@pytest.fixture
+def filename_shp(tmpdir):
+    return str(tmpdir.join("example.shp"))
+
+@pytest.fixture
+def filename_json(tmpdir):
+    return str(tmpdir.join("example.json"))
+
+properties = {"name": "str"}
+PROPERTIES = {"name": "example"}
+POINT = {"type": "Point", "coordinates": (1.0, 2.0)}
+LINESTRING = {"type": "LineString", "coordinates": [(1.0, 2.0), (3.0, 4.0)]}
+POLYGON = {"type": "Polygon", "coordinates": [[(0.0, 0.0), (1.0, 1.0), (0.0, 0.1)]]}
+MULTILINESTRING = {"type": "MultiLineString", "coordinates": [[(0.0, 0.0), (1.0, 1.0)], [(1.0, 2.0), (3.0, 4.0)]]}
+GEOMETRYCOLLECTION = {"type": "GeometryCollection", "geometries": [POINT, LINESTRING, POLYGON]}
+INVALID = {"type": "InvalidType", "coordinates": (42.0, 43.0)}
+POINT_3D = {"type": "Point", "coordinates": (1.0, 2.0, 3.0)}
+
+def write_point(collection):
+    feature = {"geometry": POINT, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_linestring(collection):
+    feature = {"geometry": LINESTRING, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_polygon(collection):
+    feature = {"geometry": POLYGON, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_invalid(collection):
+    feature = {"geometry": INVALID, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_multilinestring(collection):
+    feature = {"geometry": MULTILINESTRING, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_point_3d(collection):
+    feature = {"geometry": POINT_3D, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_geometrycollection(collection):
+    feature = {"geometry": GEOMETRYCOLLECTION, "properties": PROPERTIES}
+    collection.write(feature)
+
+def write_null(collection):
+    feature = {"geometry": None, "properties": PROPERTIES}
+    collection.write(feature)
+
+def test_point(filename_shp):
+    schema = {"geometry": "Point", "properties": properties}
+    with fiona.open(filename_shp, "w", driver="ESRI Shapefile", schema=schema) as collection:
+        write_point(collection)
+        write_point_3d(collection)
+        write_null(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_linestring(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_invalid(collection)
+
+def test_multi_type(filename_json):
+    schema = {"geometry": ("Point", "LineString"), "properties": properties}
+    with fiona.open(filename_json, "w", driver="GeoJSON", schema=schema) as collection:
+        write_point(collection)
+        write_linestring(collection)
+        write_null(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_polygon(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_invalid(collection)
+
+def test_unknown(filename_json):
+    schema = {"geometry": "Unknown", "properties": properties}
+    with fiona.open(filename_json, "w", driver="GeoJSON", schema=schema) as collection:
+        write_point(collection)
+        write_linestring(collection)
+        write_polygon(collection)
+        write_geometrycollection(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_invalid(collection)
+
+def test_invalid_schema(filename_shp):
+    """Features match schema but geometries not supported by driver"""
+    schema = {"geometry": ("Point", "LineString"), "properties": properties}
+    with fiona.open(filename_shp, "w", driver="ESRI Shapefile", schema=schema) as collection:
+        write_linestring(collection)
+
+        with pytest.raises(RuntimeError):
+            # ESRI Shapefile can only store a single geometry type
+            write_point(collection)
+
+def test_esri_multi_geom(filename_shp):
+    """ESRI Shapefile doesn't differentiate between LineString/MultiLineString"""
+    schema = {"geometry": "LineString", "properties": properties}
+    with fiona.open(filename_shp, "w", driver="ESRI Shapefile", schema=schema) as collection:
+        write_linestring(collection)
+        write_multilinestring(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_point(collection)
+
+def test_3d_schema_ignored(filename_json):
+    schema = {"geometry": "3D Point", "properties": properties}
+    with fiona.open(filename_json, "w", driver="GeoJSON", schema=schema) as collection:
+        write_point(collection)
+        write_point_3d(collection)
+
+def test_geometrycollection_schema(filename_json):
+    schema = {"geometry": "GeometryCollection", "properties": properties}
+    with fiona.open(filename_json, "w", driver="GeoJSON", schema=schema) as collection:
+        write_geometrycollection(collection)
+
+def test_none_schema(filename_json):
+    schema = {"geometry": None, "properties": properties}
+    with fiona.open(filename_json, "w", driver="GeoJSON", schema=schema) as collection:
+        write_null(collection)
+
+        with pytest.raises(GeometryTypeValidationError):
+            write_point(collection)
+        with pytest.raises(GeometryTypeValidationError):
+            write_linestring(collection)
+


### PR DESCRIPTION
This PR modifies the validation done when writing geometries to ensure they match the collection schema.

The existing behaviour of specifying a single geometry type is unchanged:

```
fiona.open(..., schema={"geometry": "Point", ...})
```

Alternatively you can specify a list of types:

```
fiona.open(..., schema={"geometry": ("Point", "LineString", "Polygon", ...})
```

Or allow any type:

```
fiona.open(..., schema={"geometry": "Unknown", ...})
```

This works for the edge cases I could think of (e.g. ESRI Shapefile doesn't care between LineString/MultiLineString, Polygon/MultiPolygon), but I may have missed something out.

A new exception is raises if a geometry is written that doesn't match the schema: `GeometryTypeValidationError`.

It's possible to specify a schema that isn't actually valid for the driver. For example, a schema of `("Point", "LineString")` for an ESRI Shapefile. The code doesn't check for this explicitly, but will raise a `RuntimeError` if you actually try to write something invalid.

Closes #446.