### PR TITLE
Fix log statement causing UnicodeDecodeError in certain circumstances

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -388,7 +388,7 @@ cdef class OGRFeatureBuilder:
                 set_field_null(cogr_feature, i)
             else:
                 raise ValueError("Invalid field type %s" % type(value))
-            log.debug("Set field %s: %s" % (key, value))
+            log.debug("Set field %s: %r" % (key, value))
         return cogr_feature
 
 

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -2,8 +2,8 @@ import fiona
 
 import os
 import pytest
+import struct
 import unittest
-import binascii
 import tempfile
 import shutil
 from collections import OrderedDict
@@ -29,8 +29,8 @@ class TestBinaryField(unittest.TestCase):
             }
         }
         
-        # create some binary data to encode
-        data = binascii.a2b_hex(b"deadbeef")
+        # create some binary data
+        input_data = struct.pack("256B", *range(256))
         
         # write the binary data to a BLOB field
         filename = os.path.join(self.tempdir, "binary_test.gpkg")
@@ -39,19 +39,17 @@ class TestBinaryField(unittest.TestCase):
                 "geometry": {"type": "Point", "coordinates": ((0,0))},
                 "properties": {
                     "name": "test",
-                    "data": data
+                    u"data": input_data,
                 }
             }
             dst.write(feature)
-        
-        del(data)
         
         # read the data back and check consistency
         with fiona.open(filename, "r") as src:
             feature = next(iter(src))
             assert(feature["properties"]["name"] == "test")
-            data = feature["properties"]["data"]
-            assert(binascii.b2a_hex(data) == b"deadbeef")
+            output_data = feature["properties"]["data"]
+            assert(output_data == input_data)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In Python 2, when writing bytes data to a binary field, `UnicodeDecodeError` is possible if the field name is provided as a Unicode string, due to string formatting in `log.debug()`.

The fix doesn't solve problems with non-ASCII field names in Python 2, just allows to pass field name consisting of ASCII symbols as a Unicode string (which is convenient in case when the calling code uses `from __future__ import unicode_literals`).

The changes in test code are to make sure that all possible byte values are written correctly.