### PR TITLE
Fix trunk repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   matrix:
     - GDALVERSION="1.11.5"
     - GDALVERSION="2.0.3"
-    - GDALVERSION="2.1.1"
-    - GDALVERSION="2.2.2"
+    - GDALVERSION="2.1.4"
+    - GDALVERSION="2.2.3"
     - GDALVERSION="trunk"
 
 matrix:

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -55,8 +55,8 @@ ls -l $GDALINST
 
 if [ "$GDALVERSION" = "trunk" ]; then
   # always rebuild trunk
-  git clone https://github.com/OSGeo/gdal.git $GDALBUILD/trunk
-  cd $GDALBUILD/trunk
+  git clone -b trunk --single-branch --depth=1 https://github.com/OSGeo/gdal.git $GDALBUILD/trunk
+  cd $GDALBUILD/trunk/gdal
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -s -j 2
   make install

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -55,7 +55,7 @@ ls -l $GDALINST
 
 if [ "$GDALVERSION" = "trunk" ]; then
   # always rebuild trunk
-  svn checkout https://svn.osgeo.org/gdal/trunk/gdal $GDALBUILD/trunk
+  svn checkout https://svn.osgeo.org/gdal/trunk/gdal gdal $GDALBUILD/trunk
   cd $GDALBUILD/trunk
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -s -j 2

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -55,7 +55,7 @@ ls -l $GDALINST
 
 if [ "$GDALVERSION" = "trunk" ]; then
   # always rebuild trunk
-  svn checkout https://svn.osgeo.org/gdal/trunk/gdal gdal $GDALBUILD/trunk
+  git clone https://github.com/OSGeo/gdal.git $GDALBUILD/trunk
   cd $GDALBUILD/trunk
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -s -j 2


### PR DESCRIPTION
SVN checkout of gdal trunk on travis fails with:

> Authentication realm: <https://svn.osgeo.org:443> OSGeo Login
Password for 'travis': 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated

This is possibly related to https://trac.osgeo.org/osgeo/ticket/2128

Fix: Change to gdal's github mirror.

Additionally, bump gdal to 2.1.4 and 2.2.3