### PR TITLE
Gdal23 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - fio --gdal-version
 
 script:
-  - pytest --cov fiona --cov-report term-missing --strict
+  - pytest --cov fiona --cov-report term-missing
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - fio --gdal-version
 
 script:
-  - pytest --cov fiona --cov-report term-missing
+  - pytest --cov fiona --cov-report term-missing --strict
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -57,8 +57,11 @@ def parse_paths(uri, vfs=None):
         scheme = parts.scheme
         path = parts.path
         if parts.netloc and parts.netloc != 'localhost':
-            # We need to deal with cases such as zip+https://server.com/data.zip
-            path = "{}://{}{}".format(scheme.split("+")[-1], parts.netloc, path)
+            if scheme.split("+")[-1] in REMOTESCHEMES:
+                # We need to deal with cases such as zip+https://server.com/data.zip
+                path = "{}://{}{}".format(scheme.split("+")[-1], parts.netloc, path)
+            else:
+                path = parts.netloc + path
         if scheme in SCHEMES:
             parts = path.split('!')
             path = parts.pop() if parts else None

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -57,7 +57,8 @@ def parse_paths(uri, vfs=None):
         scheme = parts.scheme
         path = parts.path
         if parts.netloc and parts.netloc != 'localhost':
-            path = parts.netloc + path
+            # We need to deal with cases such as zip+https://server.com/data.zip
+            path = "{}://{}{}".format(scheme.split("+")[-1], parts.netloc, path)
         if scheme in SCHEMES:
             parts = path.split('!')
             path = parts.pop() if parts else None

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -58,7 +58,7 @@ if [ "$GDALVERSION" = "trunk" ]; then
   git clone -b master --single-branch --depth=1 https://github.com/OSGeo/gdal.git $GDALBUILD/trunk
   cd $GDALBUILD/trunk/gdal
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
-  make -s -j 2
+  make -j 2
   make install
 elif [ ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   # only build if not already installed
@@ -67,7 +67,7 @@ elif [ ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   tar -xzf gdal-$GDALVERSION.tar.gz
   cd gdal-$GDALVERSION
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
-  make -s -j 2
+  make -j 2
   make install
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def pytest_report_header(config):
     headers = []
     # gdal version number
     gdal_release_name = fiona.get_gdal_release_name().decode("utf-8")
-    headers.append('GDAL: {}'.format(gdal_release_name))
+    headers.append('GDAL: {} ({})'.format(gdal_release_name, fiona.get_gdal_version_num()))
     supported_drivers = ", ".join(sorted(list(fiona.supported_drivers.keys())))
     # supported drivers
     headers.append("Supported drivers: {}".format(supported_drivers))

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -9,13 +9,6 @@ import six
 import fiona
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_json')
-
-
-def calc_gdal_version_num(maj, min, rev):
-    """Calculates the internal gdal version number based on major, minor and revision"""
-    return int(maj * 1000000 + min * 10000 + rev*100)
-
-
 class ReadingTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -5,10 +5,15 @@ import unittest
 
 import pytest
 import six
-from packaging.version import parse
+
 import fiona
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_json')
+
+
+def calc_gdal_version_num(maj, min, rev):
+    """Calculates the internal gdal version number based on major, minor and revision"""
+    return int(maj * 1000000 + min * 10000 + rev*100)
 
 
 class ReadingTest(unittest.TestCase):
@@ -221,8 +226,7 @@ def test_zipped_bytes_collection(bytes_coutwildrnp_zip):
         assert col.name == 'coutwildrnp'
         assert len(col) == 67
 
-pytest.mark.skipif(
-    parse(fiona.get_gdal_release_name().decode('utf-8')) >= parse('2.3.0'),
+pytest.mark.skipif(fiona.get_gdal_version_num() >= fiona.calc_gdal_version_num(2, 3, 0),
     reason="Changed behavior with gdal 2.3, possibly related to RFC 70:"
     "Guessing output format from output file name extension for utilities")
 def test_grenada_bytes_geojson(bytes_grenada_geojson):

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -221,7 +221,10 @@ def test_zipped_bytes_collection(bytes_coutwildrnp_zip):
         assert col.name == 'coutwildrnp'
         assert len(col) == 67
 
-
+pytest.mark.skipif(
+    parse(fiona.get_gdal_release_name().decode('utf-8')) >= parse('2.3.0'),
+    reason="Changed behavior with gdal 2.3, possibly related to RFC 70:"
+    "Guessing output format from output file name extension for utilities")
 def test_grenada_bytes_geojson(bytes_grenada_geojson):
     """Read grenada.geojson as BytesCollection.
 

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -5,7 +5,7 @@ import unittest
 
 import pytest
 import six
-
+from packaging.version import parse
 import fiona
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_json')

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -219,7 +219,7 @@ def test_zipped_bytes_collection(bytes_coutwildrnp_zip):
         assert col.name == 'coutwildrnp'
         assert len(col) == 67
 
-pytest.mark.skipif(fiona.get_gdal_version_num() >= fiona.calc_gdal_version_num(2, 3, 0),
+@pytest.mark.skipif(fiona.get_gdal_version_num() >= fiona.calc_gdal_version_num(2, 3, 0),
     reason="Changed behavior with gdal 2.3, possibly related to RFC 70:"
     "Guessing output format from output file name extension for utilities")
 def test_grenada_bytes_geojson(bytes_grenada_geojson):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -922,13 +922,13 @@ class OpenKeywordArgsTest(unittest.TestCase):
 
 @pytest.mark.network
 def test_collection_http():
-    ds = fiona.Collection('http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.shp', vsi='http')
-    assert ds.path == '/vsicurl/http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.shp'
+    ds = fiona.Collection('http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp', vsi='http')
+    assert ds.path == '/vsicurl/http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp'
     assert len(ds) == 10
 
 @pytest.mark.network
 def test_collection_zip_http():
-    ds = fiona.Collection('http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.zip', vsi='zip+http')
-    assert ds.path == '/vsizip/vsicurl/http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.zip'
+    ds = fiona.Collection('http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.zip', vsi='zip+http')
+    assert ds.path == '/vsizip/vsicurl/http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.zip'
     assert len(ds) == 10
         

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -162,7 +162,7 @@ class TarArchiveReadingTest(VsiReadingTest):
 
 @pytest.mark.network        
 def test_open_http():
-    ds = fiona.open('http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.shp')
+    ds = fiona.open('/vsicurl/https://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp')
     assert len(ds) == 10
 
 @credentials

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -162,7 +162,7 @@ class TarArchiveReadingTest(VsiReadingTest):
 
 @pytest.mark.network        
 def test_open_http():
-    ds = fiona.open('/vsicurl/https://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp')
+    ds = fiona.open('https://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp')
     assert len(ds) == 10
 
 @credentials


### PR DESCRIPTION
This PR implements https://github.com/Toblerity/Fiona/issues/573

It includes two bigger changes and a few smaller ones:

**Disable test_grenada_bytes_geojson**
In Gdal 2.3 no FionaValueError is thrown anymore. This is possible due to [RFC70](https://trac.osgeo.org/gdal/wiki/rfc70_output_format_guess): 

> Command line utilities, when neither -f nor -of are specified (note: since r39878 both switches can be indifferently used), will loop through the registered drivers and check if one or several drivers, with output capabilities, declare to recognize the extension of the output filename. 

**Include vsi remote schemes**
Changes are limited to parse_paths() in vfs.py.  This function is rather complex, I hope I thought about every cases.  There are a few tests in test_vfs.py, but I think it would be good to have a bit more documentation, either in the function itself or as test cases.

Minor changes include verbose make of gdal to avoid timeouts of travis as well as to move from svn.osgeo.org to github for the tests.

Sorry for the messy commit history, it was a bit debugging on travis as I first hesitated to install a local gdal 2.3.

