### PR TITLE
Make way for int64, the best integer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,7 +139,7 @@ test_script:
   # TODO: return to running test_write_gb18030 when GDAL build is updated.
   # GenericWriting test is skipped on Appveyor because our Windows GDAL doesn't
   # have iconv support and can't encode field names.
-  - "%CMD_IN_ENV% python -m pytest -k \"not test_write_gb18030\ and not GenericWritingTest" --cov fiona --cov-report term-missing"
+  - "%CMD_IN_ENV% python -m pytest -k \"not test_write_gb18030 and not GenericWritingTest\" --cov fiona --cov-report term-missing"
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -137,7 +137,9 @@ test_script:
   - ps: python -c "import fiona"
 
   # TODO: return to running test_write_gb18030 when GDAL build is updated.
-  - "%CMD_IN_ENV% python -m pytest -k \"not test_write_gb18030\" --cov fiona --cov-report term-missing"
+  # GenericWriting test is skipped on Appveyor because our Windows GDAL doesn't
+  # have iconv support and can't encode field names.
+  - "%CMD_IN_ENV% python -m pytest -k \"not test_write_gb18030\ and not GenericWritingTest" --cov fiona --cov-report term-missing"
 
 matrix:
   allow_failures:

--- a/fiona/_err.pxd
+++ b/fiona/_err.pxd
@@ -5,5 +5,6 @@ cdef extern from "cpl_vsi.h":
     ctypedef FILE VSILFILE
 
 
+cdef int exc_wrap_int(int retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL
 cdef VSILFILE *exc_wrap_vsilfile(VSILFILE *f) except NULL

--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -226,6 +226,18 @@ cdef inline object exc_check():
         return
 
 
+cdef int exc_wrap_int(int err) except -1:
+    """Wrap a GDAL/OGR function that returns CPLErr or OGRErr (int)
+
+    Raises a Rasterio exception if a non-fatal error has be set.
+    """
+    if err:
+        exc = exc_check()
+        if exc:
+            raise exc
+    return err
+
+
 cdef void *exc_wrap_pointer(void *ptr) except NULL:
     """Wrap a GDAL/OGR function that returns GDALDatasetH etc (void *)
     Raises a Rasterio exception if a non-fatal error has be set.

--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -136,10 +136,19 @@ class CPLE_AWSInvalidCredentialsError(CPLE_BaseError):
 class CPLE_AWSSignatureDoesNotMatchError(CPLE_BaseError):
     pass
 
+
 class FionaNullPointerError(CPLE_BaseError):
     """
     Returned from exc_wrap_pointer when a NULL pointer is passed, but no GDAL
     error was raised.
+    """
+    pass
+
+
+class FionaCPLError(CPLE_BaseError):
+    """
+    Returned from exc_wrap_int when a error code is returned, but no GDAL
+    error was set.
     """
     pass
 
@@ -235,6 +244,8 @@ cdef int exc_wrap_int(int err) except -1:
         exc = exc_check()
         if exc:
             raise exc
+        else:
+            raise FionaCPLError(-1, -1, "The wrapped function returned an error code, but no error message was set.")
     return err
 
 

--- a/fiona/fio/load.py
+++ b/fiona/fio/load.py
@@ -2,8 +2,6 @@
 
 
 from functools import partial
-import itertools
-import json
 import logging
 
 import click
@@ -11,10 +9,8 @@ import cligj
 
 import fiona
 from fiona.fio import options
+from fiona.schema import FIELD_TYPES_MAP_REV
 from fiona.transform import transform_geom
-
-
-FIELD_TYPES_MAP_REV = dict([(v, k) for k, v in fiona.FIELD_TYPES_MAP.items()])
 
 
 @click.command(short_help="Load GeoJSON to a dataset in another format.")

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -29,6 +29,7 @@ from fiona.errors import (
 from fiona.compat import OrderedDict
 from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
+from fiona.schema import FIELD_TYPES, FIELD_TYPES_MAP, normalize_field_type
 
 from fiona._shim cimport is_field_null
 
@@ -37,40 +38,7 @@ from libc.string cimport strcmp
 from cpython cimport PyBytes_FromStringAndSize, PyBytes_AsString
 
 
-log = logging.getLogger("Fiona")
-
-# Mapping of OGR integer field types to Fiona field type names.
-#
-# Lists are currently unsupported in this version, but might be done as
-# arrays in a future version.
-
-FIELD_TYPES = [
-    'int',          # OFTInteger, Simple 32bit integer
-    None,           # OFTIntegerList, List of 32bit integers
-    'float',        # OFTReal, Double Precision floating point
-    None,           # OFTRealList, List of doubles
-    'str',          # OFTString, String of ASCII chars
-    None,           # OFTStringList, Array of strings
-    None,           # OFTWideString, deprecated
-    None,           # OFTWideStringList, deprecated
-    'bytes',        # OFTBinary, Raw Binary data
-    'date',         # OFTDate, Date
-    'time',         # OFTTime, Time
-    'datetime',     # OFTDateTime, Date and Time
-    'int',          # OFTInteger64, Single 64bit integer
-    None,           # OFTInteger64List, List of 64bit integers
-    ]
-
-# Mapping of Fiona field type names to Python types.
-FIELD_TYPES_MAP = {
-    'int':      int,
-    'float':    float,
-    'str':      text_type,
-    'date':     FionaDateType,
-    'time':     FionaTimeType,
-    'datetime': FionaDateTimeType,
-    'bytes':    bytes,
-   }
+log = logging.getLogger(__name__)
 
 DEFAULT_TRANSACTION_SIZE = 20000
 
@@ -154,8 +122,29 @@ cdef class FeatureBuilder:
 
     cdef build(self, void *feature, encoding='utf-8', bbox=False, driver=None,
                ignore_fields=None, ignore_geometry=False):
-        # The only method anyone ever needs to call
-        cdef void *fdefn
+        """Build a Fiona feature object from an OGR feature
+
+        Parameters
+        ----------
+        feature : void *
+            The OGR feature # TODO: use a real typedef
+        encoding : str
+            The encoding of OGR feature attributes
+        bbox : bool
+            Not used
+        driver : str
+            OGR format driver name like 'GeoJSON'
+        ignore_fields : sequence
+            A sequence of field names that will be ignored and omitted
+            in the Fiona feature properties
+        ignore_geometry : bool
+            Flag for whether the OGR geometry field is to be ignored
+
+        Returns
+        -------
+        dict
+        """
+        cdef void *fdefn = NULL
         cdef int i
         cdef int y = 0
         cdef int m = 0
@@ -164,11 +153,13 @@ cdef class FeatureBuilder:
         cdef int mm = 0
         cdef int ss = 0
         cdef int tz = 0
-        cdef unsigned char *data
+        cdef unsigned char *data = NULL
         cdef int l
         cdef int retval
         cdef int fieldsubtype
         cdef const char *key_c = NULL
+
+        # Skeleton of the feature to be returned.
         fid = OGR_F_GetFID(feature)
         props = OrderedDict()
         fiona_feature = {
@@ -176,8 +167,10 @@ cdef class FeatureBuilder:
             "id": str(fid),
             "properties": props,
         }
-        if not ignore_fields:
-            ignore_fields = set()
+
+        ignore_fields = set(ignore_fields or [])
+
+        # Iterate over the fields of the OGR feature.
         for i in range(OGR_F_GetFieldCount(feature)):
             fdefn = OGR_F_GetFieldDefnRef(feature, i)
             if fdefn == NULL:
@@ -202,13 +195,22 @@ cdef class FeatureBuilder:
 
             # TODO: other types
             fieldtype = FIELD_TYPES_MAP[fieldtypename]
+
             if is_field_null(feature, i):
                 props[key] = None
+
+            elif fieldtypename is 'int32':
+                if fieldsubtype == OFSTBoolean:
+                    props[key] = bool(OGR_F_GetFieldAsInteger(feature, i))
+                else:
+                    props[key] = OGR_F_GetFieldAsInteger(feature, i)
+
             elif fieldtype is int:
                 if fieldsubtype == OFSTBoolean:
                     props[key] = bool(OGR_F_GetFieldAsInteger64(feature, i))
                 else:
                     props[key] = OGR_F_GetFieldAsInteger64(feature, i)
+
             elif fieldtype is float:
                 props[key] = OGR_F_GetFieldAsDouble(feature, i)
 
@@ -302,6 +304,7 @@ cdef class OGRFeatureBuilder:
             log.debug(
                 "Looking up %s in %s", key, repr(session._schema_mapping))
             ogr_key = session._schema_mapping[key]
+            # schema_type = normalize_field_type(collection.schema['properties'][key])
             schema_type = collection.schema['properties'][key]
             try:
                 key_bytes = ogr_key.encode(encoding)
@@ -319,7 +322,10 @@ cdef class OGRFeatureBuilder:
 
             # Continue over the standard OGR types.
             if isinstance(value, integer_types):
-                OGR_F_SetFieldInteger64(cogr_feature, i, value)
+                if schema_type == 'int32':
+                    OGR_F_SetFieldInteger(cogr_feature, i, value)
+                else:
+                    OGR_F_SetFieldInteger64(cogr_feature, i, value)
             elif isinstance(value, float):
                 OGR_F_SetFieldDouble(cogr_feature, i, value)
             elif (isinstance(value, string_types)
@@ -559,16 +565,16 @@ cdef class Session:
                 if precision: # and precision != 15:
                     fmt += ".%d" % precision
                 val = "float" + fmt
-            elif fieldtypename == 'int':
+            elif fieldtypename in ('int32', 'int64'):
                 fmt = ""
                 width = OGR_Fld_GetWidth(cogr_fielddefn)
-                if width: # and width != 11:
+                if width:
                     fmt = ":%d" % width
-                val = fieldtypename + fmt
+                val = 'int' + fmt
             elif fieldtypename == 'str':
                 fmt = ""
                 width = OGR_Fld_GetWidth(cogr_fielddefn)
-                if width: # and width != 80:
+                if width:
                     fmt = ":%d" % width
                 val = fieldtypename + fmt
 
@@ -970,11 +976,13 @@ cdef class WritingSession(Session):
 
                 # Convert 'long' to 'int'. See
                 # https://github.com/Toblerity/Fiona/issues/101.
-                if value == 'long':
-                    value = 'int'
-                
+                if GDAL_VERSION_NUM >= 2000000 and value in ('int', 'long'):
+                    value = 'int64'
+                elif value == 'int':
+                    value = 'int32'
+
                 if value == 'bool':
-                    value = 'int'
+                    value = 'int32'
                     field_subtype = OFSTBoolean
 
                 # Is there a field width/precision?
@@ -985,12 +993,17 @@ cdef class WritingSession(Session):
                         width, precision = map(int, fmt.split('.'))
                     else:
                         width = int(fmt)
+                    if value == 'int':
+                        if GDAL_VERSION_NUM >= 2000000 and width == 0 or width >= 10:
+                            value = 'int64'
+                        else:
+                            value = 'int32'
 
                 field_type = FIELD_TYPES.index(value)
-                if GDAL_VERSION_NUM >= 2000000:
-                    # See https://trac.osgeo.org/gdal/wiki/rfc31_ogr_64
-                    if value == 'int' and (width is not None and width >= 10):
-                        field_type = 12
+                #if GDAL_VERSION_NUM >= 2000000:
+                #    # See https://trac.osgeo.org/gdal/wiki/rfc31_ogr_64
+                #    if value == 'int64':
+                #        field_type = 12
 
                 encoding = self.get_internalencoding()
                 key_bytes = key.encode(encoding)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -997,7 +997,7 @@ cdef class WritingSession(Session):
             # which are an ordered dict since Fiona 1.0.1.
             for key, value in collection.schema['properties'].items():
 
-                log.debug("Begin creating field: %r %r", key, value)
+                log.debug("Begin creating field: %r value: %r", key, value)
 
                 field_subtype = OFSTNone
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -315,7 +315,6 @@ cdef class OGRFeatureBuilder:
             ogr_key = session._schema_mapping[key]
 
             schema_type = normalize_field_type(collection.schema['properties'][key])
-            # schema_type = collection.schema['properties'][key]
 
             log.debug("Normalizing schema type for key %r in schema %r to %r", key, collection.schema['properties'], schema_type)
 
@@ -998,7 +997,7 @@ cdef class WritingSession(Session):
             # which are an ordered dict since Fiona 1.0.1.
             for key, value in collection.schema['properties'].items():
 
-                log.debug("Begin creating field: %s %s", key, value)
+                log.debug("Begin creating field: %r %r", key, value)
 
                 field_subtype = OFSTNone
 
@@ -1060,7 +1059,7 @@ cdef class WritingSession(Session):
 
                 OGR_Fld_Destroy(cogr_fielddefn)
 
-                log.debug("End creating field {}".format(key))
+                log.debug("End creating field %r", key)
 
         # Mapping of the Python collection schema to the munged
         # OGR schema.

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1000,11 +1000,6 @@ cdef class WritingSession(Session):
                             value = 'int32'
 
                 field_type = FIELD_TYPES.index(value)
-                #if GDAL_VERSION_NUM >= 2000000:
-                #    # See https://trac.osgeo.org/gdal/wiki/rfc31_ogr_64
-                #    if value == 'int64':
-                #        field_type = 12
-
                 encoding = self.get_internalencoding()
                 key_bytes = key.encode(encoding)
 

--- a/fiona/schema.py
+++ b/fiona/schema.py
@@ -7,8 +7,6 @@ from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
 # Mapping of OGR integer field types to Fiona field type names.
 # Lists are currently unsupported in this version, but might be done as
 # arrays in a future version.
-#
-# NB: in Fiona 2, we will switch 'int' -> 'int64'.
 FIELD_TYPES = [
     'int32',        # OFTInteger, Simple 32bit integer
     None,           # OFTIntegerList, List of 32bit integers

--- a/fiona/schema.py
+++ b/fiona/schema.py
@@ -1,0 +1,71 @@
+from six import text_type
+
+from fiona.errors import SchemaError
+from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
+
+
+# Mapping of OGR integer field types to Fiona field type names.
+# Lists are currently unsupported in this version, but might be done as
+# arrays in a future version.
+#
+# NB: in Fiona 2, we will switch 'int' -> 'int64'.
+FIELD_TYPES = [
+    'int32',        # OFTInteger, Simple 32bit integer
+    None,           # OFTIntegerList, List of 32bit integers
+    'float',        # OFTReal, Double Precision floating point
+    None,           # OFTRealList, List of doubles
+    'str',          # OFTString, String of UTF-8 chars
+    None,           # OFTStringList, Array of strings
+    None,           # OFTWideString, deprecated
+    None,           # OFTWideStringList, deprecated
+    'bytes',        # OFTBinary, Raw Binary data
+    'date',         # OFTDate, Date
+    'time',         # OFTTime, Time
+    'datetime',     # OFTDateTime, Date and Time
+    'int64',        # OFTInteger64, Single 64bit integer
+    None            # OFTInteger64List, List of 64bit integers
+]
+
+# Mapping of Fiona field type names to Python types.
+FIELD_TYPES_MAP = {
+    'int32': int,
+    'float': float,
+    'str': text_type,
+    'date': FionaDateType,
+    'time': FionaTimeType,
+    'datetime': FionaDateTimeType,
+    'bytes': bytes,
+    'int64': int,
+    'int': int
+}
+
+
+def normalize_field_type(ftype):
+    """Normalize free form field types to an element of FIELD_TYPES
+
+    Parameters
+    ----------
+    ftype : str
+        A type:width format like 'int:9' or 'str:255'
+
+    Returns
+    -------
+    str
+        An element from FIELD_TYPES
+    """
+    if ftype in FIELD_TYPES:
+        return ftype
+    elif ftype == 'bool':
+        return 'bool'
+    elif ftype.startswith('int'):
+        width = int((ftype.split(':')[1:] or ['0'])[0])
+        if width == 0 or width >= 10:
+            return 'int64'
+        else:
+            return 'int32'
+    elif ftype.startswith('str'):
+        return 'str'
+    elif ftype.startswith('float'):
+        return 'float'
+    else:
+        raise SchemaError("Unknown field type: {}".format(ftype))

--- a/fiona/schema.pyx
+++ b/fiona/schema.pyx
@@ -8,12 +8,12 @@ cdef extern from "gdal.h":
     char * GDALVersionInfo (char *pszRequest)
 
 
-def get_gdal_version_num():
+def _get_gdal_version_num():
     """Return current internal version number of gdal"""
     return int(GDALVersionInfo("VERSION_NUM"))
 
 
-GDAL_VERSION_NUM = get_gdal_version_num()
+GDAL_VERSION_NUM = _get_gdal_version_num()
 
 # Mapping of OGR integer field types to Fiona field type names.
 # Lists are currently unsupported in this version, but might be done as

--- a/fiona/schema.pyx
+++ b/fiona/schema.pyx
@@ -4,6 +4,17 @@ from fiona.errors import SchemaError
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
 
 
+cdef extern from "gdal.h":
+    char * GDALVersionInfo (char *pszRequest)
+
+
+def get_gdal_version_num():
+    """Return current internal version number of gdal"""
+    return int(GDALVersionInfo("VERSION_NUM"))
+
+
+GDAL_VERSION_NUM = get_gdal_version_num()
+
 # Mapping of OGR integer field types to Fiona field type names.
 # Lists are currently unsupported in this version, but might be done as
 # arrays in a future version.
@@ -57,7 +68,7 @@ def normalize_field_type(ftype):
         return 'bool'
     elif ftype.startswith('int'):
         width = int((ftype.split(':')[1:] or ['0'])[0])
-        if width == 0 or width >= 10:
+        if GDAL_VERSION_NUM >= 2000000 and (width == 0 or width >= 10):
             return 'int64'
         else:
             return 'int32'

--- a/fiona/schema.pyx
+++ b/fiona/schema.pyx
@@ -48,6 +48,9 @@ FIELD_TYPES_MAP = {
     'int': int
 }
 
+FIELD_TYPES_MAP_REV = dict([(v, k) for k, v in FIELD_TYPES_MAP.items()])
+FIELD_TYPES_MAP_REV[int] = 'int'
+
 
 def normalize_field_type(ftype):
     """Normalize free form field types to an element of FIELD_TYPES

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,7 @@ if source_is_repo and "clean" not in sys.argv:
 
     ext_modules = cythonize([
         Extension('fiona._geometry', ['fiona/_geometry.pyx'], **ext_options),
+        Extension('fiona.schema', ['fiona/schema.pyx'], **ext_options),
         Extension('fiona._transform', ['fiona/_transform.pyx'], **ext_options_cpp),
         Extension('fiona._crs', ['fiona/_crs.pyx'], **ext_options),
         Extension('fiona._drivers', ['fiona/_drivers.pyx'], **ext_options),
@@ -224,6 +225,7 @@ if source_is_repo and "clean" not in sys.argv:
 # If there's no manifest template, as in an sdist, we just specify .c files.
 elif "clean" not in sys.argv:
     ext_modules = [
+        Extension('fiona.schema', ['fiona/schema.c'], **ext_options),
         Extension('fiona._transform', ['fiona/_transform.cpp'], **ext_options_cpp),
         Extension('fiona._geometry', ['fiona/_geometry.c'], **ext_options),
         Extension('fiona._crs', ['fiona/_crs.c'], **ext_options),

--- a/tests/test_bigint.py
+++ b/tests/test_bigint.py
@@ -34,7 +34,7 @@ class TestBigInt(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
-    @pytest.mark.xfail(get_gdal_version_num() < calc_gdal_version_num(2, 0, 0),
+    @pytest.mark.xfail(fiona.gdal_version.major < 2,
                        reason="64-bit integer fields require GDAL 2+")
     def testCreateBigIntSchema(self):
         name = os.path.join(self.tempdir, 'output1.shp')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,8 +3,11 @@ import shutil
 import tempfile
 import unittest
 
+import pytest
+
 import fiona
-from fiona.errors import UnsupportedGeometryTypeError
+from fiona.errors import SchemaError, UnsupportedGeometryTypeError
+from fiona.schema import FIELD_TYPES, normalize_field_type
 
 
 class SchemaOrder(unittest.TestCase):
@@ -18,10 +21,10 @@ class SchemaOrder(unittest.TestCase):
     def test_schema_ordering_items(self):
         items = [('title', 'str:80'), ('date', 'date')]
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
-                driver="ESRI Shapefile",
-                schema={
-                    'geometry': 'LineString', 
-                    'properties': items }) as c:
+                        driver="ESRI Shapefile",
+                        schema={
+                            'geometry': 'LineString',
+                            'properties': items}) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
@@ -57,10 +60,10 @@ class ShapefileSchema(unittest.TestCase):
             'GEOID10': 'str',
             'INTPTLON10': 'str'}.items())
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
-                driver="ESRI Shapefile",
-                schema={
-                    'geometry': 'Polygon', 
-                    'properties': items }) as c:
+                        driver="ESRI Shapefile",
+                        schema={
+                            'geometry': 'Polygon',
+                            'properties': items}) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
             c.write(
                 {'geometry': {'coordinates': [[(-117.882442, 33.783633),
@@ -68,17 +71,17 @@ class ShapefileSchema(unittest.TestCase):
                                                (-117.863348, 33.760016),
                                                (-117.863478, 33.760016),
                                                (-117.863869, 33.760017),
-                                                (-117.864, 33.760017999999995),
-                                                (-117.864239, 33.760019),
-                                                (-117.876608, 33.755769),
-                                                (-117.882886, 33.783114),
-                                                (-117.882688, 33.783345),
-                                                (-117.882639, 33.783401999999995),
-                                                (-117.88259, 33.78346),
-                                                (-117.882442, 33.783633)]],
-                               'type': 'Polygon'},
+                                               (-117.864, 33.760017999999995),
+                                               (-117.864239, 33.760019),
+                                               (-117.876608, 33.755769),
+                                               (-117.882886, 33.783114),
+                                               (-117.882688, 33.783345),
+                                               (-117.882639, 33.783401999999995),
+                                               (-117.88259, 33.78346),
+                                               (-117.882442, 33.783633)]],
+                              'type': 'Polygon'},
                  'id': '1',
-                 'properties':{
+                 'properties': {
                     'ALAND10': 8819240.0,
                     'AWATER10': 309767.0,
                     'CLASSFP10': 'B5',
@@ -99,31 +102,31 @@ class ShapefileSchema(unittest.TestCase):
                     'TaxReturnsFiled': 14635.0,
                     'TotalWages': 521280485.0,
                     'ZipCodeType': 'STANDARD'},
-                 'type': 'Feature'} )
+                 'type': 'Feature'})
             self.assertEqual(len(c), 1)
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
             self.assertEqual(
-                list(c.schema['properties'].items()), 
-                sorted([('AWATER10', 'float:24.15'), 
-                 ('CLASSFP10', 'str:80'), 
-                 ('ZipCodeTyp', 'str:80'), 
-                 ('EstimatedP', 'float:24.15'), 
-                 ('LocationTy', 'str:80'), 
-                 ('ALAND10', 'float:24.15'), 
-                 ('INTPTLAT10', 'str:80'), 
-                 ('FUNCSTAT10', 'str:80'), 
-                 ('Long', 'float:24.15'), 
-                 ('City', 'str:80'), 
-                 ('TaxReturns', 'float:24.15'), 
-                 ('State', 'str:80'), 
-                 ('Location', 'str:80'), 
-                 ('GSrchCnt', 'float:24.15'), 
-                 ('TotalWages', 'float:24.15'), 
-                 ('Lat', 'float:24.15'), 
-                 ('MTFCC10', 'str:80'), 
-                 ('INTPTLON10', 'str:80'), 
-                 ('GEOID10', 'str:80'), 
-                 ('Decommisio', 'str:80')]) )
+                list(c.schema['properties'].items()),
+                sorted([('AWATER10', 'float:24.15'),
+                        ('CLASSFP10', 'str:80'),
+                        ('ZipCodeTyp', 'str:80'),
+                        ('EstimatedP', 'float:24.15'),
+                        ('LocationTy', 'str:80'),
+                        ('ALAND10', 'float:24.15'),
+                        ('INTPTLAT10', 'str:80'),
+                        ('FUNCSTAT10', 'str:80'),
+                        ('Long', 'float:24.15'),
+                        ('City', 'str:80'),
+                        ('TaxReturns', 'float:24.15'),
+                        ('State', 'str:80'),
+                        ('Location', 'str:80'),
+                        ('GSrchCnt', 'float:24.15'),
+                        ('TotalWages', 'float:24.15'),
+                        ('Lat', 'float:24.15'),
+                        ('MTFCC10', 'str:80'),
+                        ('INTPTLON10', 'str:80'),
+                        ('GEOID10', 'str:80'),
+                        ('Decommisio', 'str:80')]))
             f = next(iter(c))
             self.assertEqual(f['properties']['EstimatedP'], 27773.0)
 
@@ -172,3 +175,36 @@ def test_unsupported_geometry_type():
         fiona.open(tmpfile, 'w', **profile)
     except UnsupportedGeometryTypeError:
         assert True
+
+
+@pytest.mark.parametrize('x', list(range(1, 10)))
+def test_normalize_int32(x):
+    assert normalize_field_type('int:{}'.format(x)) == 'int32'
+
+
+@pytest.mark.parametrize('x', list(range(10, 20)))
+def test_normalize_int64(x):
+    assert normalize_field_type('int:{}'.format(x)) == 'int64'
+
+
+@pytest.mark.parametrize('x', list(range(0, 20)))
+def test_normalize_str(x):
+    assert normalize_field_type('str:{}'.format(x)) == 'str'
+
+
+def test_normalize_bool():
+    assert normalize_field_type('bool') == 'bool'
+
+
+def test_normalize_float():
+    assert normalize_field_type('float:25.8') == 'float'
+
+
+@pytest.mark.parametrize('x', set(FIELD_TYPES))
+def test_normalize_std(x):
+    assert normalize_field_type(x) == x
+
+
+def test_normalize_error():
+    with pytest.raises(SchemaError):
+        assert normalize_field_type('thingy')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,6 +8,7 @@ import pytest
 import fiona
 from fiona.errors import SchemaError, UnsupportedGeometryTypeError
 from fiona.schema import FIELD_TYPES, normalize_field_type
+from fiona.ogrext import calc_gdal_version_num, get_gdal_version_num
 
 
 class SchemaOrder(unittest.TestCase):
@@ -28,6 +29,7 @@ class SchemaOrder(unittest.TestCase):
             self.assertEqual(list(c.schema['properties'].items()), items)
         with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
             self.assertEqual(list(c.schema['properties'].items()), items)
+
 
 class ShapefileSchema(unittest.TestCase):
 
@@ -182,6 +184,8 @@ def test_normalize_int32(x):
     assert normalize_field_type('int:{}'.format(x)) == 'int32'
 
 
+@pytest.mark.skipif(get_gdal_version_num() < calc_gdal_version_num(2, 0, 0),
+                    reason="64-bit integer fields require GDAL 2+")
 @pytest.mark.parametrize('x', list(range(10, 20)))
 def test_normalize_int64(x):
     assert normalize_field_type('int:{}'.format(x)) == 'int64'

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -26,7 +26,9 @@ class DebugHandler(logging.Handler):
         if self.pattern in record.msg:
             self.history[record.msg] += 1
 
-log = logging.getLogger("Fiona")
+
+log = logging.getLogger()
+
 
 @pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
 class TestTransaction:
@@ -54,8 +56,6 @@ class TestTransaction:
         assert fiona.ogrext.DEFAULT_TRANSACTION_SIZE == transaction_size
 
         path = str(tmpdir.join("output.gpkg"))
-
-        feature = next(create_records(1))
 
         schema = {
             "geometry": "Point",


### PR DESCRIPTION
Collection schemas still report 'int:9' or 'int:18' for now (with GDAL 2) but in creating a collection, 'int' means 'int64'.

Resolves #562 