### PR TITLE
Added fiona.gdal_version named tuple

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -86,7 +86,8 @@ from fiona.compat import OrderedDict
 from fiona.io import MemoryFile
 from fiona.ogrext import _bounds, _listlayers, FIELD_TYPES_MAP, _remove, _remove_layer
 from fiona.ogrext import (
-    calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name)
+    calc_gdal_version_num, get_gdal_version_num, get_gdal_release_name,
+    get_gdal_version_tuple)
 
 # These modules are imported by fiona.ogrext, but are also import here to
 # help tools like cx_Freeze find them automatically
@@ -97,6 +98,8 @@ import uuid
 __all__ = ['bounds', 'listlayers', 'open', 'prop_type', 'prop_width']
 __version__ = "1.8a2"
 __gdal_version__ = get_gdal_release_name().decode('utf-8')
+
+gdal_version = get_gdal_version_tuple()
 
 log = logging.getLogger(__name__)
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -10,6 +10,7 @@ import os
 import warnings
 import math
 import uuid
+from collections import namedtuple
 
 from six import integer_types, string_types, text_type
 
@@ -142,6 +143,14 @@ def get_gdal_release_name():
     return GDALVersionInfo("RELEASE_NAME")
 
 cdef int GDAL_VERSION_NUM = get_gdal_version_num()
+
+GDALVersion = namedtuple("GDALVersion", ["major", "minor", "revision"])
+def get_gdal_version_tuple():
+    gdal_version_num = get_gdal_version_num()
+    major = gdal_version_num // 1000000
+    minor = (gdal_version_num - (major * 1000000)) // 10000
+    revision = (gdal_version_num - (major * 1000000) - (minor * 10000)) // 100
+    return GDALVersion(major, minor, revision)
 
 # Feature extension classes and functions follow.
 

--- a/tests/test_bigint.py
+++ b/tests/test_bigint.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from fiona.ogrext import calc_gdal_version_num, get_gdal_version_num
+import fiona
 
 """
 
@@ -43,7 +43,7 @@ class TestBigInt(unittest.TestCase):
             'schema': {
                 'geometry': 'Point',
                 'properties': [(fieldname, 'int:10')]}}
-        if get_gdal_version_num() < calc_gdal_version_num(2, 0, 0):
+        if fiona.gdal_version < (2, 0, 0):
             with self.assertRaises(OverflowError):
                 with fiona.open(name, 'w', **kwargs) as dst:
                     rec = {}
@@ -59,7 +59,7 @@ class TestBigInt(unittest.TestCase):
                 dst.write(rec)
 
             with fiona.open(name) as src:
-                if get_gdal_version_num() >= calc_gdal_version_num(2, 0, 0):
+                if fiona.gdal_version >= (2, 0, 0):
                     first = next(iter(src))
                     self.assertEqual(first['properties'][fieldname], a_bigint)
 

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -219,7 +219,7 @@ def test_zipped_bytes_collection(bytes_coutwildrnp_zip):
         assert col.name == 'coutwildrnp'
         assert len(col) == 67
 
-@pytest.mark.skipif(fiona.get_gdal_version_num() >= fiona.calc_gdal_version_num(2, 3, 0),
+@pytest.mark.skipif(fiona.gdal_version >= (2, 3, 0),
     reason="Changed behavior with gdal 2.3, possibly related to RFC 70:"
     "Guessing output format from output file name extension for utilities")
 def test_grenada_bytes_geojson(bytes_grenada_geojson):

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -11,8 +11,6 @@ import fiona
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-GDAL_MAJOR_VER = fiona.get_gdal_version_num() // 1000000
-
 def test_options(tmpdir):
     """Test that setting CPL_DEBUG=ON works"""
     logfile = str(tmpdir.mkdir('tests').join('test_options.log'))
@@ -28,7 +26,7 @@ def test_options(tmpdir):
         c.close()
         with open(logfile, "r") as f:
             log = f.read()
-        if GDAL_MAJOR_VER >= 2:
+        if fiona.gdal_version.major >= 2:
             assert "GDALOpen" in log
         else:
             assert "OGROpen" in log

--- a/tests/test_subtypes.py
+++ b/tests/test_subtypes.py
@@ -1,8 +1,6 @@
 import fiona
 import six
 
-GDAL_MAJOR_VER = fiona.get_gdal_version_num() // 1000000
-
 def test_read_bool_subtype(tmpdir):
     test_data = """{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"bool": true, "not_bool": 1, "float": 42.5}, "geometry": null}]}"""
     path = tmpdir.join("test_read_bool_subtype.geojson")
@@ -12,7 +10,7 @@ def test_read_bool_subtype(tmpdir):
     with fiona.open(str(path), "r") as src:
         feature = next(iter(src))
     
-    if GDAL_MAJOR_VER >= 2:
+    if fiona.gdal_version.major >= 2:
         assert type(feature["properties"]["bool"]) is bool
     else:
         assert type(feature["properties"]["bool"]) is int
@@ -46,7 +44,7 @@ def test_write_bool_subtype(tmpdir):
     with open(str(path), "r") as f:
         data = f.read()
     
-    if GDAL_MAJOR_VER >= 2:
+    if fiona.gdal_version.major >= 2:
         assert """"bool": true""" in data
     else:
         assert """"bool": 1""" in data

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,21 @@
+import fiona
+from fiona.ogrext import GDALVersion
+
+def test_version_tuple():
+    version = fiona.gdal_version
+    assert version.major >= 1 and isinstance(version.major, int)
+    assert version.minor >= 0 and isinstance(version.minor, int)
+    assert version.revision >= 0 and isinstance(version.revision, int)
+
+def test_version_comparison():
+    # version against version
+    assert GDALVersion(4, 0, 0) > GDALVersion(3, 2, 1)
+    assert GDALVersion(2, 0, 0) < GDALVersion(3, 2, 1)
+    assert GDALVersion(3, 2, 2) > GDALVersion(3, 2, 1)
+    assert GDALVersion(3, 2, 0) < GDALVersion(3, 2, 1)
+    
+    # tuple against version
+    assert (4, 0, 0) > GDALVersion(3, 2, 1)
+    assert (2, 0, 0) < GDALVersion(3, 2, 1)
+    assert (3, 2, 2) > GDALVersion(3, 2, 1)
+    assert (3, 2, 0) < GDALVersion(3, 2, 1)

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -16,8 +16,8 @@ logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
 # Custom markers (from rasterio)
 mingdalversion = pytest.mark.skipif(
-    parse(fiona.get_gdal_release_name().decode('utf-8')) < parse('2.1.0dev'),
-          reason="S3 raster access requires GDAL 2.1")
+    fiona.gdal_version < (2, 1, 0),
+    reason="S3 raster access requires GDAL 2.1")
 
 credentials = pytest.mark.skipif(
     not(boto3.Session()._session.get_credentials()),


### PR DESCRIPTION
Adds a named tuple with the runtime GDAL version number.

```python
import fiona
print(fiona.gdal_version.major)
print(fiona.gdal_version.minor)
print(fiona.gdal_version.release)

assert fiona.gdal_version.major >= 2
assert fiona.gdal_version >= (2, 2, 0)
```

Closes #575.