### PR TITLE
Fixed some warnings in tests

### DIFF
--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -48,7 +48,7 @@ class TestBinaryField(unittest.TestCase):
         
         # read the data back and check consistency
         with fiona.open(filename, "r") as src:
-            feature = next(src)
+            feature = next(iter(src))
             assert(feature["properties"]["name"] == "test")
             data = feature["properties"]["data"]
             assert(binascii.b2a_hex(data) == b"deadbeef")

--- a/tests/test_fio_calc.py
+++ b/tests/test_fio_calc.py
@@ -30,9 +30,7 @@ def _load(output):
     return features
 
 
-def test_calc_seq(feature_seq):
-    runner = CliRunner()
-
+def test_calc_seq(feature_seq, runner):
     result = runner.invoke(calc, [
         "TEST",
         "f.properties.AREA / f.properties.PERIMETER"],

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -11,12 +11,13 @@ from fiona.io import MemoryFile, ZipMemoryFile
 @pytest.fixture(scope='session')
 def profile_first_coutwildrnp_shp(path_coutwildrnp_shp):
     with fiona.open(path_coutwildrnp_shp) as col:
-        return col.profile, next(col)
+        return col.profile, next(iter(col))
 
 
 def test_memoryfile(path_coutwildrnp_json):
     """In-memory GeoJSON file can be read"""
-    data = open(path_coutwildrnp_json, 'rb').read()
+    with open(path_coutwildrnp_json, 'rb') as f:
+        data = f.read()
     with MemoryFile(data) as memfile:
         with memfile.open() as collection:
             assert len(collection) == 67
@@ -46,7 +47,8 @@ def test_write_memoryfile(profile_first_coutwildrnp_shp):
 
 def test_memoryfile_bytesio(path_coutwildrnp_json):
     """In-memory GeoJSON file can be read"""
-    data = open(path_coutwildrnp_json, 'rb').read()
+    with open(path_coutwildrnp_json, 'rb') as f:
+        data = f.read()
 
     with fiona.open(BytesIO(data)) as collection:
         assert len(collection) == 67


### PR DESCRIPTION
This fixes a few warnings raised in the tests.

There is still one left from fio.calc that I can't figure out.
```
tests/test_fio_calc.py ....                                                                                               [100%]

======================================================= warnings summary ========================================================
tests/test_fio_calc.py::test_calc_seq
  /Users/snorf/miniconda3/envs/python36/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
    return f(*args, **kwds)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```