### PR TITLE
gdal version macro < gdal 1.10

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -100,8 +100,15 @@ def _bounds(geometry):
         return None
 
 def calc_gdal_version_num(maj, min, rev):
-    """Calculates the internal gdal version number based on major, minor and revision"""
-    return int(maj * 1000000 + min * 10000 + rev*100)
+    """Calculates the internal gdal version number based on major, minor and revision
+
+    GDAL Version Information macro changed with GDAL version 1.10.0 (April 2013)
+
+    """
+    if (maj, min, rev) >= (1, 10, 0):
+        return int(maj * 1000000 + min * 10000 + rev * 100)
+    else:
+        return int(maj * 1000 + min * 100 + rev * 10)
 
 def get_gdal_version_num():
     """Return current internal version number of gdal"""
@@ -115,11 +122,23 @@ cdef int GDAL_VERSION_NUM = get_gdal_version_num()
 
 GDALVersion = namedtuple("GDALVersion", ["major", "minor", "revision"])
 def get_gdal_version_tuple():
+    """
+    Calculates gdal version tuple from gdal's internal version number.
+    
+    GDAL Version Information macro changed with GDAL version 1.10.0 (April 2013)
+    """
     gdal_version_num = get_gdal_version_num()
-    major = gdal_version_num // 1000000
-    minor = (gdal_version_num - (major * 1000000)) // 10000
-    revision = (gdal_version_num - (major * 1000000) - (minor * 10000)) // 100
-    return GDALVersion(major, minor, revision)
+
+    if gdal_version_num >= calc_gdal_version_num(1, 10, 0):
+        major = gdal_version_num // 1000000
+        minor = (gdal_version_num - (major * 1000000)) // 10000
+        revision = (gdal_version_num - (major * 1000000) - (minor * 10000)) // 100
+        return GDALVersion(major, minor, revision)
+    else:
+        major = gdal_version_num // 1000
+        minor = (gdal_version_num - (major * 1000)) // 100
+        revision = (gdal_version_num - (major * 1000) - (minor * 100)) // 10
+        return GDALVersion(major, minor, revision)     
 
 # Feature extension classes and functions follow.
 


### PR DESCRIPTION
With gdal 1.10.0 (Released in April 2013) the current "GDAL Version Information macro" was introduced. Older versions used a different version of the macro. The current version of Fiona does only follow the new macro definition. However, the documentation says that GDAL/OGR 1.8+ is supported. 
This PR makes calc_gdal_version_num and get_gdal_version_tuple aware of the different GDAL Version Information macro for OGR versions prior to 1.10.0. 

I'm not sure if there are users that use a recent version of Fiona in combination with such an old version of gdal/ogr.  Thus we could also just bump the minimal supported version of gdal to 1.10. 

However,  we currently do not test in the CI for backwards compability to the oldest supported version of gdal/ogr, which might be something that we should do (thus, this PR will not be tested by the CI).