### PR TITLE
Test support for date/datetime/time fields

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -11,7 +11,7 @@ from fiona.ogrext import Session, WritingSession
 from fiona.ogrext import (
     calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
 from fiona.ogrext import buffer_to_virtual_file, remove_virtual_file, GEOMETRY_TYPES
-from fiona.errors import DriverError, SchemaError, CRSError, UnsupportedGeometryTypeError
+from fiona.errors import (DriverError, SchemaError, CRSError, UnsupportedGeometryTypeError, DriverSupportError)
 from fiona._drivers import driver_count, GDALEnv
 from fiona.drvsupport import supported_drivers, AWSGDALEnv
 from six import string_types, binary_type
@@ -132,6 +132,8 @@ class Collection(object):
             elif 'geometry' not in schema:
                 raise SchemaError("schema lacks: geometry")
             self._schema = schema
+
+            self._check_schema_driver_support()
 
             if crs_wkt:
                 self._crs_wkt = crs_wkt
@@ -394,6 +396,31 @@ class Collection(object):
         if self._bounds is None and self.session is not None:
             self._bounds = self.session.get_extent()
         return self._bounds
+
+    def _check_schema_driver_support(self):
+        """Check support for the schema against the driver
+
+        See GH#572 for discussion.
+        """
+        gdal_version_major = get_gdal_version_num() // 1000000
+        for field in self._schema["properties"]:
+            field_type = field.split(":")[0]
+            if self._driver == "ESRI Shapefile":
+                if field_type == "datetime":
+                    raise DriverSupportError("ESRI Shapefile does not support datetime fields")
+                elif field_type == "time":
+                    raise DriverSupportError("ESRI Shapefile does not support time fields")
+            elif self._driver == "GPKG":
+                if field_type == "time":
+                    raise DriverSupportError("GPKG does not support time fields")
+            elif self._driver == "GeoJSON":
+                if gdal_version_major == 1:
+                    if field_type == "date":
+                        warnings.warn("GeoJSON driver in GDAL 1.x silently converts date to string in non-standard format")
+                    elif field_type == "datetime":
+                        warnings.warn("GeoJSON driver in GDAL 1.x silently converts datetime to string in non-standard format")
+                    elif field_type == "time":
+                        warnings.warn("GeoJSON driver in GDAL 1.x silently converts time to string")
 
     def flush(self):
         """Flush the buffer."""

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -413,6 +413,9 @@ class Collection(object):
             elif self._driver == "GPKG":
                 if field_type == "time":
                     raise DriverSupportError("GPKG does not support time fields")
+                elif gdal_version_major == 1:
+                    if field_type == "datetime":
+                        raise DriverSupportError("GDAL 1.x GPKG driver does not support datetime fields")
             elif self._driver == "GeoJSON":
                 if gdal_version_major == 1:
                     if field_type == "date":

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -25,6 +25,10 @@ class DriverIOError(IOError):
     """A format specific driver error."""
 
 
+class DriverSupportError(DriverIOError):
+    """Driver does not support schema"""
+
+
 class DatasetDeleteError(IOError):
     """Failure to delete a dataset"""
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -152,15 +152,15 @@ class TestDatetimeFieldSupport:
     def test_gpkg(self):
         # GDAL 1: datetime silently downgraded to date
         driver = "GPKG"
-        schema, features = self.write_data(driver)
         
         if GDAL_MAJOR_VER >= 2:
+            schema, features = self.write_data(driver)
             assert schema["properties"]["datetime"] == "datetime"
             assert features[0]["properties"]["datetime"] == DATETIME_EXAMPLE
+            assert features[1]["properties"]["datetime"] is None
         else:
-            assert schema["properties"]["datetime"] == "date"
-            assert features[0]["properties"]["datetime"] == DATE_EXAMPLE
-        assert features[1]["properties"]["datetime"] is None
+            with pytest.raises(DriverSupportError):
+                schema, features = self.write_data(driver)
 
     def test_geojson(self):
         # GDAL 1: datetime silently converted to string

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,264 @@
+"""
+See also test_rfc3339.py for datetime parser tests.
+"""
+
+import fiona
+import pytest
+import tempfile, shutil
+import os
+from .conftest import requires_gpkg
+
+GDAL_MAJOR_VER = fiona.get_gdal_version_num() // 1000000
+
+GEOMETRY_TYPE = "Point"
+GEOMETRY_EXAMPLE = {"type": "Point", "coordinates": [1, 2]}
+
+DRIVER_FILENAME = {
+    "ESRI Shapefile": "test.shp",
+    "GPKG": "test.gpkg",
+    "GeoJSON": "test.geojson",
+    "MapInfo File": "test.tab",
+}
+
+DATE_EXAMPLE = "2018-03-25"
+DATETIME_EXAMPLE = "2018-03-25T22:49:05"
+TIME_EXAMPLE = "22:49:05"
+
+class TestDateFieldSupport:
+    def write_data(self, driver):
+        filename = DRIVER_FILENAME[driver]
+        temp_dir = tempfile.mkdtemp()
+        path = os.path.join(temp_dir, filename)
+        schema = {
+            "geometry": GEOMETRY_TYPE,
+            "properties": {
+                "date": "date",
+            }
+        }
+        records = [
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "date": DATE_EXAMPLE,
+                }
+            },
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "date": None,
+                }
+            },
+        ]
+        with fiona.open(path, "w", driver=driver, schema=schema) as collection:
+            collection.writerecords(records)
+            
+        with fiona.open(path, "r") as collection:
+            schema = collection.schema
+            features = list(collection)
+
+        shutil.rmtree(temp_dir)
+
+        return schema, features
+
+    def test_shapefile(self):
+        driver = "ESRI Shapefile"
+        schema, features = self.write_data(driver)
+        
+        assert schema["properties"]["date"] == "date"
+        assert features[0]["properties"]["date"] == DATE_EXAMPLE
+        assert features[1]["properties"]["date"] is None
+
+    @requires_gpkg
+    def test_gpkg(self):
+        driver = "GPKG"
+        schema, features = self.write_data(driver)
+        
+        assert schema["properties"]["date"] == "date"
+        assert features[0]["properties"]["date"] == DATE_EXAMPLE
+        assert features[1]["properties"]["date"] is None
+
+    def test_geojson(self):
+        # GDAL 1: date field silently converted to string
+        # GDAL 1: date string format uses / instead of -
+        driver = "GeoJSON"
+        schema, features = self.write_data(driver)
+        
+        if GDAL_MAJOR_VER >= 2:
+            assert schema["properties"]["date"] == "date"
+            assert features[0]["properties"]["date"] == DATE_EXAMPLE
+        else:
+            assert schema["properties"]["date"] == "str"
+            assert features[0]["properties"]["date"] == "2018/03/25"
+        assert features[1]["properties"]["date"] is None
+
+    def test_mapinfo(self):
+        driver = "MapInfo File"
+        schema, features = self.write_data(driver)
+        
+        assert schema["properties"]["date"] == "date"
+        assert features[0]["properties"]["date"] == DATE_EXAMPLE
+        assert features[1]["properties"]["date"] is None
+
+
+class TestDatetimeFieldSupport:
+    def write_data(self, driver):
+        filename = DRIVER_FILENAME[driver]
+        temp_dir = tempfile.mkdtemp()
+        path = os.path.join(temp_dir, filename)
+        schema = {
+            "geometry": GEOMETRY_TYPE,
+            "properties": {
+                "datetime": "datetime",
+            }
+        }
+        records = [
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "datetime": DATETIME_EXAMPLE,
+                }
+            },
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "datetime": None,
+                }
+            },
+        ]
+        with fiona.open(path, "w", driver=driver, schema=schema) as collection:
+            collection.writerecords(records)
+            
+        with fiona.open(path, "r") as collection:
+            schema = collection.schema
+            features = list(collection)
+
+        shutil.rmtree(temp_dir)
+
+        return schema, features
+
+    def test_shapefile(self):
+        # datetime is silently converted to date
+        driver = "ESRI Shapefile"
+        schema, features = self.write_data(driver)
+        
+        assert schema["properties"]["datetime"] == "date"
+        assert features[0]["properties"]["datetime"] == "2018-03-25"
+        assert features[1]["properties"]["datetime"] is None
+
+    @requires_gpkg
+    def test_gpkg(self):
+        # GDAL 1: datetime silently downgraded to date
+        driver = "GPKG"
+        schema, features = self.write_data(driver)
+        
+        if GDAL_MAJOR_VER >= 2:
+            assert schema["properties"]["datetime"] == "datetime"
+            assert features[0]["properties"]["datetime"] == DATETIME_EXAMPLE
+        else:
+            assert schema["properties"]["datetime"] == "date"
+            assert features[0]["properties"]["datetime"] == DATE_EXAMPLE
+        assert features[1]["properties"]["datetime"] is None
+
+    def test_geojson(self):
+        # GDAL 1: datetime silently converted to string
+        # GDAL 1: date string format uses / instead of -
+        driver = "GeoJSON"
+        schema, features = self.write_data(driver)
+        
+        if GDAL_MAJOR_VER >= 2:
+            assert schema["properties"]["datetime"] == "datetime"
+            assert features[0]["properties"]["datetime"] == DATETIME_EXAMPLE
+        else:
+            assert schema["properties"]["datetime"] == "str"
+            assert features[0]["properties"]["datetime"] == "2018/03/25 22:49:05"
+        assert features[1]["properties"]["datetime"] is None
+
+    def test_mapinfo(self):
+        driver = "MapInfo File"
+        schema, features = self.write_data(driver)
+        
+        assert schema["properties"]["datetime"] == "datetime"
+        assert features[0]["properties"]["datetime"] == DATETIME_EXAMPLE
+        assert features[1]["properties"]["datetime"] is None
+
+
+class TestTimeFieldSupport:
+    def write_data(self, driver):
+        filename = DRIVER_FILENAME[driver]
+        temp_dir = tempfile.mkdtemp()
+        path = os.path.join(temp_dir, filename)
+        schema = {
+            "geometry": GEOMETRY_TYPE,
+            "properties": {
+                "time": "time",
+            }
+        }
+        records = [
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "time": TIME_EXAMPLE,
+                }
+            },
+            {
+                "geometry": GEOMETRY_EXAMPLE,
+                "properties": {
+                    "time": None,
+                }
+            },
+        ]
+        with fiona.open(path, "w", driver=driver, schema=schema) as collection:
+            collection.writerecords(records)
+            
+        with fiona.open(path, "r") as collection:
+            schema = collection.schema
+            features = list(collection)
+
+        shutil.rmtree(temp_dir)
+
+        return schema, features
+
+    def test_shapefile(self):
+        # attempting to write time field to shapefile raises KeyError
+        # this is a bug in fiona
+        driver = "ESRI Shapefile"
+        with pytest.raises(KeyError):
+            self.write_data(driver)
+
+    @requires_gpkg
+    def test_gpkg(self):
+        # GDAL 2: time field is silently converted to string
+        # GDAL 1: time field dropped completely
+        driver = "GPKG"
+        schema, features = self.write_data(driver)
+    
+        if GDAL_MAJOR_VER >= 2:
+            assert schema["properties"]["time"] == "str"
+            assert features[0]["properties"]["time"] == TIME_EXAMPLE
+            assert features[1]["properties"]["time"] is None
+        else:
+            assert "time" not in schema["properties"]
+
+    def test_geojson(self):
+        # GDAL 1: time field silently converted to string
+        driver = "GeoJSON"
+        schema, features = self.write_data(driver)
+    
+        if GDAL_MAJOR_VER >= 2:
+            assert schema["properties"]["time"] == "time"
+        else:
+            assert schema["properties"]["time"] == "str"
+        assert features[0]["properties"]["time"] == TIME_EXAMPLE
+        assert features[1]["properties"]["time"] is None
+
+    def test_mapinfo(self):
+        # GDAL 2: null time is converted to 00:00:00 (regression?)
+        driver = "MapInfo File"
+        schema, features = self.write_data(driver)
+    
+        assert schema["properties"]["time"] == "time"
+        assert features[0]["properties"]["time"] == TIME_EXAMPLE
+        if GDAL_MAJOR_VER >= 2:
+            assert features[1]["properties"]["time"] == "00:00:00"
+        else:
+            assert features[1]["properties"]["time"] is None


### PR DESCRIPTION
#540 got me looking at the support for date/datetime/time fields. It's a little complicated, with different drivers having different levels of support and behaviours. I've added some tests to illustrate the current behaviour. I don't think anything needs to change, except that we should raise a more useful error when trying to create a time-type field in an ESRI Shapefile, which currently raises an unexpected KeyError.