### PR TITLE
Expand range of Python and GDAL versions in Appveyor matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,4 +121,4 @@ test_script:
 
 matrix:
   allow_failures:
-    GDAL_VERSION : trunk
+    - GDAL_VERSION : trunk

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
         - PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.4"
           PYTHON_ARCH: "64"
-          GDAL_VERSION: "trunk"
+          GDAL_VERSION: "2.3.0"
           GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
           GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,12 @@ environment:
         GDAL_HOME: "C:\\gdal"
 
     matrix:
-        # - PYTHON: "C:\\Python27.10-x64"
-        #  PYTHON_VERSION: "2.7.10"
-        #  PYTHON_ARCH: "64"
+        - PYTHON: "C:\\Python27-x64"
+          PYTHON_VERSION: "2.7.14"
+          PYTHON_ARCH: "64"
+          GDAL_VERSION: "1.11.4"
+          GIS_INTERNALS: "release-1600-x64-gdal-1-11-4-mapserver-6-4-3.zip"
+          GIS_INTERNALS_LIBS: "release-1600-x64-gdal-1-11-4-mapserver-6-4-3-libs.zip"
 
         - PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,13 @@ environment:
           GIS_INTERNALS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7.zip"
           GIS_INTERNALS_LIBS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7-libs.zip"
 
+        - PYTHON: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.6.4"
+          PYTHON_ARCH: "64"
+          GDAL_VERSION: "trunk"
+          GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
+          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
+
 install:
 
   - ECHO "Filesystem root:"
@@ -111,3 +118,7 @@ test_script:
 
   # TODO: return to running test_write_gb18030 when GDAL build is updated.
   - "%CMD_IN_ENV% pytest -k \"not test_write_gb18030\" --cov fiona --cov-report term-missing"
+
+matrix:
+  allow_failures:
+    GDAL_VERSION : trunk

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,13 @@ environment:
           GIS_INTERNALS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7.zip"
           GIS_INTERNALS_LIBS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7-libs.zip"
 
+        - PYTHON: "C:\\Python27-x64"
+          PYTHON_VERSION: "2.7.14"
+          PYTHON_ARCH: "64"
+          GDAL_VERSION: "2.3.0"
+          GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
+          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
+
         - PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.4"
           PYTHON_ARCH: "64"
@@ -121,4 +128,4 @@ test_script:
 
 matrix:
   allow_failures:
-    - GDAL_VERSION : trunk
+    - GDAL_VERSION: 2.3.0


### PR DESCRIPTION
- Pythons: 2.7 and 3.6
- GDAL: 1.11.4, 2.2.3, and trunk (from GIS internals)

I'm still not using conda-forge for GDAL because of the value in testing against the GDAL trunk.