### PR TITLE
Added set_field_null for GDAL 2.2+

### DIFF
--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -8,6 +8,7 @@ ctypedef enum OGRFieldSubType:
     OFSTMaxSubType = 3
 
 cdef bint is_field_null(void *feature, int n)
+cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers, options)
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *

--- a/fiona/_shim1.pyx
+++ b/fiona/_shim1.pyx
@@ -18,6 +18,10 @@ cdef bint is_field_null(void *feature, int n):
         return False
 
 
+cdef void set_field_null(void *feature, int n):
+    pass
+
+
 cdef void gdal_flush_cache(void *cogr_ds):
     retval = OGR_DS_SyncToDisk(cogr_ds)
     if retval != OGRERR_NONE:

--- a/fiona/_shim2.pxd
+++ b/fiona/_shim2.pxd
@@ -1,6 +1,7 @@
 include "ogrext2.pxd"
 
 cdef bint is_field_null(void *feature, int n)
+cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers, options)
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *

--- a/fiona/_shim2.pyx
+++ b/fiona/_shim2.pyx
@@ -14,6 +14,10 @@ cdef bint is_field_null(void *feature, int n):
         return False
 
 
+cdef void set_field_null(void *feature, int n):
+    pass
+
+
 cdef void gdal_flush_cache(void *cogr_ds):
     with cpl_errs:
         GDALFlushCache(cogr_ds)

--- a/fiona/_shim22.pxd
+++ b/fiona/_shim22.pxd
@@ -1,6 +1,7 @@
 include "ogrext2.pxd"
 
 cdef bint is_field_null(void *feature, int n)
+cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(char* path_c, int mode, drivers, options)
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except *

--- a/fiona/_shim22.pyx
+++ b/fiona/_shim22.pyx
@@ -19,6 +19,10 @@ cdef bint is_field_null(void *feature, int n):
         return False
 
 
+cdef void set_field_null(void *feature, int n):
+    OGR_F_SetFieldNull(feature, n)
+
+
 cdef void gdal_flush_cache(void *cogr_ds):
     with cpl_errs:
         GDALFlushCache(cogr_ds)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -360,7 +360,7 @@ cdef class OGRFeatureBuilder:
                 OGR_F_SetFieldBinary(cogr_feature, i, len(value),
                     <unsigned char*>string_c)
             elif value is None:
-                pass # keep field unset/null
+                set_field_null(cogr_feature, i)
             else:
                 raise ValueError("Invalid field type %s" % type(value))
             log.debug("Set field %s: %s" % (key, value))

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -165,6 +165,7 @@ cdef extern from "ogr_api.h":
     void    OGR_F_SetFieldInteger (void *feature, int n, int value)
     void    OGR_F_SetFieldString (void *feature, int n, char *value)
     void    OGR_F_SetFieldBinary (void *feature, int n, int l, unsigned char *value)
+    void    OGR_F_SetFieldNull (void *feature, int n)  # new in GDAL 2.2
     int     OGR_F_SetGeometryDirectly (void *feature, void *geometry)
     void *  OGR_FD_Create (char *name)
     int     OGR_FD_GetFieldCount (void *featuredefn)


### PR DESCRIPTION
This PR uses `OGR_F_SetFieldNull` which was introduced in GDAL 2.2. Without it the `test_feature_null_field` test fails for the GeoJSON driver.