### PR TITLE
TST: Fix flaky listing test.

### DIFF
--- a/tests/test_fio_ls.py
+++ b/tests/test_fio_ls.py
@@ -18,7 +18,7 @@ def test_fio_ls_single_layer():
         DATA_DIR])
     assert result.exit_code == 0
     assert len(result.output.splitlines()) == 1
-    assert json.loads(result.output) == ['coutwildrnp', 'gre']
+    assert sorted(json.loads(result.output)) == ['coutwildrnp', 'gre']
 
 
 def test_fio_ls_indent(path_coutwildrnp_shp):

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -24,11 +24,11 @@ def test_single_file(path_coutwildrnp_shp):
 
 
 def test_directory(data_dir):
-    assert fiona.listlayers(data_dir) == ['coutwildrnp', 'gre']
+    assert sorted(fiona.listlayers(data_dir)) == ['coutwildrnp', 'gre']
 
 
 def test_directory_trailing_slash(data_dir):
-    assert fiona.listlayers(data_dir) == ['coutwildrnp', 'gre']
+    assert sorted(fiona.listlayers(data_dir)) == ['coutwildrnp', 'gre']
 
 
 def test_zip_path(path_coutwildrnp_zip):


### PR DESCRIPTION
Since this reads layer names from multiple files, there's no guarantee that they will be in order since the filesystem can iterate in any order.