### PR TITLE
Some fixes for Python 2.7, and a fix for the binary field test

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -346,6 +346,10 @@ cdef class OGRFeatureBuilder:
                 hh, mm, ss = value.hour, value.minute, value.second
                 OGR_F_SetFieldDateTime(
                     cogr_feature, i, 0, 0, 0, hh, mm, ss, 0)
+            elif isinstance(value, bytes) and schema_type == "bytes":
+                string_c = value
+                OGR_F_SetFieldBinary(cogr_feature, i, len(value),
+                    <unsigned char*>string_c)
             elif isinstance(value, string_types):
                 try:
                     value_bytes = value.encode(encoding)
@@ -355,10 +359,6 @@ cdef class OGRFeatureBuilder:
                     value_bytes = value
                 string_c = value_bytes
                 OGR_F_SetFieldString(cogr_feature, i, string_c)
-            elif isinstance(value, bytes):
-                string_c = value
-                OGR_F_SetFieldBinary(cogr_feature, i, len(value),
-                    <unsigned char*>string_c)
             elif value is None:
                 pass # keep field unset/null
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def _read_file(name):
         return f.read()
 
 
+has_gpkg = "GPKG" in fiona.supported_drivers.keys()
+has_gpkg_reason = "Requires geopackage driver"
+requires_gpkg = pytest.mark.skipif(not has_gpkg, reason=has_gpkg_reason)
+
+
 @pytest.fixture(scope='session')
 def data_dir():
     """Absolute file path to the directory containing test datasets."""
@@ -107,7 +112,6 @@ def bytes_grenada_geojson():
 def path_coutwildrnp_gpkg():
     """Creates ``coutwildrnp.gpkg`` if it does not exist and returns the absolute
     file path."""
-    has_gpkg = "GPKG" in fiona.supported_drivers.keys()
     if not has_gpkg:
         raise RuntimeError("GDAL has not been compiled with GPKG support")
     path = os.path.join(data_dir(), 'coutwildrnp.gpkg')

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -7,8 +7,7 @@ import binascii
 import tempfile
 import shutil
 from collections import OrderedDict
-
-has_gpkg = os.path.exists('tests/data/coutwildrnp.gpkg')
+from .conftest import requires_gpkg
 
 class TestBinaryField(unittest.TestCase):
     def setUp(self):
@@ -17,7 +16,7 @@ class TestBinaryField(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
     
-    @pytest.mark.skipif(not has_gpkg, reason="Requires geopackage fixture")
+    @requires_gpkg
     def test_binary_field(self):
         meta = {
             "driver": "GPKG",

--- a/tests/test_geopackage.py
+++ b/tests/test_geopackage.py
@@ -1,10 +1,9 @@
 import os
 import pytest
 import fiona
+from .conftest import requires_gpkg
 
-has_gpkg = "GPKG" in fiona.supported_drivers.keys()
-
-@pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
+@requires_gpkg
 def test_read_gpkg(path_coutwildrnp_gpkg):
     """
     Implicitly tests writing gpkg as the fixture will create the data source on
@@ -16,7 +15,7 @@ def test_read_gpkg(path_coutwildrnp_gpkg):
         assert feature["geometry"]["type"] == "Polygon"
         assert feature["properties"]["NAME"] == "Mount Naomi Wilderness"
 
-@pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
+@requires_gpkg
 def test_write_gpkg(tmpdir):
     schema = {
         'geometry': 'Point',

--- a/tests/test_subtypes.py
+++ b/tests/test_subtypes.py
@@ -1,4 +1,5 @@
 import fiona
+import six
 
 GDAL_MAJOR_VER = fiona.get_gdal_version_num() // 1000000
 
@@ -15,7 +16,7 @@ def test_read_bool_subtype(tmpdir):
         assert type(feature["properties"]["bool"]) is bool
     else:
         assert type(feature["properties"]["bool"]) is int
-    assert type(feature["properties"]["not_bool"]) is int
+    assert isinstance(feature["properties"]["not_bool"], six.integer_types)
     assert type(feature["properties"]["float"]) is float
 
 def test_write_bool_subtype(tmpdir):

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -18,7 +18,7 @@ class UnicodePathTest(unittest.TestCase):
 
     def setUp(self):
         tempdir = tempfile.mkdtemp()
-        self.dir = os.path.join(tempdir, 'français')
+        self.dir = os.path.join(tempdir, u'français')
         shutil.copytree('tests/data/', self.dir)
 
     def tearDown(self):
@@ -26,17 +26,12 @@ class UnicodePathTest(unittest.TestCase):
 
     def test_unicode_path(self):
         path = self.dir + '/coutwildrnp.shp'
-        if sys.version_info < (3,):
-            path = path.decode('utf-8')
         with fiona.open(path) as c:
             assert len(c) == 67
 
     def test_unicode_path_layer(self):
         path = self.dir
         layer = 'coutwildrnp'
-        if sys.version_info < (3,):
-            path = path.decode('utf-8')
-            layer = layer.decode('utf-8')
         with fiona.open(path, layer=layer) as c:
             assert len(c) == 67
 


### PR DESCRIPTION
Another batch of commits extracted from #532.

https://github.com/Toblerity/Fiona/commit/6ebf990d7de43636a98796debb7aa932693ef546 fixes an issue whereby the binary field test ways always skipped when running on CI.