### PR TITLE
Fixed issue when using field names not supported by layer encoding

### DIFF
--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -66,7 +66,7 @@ class CPLE_BaseError(Exception):
         return self.__unicode__()
 
     def __unicode__(self):
-        return "{}".format(self.errmsg)
+        return u"{}".format(self.errmsg)
 
     @property
     def args(self):

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1095,7 +1095,7 @@ cdef class WritingSession(Session):
                 try:
                     exc_wrap_int(OGR_L_CreateField(self.cogr_layer, cogr_fielddefn, 1))
                 except CPLE_BaseError as exc:
-                    raise SchemaError(str(exc))
+                    raise SchemaError(u"{}".format(exc))
 
                 OGR_Fld_Destroy(cogr_fielddefn)
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1077,7 +1077,10 @@ cdef class WritingSession(Session):
 
                 field_type = FIELD_TYPES.index(value)
                 encoding = self.get_internalencoding()
-                key_bytes = key.encode(encoding)
+                try:
+                    key_bytes = key.encode(encoding)
+                except UnicodeEncodeError as exc:
+                    raise SchemaError(u"{}".format(exc))
 
                 cogr_fielddefn = exc_wrap_pointer(OGR_Fld_Create(key_bytes, field_type))
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -822,6 +822,7 @@ cdef class WritingSession(Session):
         cdef const char *proj_c = NULL
         cdef const char *fileencoding_c = NULL
         cdef OGRFieldSubType field_subtype
+        cdef int ret
         path = collection.path
         self.collection = collection
 

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -148,7 +148,7 @@ cdef extern from "ogr_api.h":
     void    OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
     int     OGR_G_WkbSize (void *geometry)
     OGRErr  OGR_L_CreateFeature (void *layer, void *feature)
-    int     OGR_L_CreateField (void *layer, void *fielddefn, int flexible)
+    OGRErr  OGR_L_CreateField (void *layer, void *fielddefn, int flexible)
     OGRErr  OGR_L_GetExtent (void *layer, void *extent, int force)
     void *  OGR_L_GetFeature (void *layer, int n)
     int     OGR_L_GetFeatureCount (void *layer, int m)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -209,7 +209,7 @@ cdef extern from "ogr_api.h":
     void    OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
     int     OGR_G_WkbSize (void *geometry)
     OGRErr  OGR_L_CreateFeature (void *layer, void *feature)
-    int     OGR_L_CreateField (void *layer, void *fielddefn, int flexible)
+    OGRErr  OGR_L_CreateField (void *layer, void *fielddefn, int flexible)
     OGRErr  OGR_L_GetExtent (void *layer, void *extent, int force)
     void *  OGR_L_GetFeature (void *layer, int n)
     int     OGR_L_GetFeatureCount (void *layer, int m)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -128,7 +128,7 @@ class TestUnicodeStringField(object):
 
         See GH#595.
         """
-        field_name = "区县名称"
+        field_name = u"区县名称"
         meta = {
             "schema": {
                 "properties": OrderedDict([(field_name, "int")]),
@@ -141,10 +141,9 @@ class TestUnicodeStringField(object):
             "geometry": {"type": "Point", "coordinates": [1, 2]}
         }
         # when encoding is specified, write is successful
-        collection = fiona.open(os.path.join(self.tempdir, "test1.shp"), "w", encoding="GB2312", **meta)
-        collection.write(feature)
-        collection.close()
+        with fiona.open(os.path.join(self.tempdir, "test1.shp"), "w", encoding="GB2312", **meta) as collection:
+            collection.write(feature)
         # no encoding
         with pytest.raises(ValueError):
-            collection = fiona.open(os.path.join(self.tempdir, "test2.shp"), "w", **meta)
+            fiona.open(os.path.join(self.tempdir, "test2.shp"), "w", **meta)
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 import pytest
 
 import fiona
+from fiona.errors import SchemaError
 
 
 class TestUnicodePath(object):
@@ -144,6 +145,6 @@ class TestUnicodeStringField(object):
         with fiona.open(os.path.join(self.tempdir, "test1.shp"), "w", encoding="GB2312", **meta) as collection:
             collection.write(feature)
         # no encoding
-        with pytest.raises(ValueError):
+        with pytest.raises(SchemaError):
             fiona.open(os.path.join(self.tempdir, "test2.shp"), "w", **meta)
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import tempfile
+from collections import OrderedDict
 
 import pytest
 
@@ -116,3 +117,34 @@ class TestUnicodeStringField(object):
             f = next(iter(c))
             assert f['properties']['label'] == u'徐汇区'
             assert f['properties']['num'] == 0
+
+    def test_gb2312_field_wrong_encoding(self):
+        """Attempt to create field with a name not supported by the encoding
+
+        ESRI Shapefile driver defaults to ISO-8859-1 encoding if none is
+        specified. This doesn't support the field name used. Previously this
+        went undetected and would raise a KeyError later when the user tried
+        to write a feature to the layer. Instead we raise a more useful error.
+
+        See GH#595.
+        """
+        field_name = "区县名称"
+        meta = {
+            "schema": {
+                "properties": OrderedDict([(field_name, "int")]),
+                "geometry": "Point",
+            },
+            "driver": "ESRI Shapefile",
+        }
+        feature = {
+            "properties": {field_name: 123},
+            "geometry": {"type": "Point", "coordinates": [1, 2]}
+        }
+        # when encoding is specified, write is successful
+        collection = fiona.open(os.path.join(self.tempdir, "test1.shp"), "w", encoding="GB2312", **meta)
+        collection.write(feature)
+        collection.close()
+        # no encoding
+        with pytest.raises(ValueError):
+            collection = fiona.open(os.path.join(self.tempdir, "test2.shp"), "w", **meta)
+


### PR DESCRIPTION
This PR fixes a bug triggered when creating a field with a name not supported by the layer encoding. Previously this would go unnoticed until a feature was written, at which point a `KeyError` is raised because the field is missing in the schema mapping. This change detects the issue at the time of creation and raises a `ValueError` with some useful information. I'd be willing to raise a more specific error if we can think of a name - `FieldCreationError`?

Closes #595.