### PR TITLE
Added GDAL 2.4.0dev to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,17 +35,17 @@ environment:
           GIS_INTERNALS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7.zip"
           GIS_INTERNALS_LIBS: "release-1600-x64-gdal-2-2-3-mapserver-7-0-7-libs.zip"
 
-        - PYTHON: "C:\\Python27-x64"
-          PYTHON_VERSION: "2.7.14"
-          PYTHON_ARCH: "64"
-          GDAL_VERSION: "2.3.0"
-          GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
-          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
-
         - PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.4"
           PYTHON_ARCH: "64"
           GDAL_VERSION: "2.3.0"
+          GIS_INTERNALS: "release-1911-x64-gdal-2-3-0-mapserver-7-0-7.zip"
+          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-2-3-0-mapserver-7-0-7-libs.zip"
+
+        - PYTHON: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.6.4"
+          PYTHON_ARCH: "64"
+          GDAL_VERSION: "2.4.0"
           GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
           GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
 
@@ -143,7 +143,7 @@ test_script:
 
 matrix:
   allow_failures:
-    - GDAL_VERSION: 2.3.0
+    - GDAL_VERSION: 2.4.0
 
 artifacts:
   - path: dist\*.whl


### PR DESCRIPTION
Added GDAL 2.4.0dev to appveyor, allowed to fail.

GDAL 2.3.0 is no longer allowed to fail.

Also removed GDAL 2.3.0 with Python 2.7 as they are incompatible (see #514).