### PR TITLE
Cut down on unittest usage

### DIFF
--- a/tests/test_bigint.py
+++ b/tests/test_bigint.py
@@ -80,7 +80,3 @@ def test_issue691(tmpdir, dtype):
         assert src.schema['properties']['foo'] == 'int:18'
         first = next(iter(src))
         assert first['properties']['foo'] == 3694063472
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -50,6 +50,3 @@ class TestBinaryField(unittest.TestCase):
             assert(feature["properties"]["name"] == "test")
             output_data = feature["properties"]["data"]
             assert(output_data == input_data)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -1,52 +1,42 @@
 import fiona
 
-import os
 import pytest
 import struct
-import unittest
-import tempfile
-import shutil
 from collections import OrderedDict
 from .conftest import requires_gpkg
 
-class TestBinaryField(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-    
-    @requires_gpkg
-    def test_binary_field(self):
-        meta = {
-            "driver": "GPKG",
-            "schema": {
-                "geometry": "Point",
-                "properties": OrderedDict([
-                    ("name", "str"),
-                    ("data", "bytes"),
-                ])
+@requires_gpkg
+def test_binary_field(tmpdir):
+    meta = {
+        "driver": "GPKG",
+        "schema": {
+            "geometry": "Point",
+            "properties": OrderedDict([
+                ("name", "str"),
+                ("data", "bytes"),
+            ])
+        }
+    }
+
+    # create some binary data
+    input_data = struct.pack("256B", *range(256))
+
+    # write the binary data to a BLOB field
+    filename = str(tmpdir.join("binary_test.gpkg"))
+    with fiona.open(filename, "w", **meta) as dst:
+        feature = {
+            "geometry": {"type": "Point", "coordinates": ((0, 0))},
+            "properties": {
+                "name": "test",
+                u"data": input_data,
             }
         }
-        
-        # create some binary data
-        input_data = struct.pack("256B", *range(256))
-        
-        # write the binary data to a BLOB field
-        filename = os.path.join(self.tempdir, "binary_test.gpkg")
-        with fiona.open(filename, "w", **meta) as dst:
-            feature = {
-                "geometry": {"type": "Point", "coordinates": ((0,0))},
-                "properties": {
-                    "name": "test",
-                    u"data": input_data,
-                }
-            }
-            dst.write(feature)
-        
-        # read the data back and check consistency
-        with fiona.open(filename, "r") as src:
-            feature = next(iter(src))
-            assert(feature["properties"]["name"] == "test")
-            output_data = feature["properties"]["data"]
-            assert(output_data == input_data)
+        dst.write(feature)
+
+    # read the data back and check consistency
+    with fiona.open(filename, "r") as src:
+        feature = next(iter(src))
+        assert feature["properties"]["name"] == "test"
+        output_data = feature["properties"]["data"]
+        assert output_data == input_data

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -2,52 +2,35 @@
 """Encoding tests"""
 
 from glob import glob
-import logging
 import os
 import shutil
-import tempfile
-import unittest
 
 import pytest
 
 import fiona
 
 
-# TODO: Uncomment when merged to master, where we're using pytest.
-# We're still holding our noses in maint-1.7.
-# @pytest.fixture(scope='function')
-# def gre_shp_cp1252():
-#     """A tempdir containing copies of gre.* files, .cpg set to cp1252
-#
-#     The shapefile attributes are in fact utf-8 encoded.
-#     """
-#     test_files = glob(os.path.join(os.path.dirname(__file__), 'data/gre.*'))
-#     tmpdir = pytest.ensuretemp('tests/data')
-#     for filename in test_files:
-#         shutil.copy(filename, str(tmpdir))
-#     tmpdir.join('gre.cpg').write('cp1252')
-#     return tmpdir
+@pytest.fixture(scope='function')
+def gre_shp_cp1252(tmpdir):
+    """A tempdir containing copies of gre.* files, .cpg set to cp1252
 
-class BadCodePointTest(unittest.TestCase):
+    The shapefile attributes are in fact utf-8 encoded.
+    """
+    test_files = glob(os.path.join(os.path.dirname(__file__), 'data/gre.*'))
+    tmpdir = tmpdir.mkdir('data')
+    for filename in test_files:
+        shutil.copy(filename, str(tmpdir))
+    tmpdir.join('gre.cpg').write('cp1252')
+    yield tmpdir.join('gre.shp')
 
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp(prefix='badcodepointtest')
-        test_files = glob(os.path.join(os.path.dirname(__file__), 'data/gre.*'))
-        for filename in test_files:
-            shutil.copy(filename, self.tempdir)
-        with open(os.path.join(self.tempdir, 'gre.cpg'), 'w') as cpg:
-            cpg.write('cp1252')
-        self.shapefile = os.path.join(self.tempdir, 'gre.shp')
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+def test_broken_encoding(gre_shp_cp1252):
+    """Reading as cp1252 mis-encodes a Russian name"""
+    with fiona.open(str(gre_shp_cp1252)) as src:
+        assert next(iter(src))['properties']['name_ru'] != u'Гренада'
 
-    def test_broken_encoding(self):
-        """Reading as cp1252 mis-encodes a Russian name"""
-        with fiona.open(self.shapefile) as src:
-            self.assertNotEqual(next(iter(src))['properties']['name_ru'], u'Гренада')
 
-    def test_override_encoding(self):
-        """utf-8 override succeeds"""
-        with fiona.open(self.shapefile, encoding='utf-8') as src:
-            self.assertEqual(next(iter(src))['properties']['name_ru'], u'Гренада')
+def test_override_encoding(gre_shp_cp1252):
+    """utf-8 override succeeds"""
+    with fiona.open(str(gre_shp_cp1252), encoding='utf-8') as src:
+        assert next(iter(src))['properties']['name_ru'] == u'Гренада'

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import sys
 import tempfile
-import unittest
 import pytest
 
 import fiona
@@ -14,15 +13,15 @@ from fiona.collection import Collection
 from fiona.ogrext import featureRT
 
 
-class PointRoundTripTest(unittest.TestCase):
+class TestPointRoundTrip(object):
 
-    def setUp(self):
+    def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {'geometry': 'Point', 'properties': {'title': 'str'}}
         self.c = Collection(os.path.join(self.tempdir, "foo.shp"),
                             "w", driver="ESRI Shapefile", schema=schema)
 
-    def tearDown(self):
+    def teardown(self):
         self.c.close()
         shutil.rmtree(self.tempdir)
 
@@ -31,8 +30,8 @@ class PointRoundTripTest(unittest.TestCase):
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(
-            sorted(g['geometry'].items()),
+        assert (
+            sorted(g['geometry'].items()) ==
             [('coordinates', (0.0, 0.0)), ('type', 'Point')])
 
     def test_properties(self):
@@ -40,25 +39,25 @@ class PointRoundTripTest(unittest.TestCase):
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(g['properties']['title'], 'foo')
+        assert g['properties']['title'] == 'foo'
 
     def test_none_property(self):
         f = { 'id': '1',
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
               'properties': {'title': None} }
         g = featureRT(f, self.c)
-        self.assertEqual(g['properties']['title'], None)
+        assert g['properties']['title'] is None
 
 
-class LineStringRoundTripTest(unittest.TestCase):
+class TestLineStringRoundTrip(object):
 
-    def setUp(self):
+    def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {'geometry': 'LineString', 'properties': {'title': 'str'}}
         self.c = Collection(os.path.join(self.tempdir, "foo.shp"),
                             "w", "ESRI Shapefile", schema=schema)
 
-    def tearDown(self):
+    def teardown(self):
         self.c.close()
         shutil.rmtree(self.tempdir)
 
@@ -68,8 +67,8 @@ class LineStringRoundTripTest(unittest.TestCase):
                             'coordinates': [(0.0, 0.0), (1.0, 1.0)] },
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(
-            sorted(g['geometry'].items()),
+        assert (
+            sorted(g['geometry'].items()) ==
             [('coordinates', [(0.0, 0.0), (1.0, 1.0)]),
              ('type', 'LineString')])
 
@@ -78,18 +77,18 @@ class LineStringRoundTripTest(unittest.TestCase):
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(g['properties']['title'], 'foo')
+        assert g['properties']['title'] == 'foo'
 
 
-class PolygonRoundTripTest(unittest.TestCase):
+class TestPolygonRoundTrip(object):
 
-    def setUp(self):
+    def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {'geometry': 'Polygon', 'properties': {'title': 'str'}}
         self.c = Collection(os.path.join(self.tempdir, "foo.shp"),
                             "w", "ESRI Shapefile", schema=schema)
 
-    def tearDown(self):
+    def teardown(self):
         self.c.close()
         shutil.rmtree(self.tempdir)
 
@@ -104,8 +103,8 @@ class PolygonRoundTripTest(unittest.TestCase):
                                   (0.0, 0.0)]] },
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(
-            sorted(g['geometry'].items()),
+        assert (
+            sorted(g['geometry'].items()) ==
             [('coordinates', [[(0.0, 0.0),
                                   (0.0, 1.0),
                                   (1.0, 1.0),
@@ -124,7 +123,7 @@ class PolygonRoundTripTest(unittest.TestCase):
                                   (0.0, 0.0)]] },
               'properties': {'title': u'foo'} }
         g = featureRT(f, self.c)
-        self.assertEqual(g['properties']['title'], 'foo')
+        assert g['properties']['title'] == 'foo'
 
 
 @pytest.mark.parametrize("driver, extension", [("ESRI Shapefile", "shp"), ("GeoJSON", "geojson")])

--- a/tests/test_fio_collect.py
+++ b/tests/test_fio_collect.py
@@ -3,7 +3,6 @@
 
 import json
 import sys
-import unittest
 
 from click.testing import CliRunner
 import pytest

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -1,10 +1,3 @@
-
-import logging
-import os
-import shutil
-import sys
-import tempfile
-import unittest
 import pytest
 
 import fiona
@@ -17,106 +10,102 @@ def test_json_read(path_coutwildrnp_json):
         assert len(c) == 67
 
 
-class WritingTest(unittest.TestCase):
+def test_json(tmpdir):
+    """Write a simple GeoJSON file"""
+    path = str(tmpdir.join('foo.json'))
+    with fiona.open(path, 'w',
+                    driver='GeoJSON',
+                    schema={'geometry': 'Unknown',
+                            'properties': [('title', 'str')]}) as c:
+        c.writerecords([{
+            'geometry': {'type': 'Point', 'coordinates': [0.0, 0.0]},
+            'properties': {'title': 'One'}}])
+        c.writerecords([{
+            'geometry': {'type': 'MultiPoint', 'coordinates': [[0.0, 0.0]]},
+            'properties': {'title': 'Two'}}])
+    with fiona.open(path) as c:
+        assert c.schema['geometry'] == 'Unknown'
+        assert len(c) == 2
 
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+def test_json_overwrite(tmpdir):
+    """Overwrite an existing GeoJSON file"""
+    path = str(tmpdir.join('foo.json'))
 
-    def test_json(self):
-        """Write a simple GeoJSON file"""
-        path = os.path.join(self.tempdir, 'foo.json')
-        with fiona.open(path, 'w',
-                driver='GeoJSON',
-                schema={'geometry': 'Unknown', 'properties': [('title', 'str')]}) as c:
-            c.writerecords([{
-                'geometry': {'type': 'Point', 'coordinates': [0.0, 0.0]},
-                'properties': {'title': 'One'}}])
-            c.writerecords([{
-                'geometry': {'type': 'MultiPoint', 'coordinates': [[0.0, 0.0]]},
-                'properties': {'title': 'Two'}}])
-        with fiona.open(path) as c:
-            self.assertEqual(c.schema['geometry'], 'Unknown')
-            self.assertEqual(len(c), 2)
+    driver = "GeoJSON"
+    schema1 = {"geometry": "Unknown", "properties": [("title", "str")]}
+    schema2 = {"geometry": "Unknown", "properties": [("other", "str")]}
 
-    def test_json_overwrite(self):
-        """Overwrite an existing GeoJSON file"""
-        path = os.path.join(self.tempdir, 'foo.json')
+    features1 = [
+        {
+            "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+            "properties": {"title": "One"},
+        },
+        {
+            "geometry": {"type": "MultiPoint", "coordinates": [[0.0, 0.0]]},
+            "properties": {"title": "Two"},
+        }
+    ]
+    features2 = [
+        {
+            "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+            "properties": {"other": "Three"},
+        },
+    ]
 
-        driver = "GeoJSON"
-        schema1 = {"geometry": "Unknown", "properties": [("title", "str")]}
-        schema2 = {"geometry": "Unknown", "properties": [("other", "str")]}
+    # write some data to a file
+    with fiona.open(path, "w", driver=driver, schema=schema1) as c:
+        c.writerecords(features1)
 
-        features1 = [
-            {
-                "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
-                "properties": {"title": "One"},
-            },
-            {
-                "geometry": {"type": "MultiPoint", "coordinates": [[0.0, 0.0]]},
-                "properties": {"title": "Two"},
-            }
-        ]
-        features2 = [
-            {
-                "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
-                "properties": {"other": "Three"},
-            },
-        ]
+    # test the data was written correctly
+    with fiona.open(path, "r") as c:
+        assert len(c) == 2
+        feature = next(iter(c))
+        assert feature["properties"]["title"] == "One"
 
-        # write some data to a file
-        with fiona.open(path, "w", driver=driver, schema=schema1) as c:
-            c.writerecords(features1)
+    # attempt to overwrite the existing file with some new data
+    with fiona.open(path, "w", driver=driver, schema=schema2) as c:
+        c.writerecords(features2)
 
-        # test the data was written correctly
-        with fiona.open(path, "r") as c:
-            self.assertEqual(len(c), 2)
-            feature = next(iter(c))
-            self.assertEqual(feature["properties"]["title"], "One")
+    # test the second file was written correctly
+    with fiona.open(path, "r") as c:
+        assert len(c) == 1
+        feature = next(iter(c))
+        assert feature["properties"]["other"] == "Three"
 
-        # attempt to overwrite the existing file with some new data
-        with fiona.open(path, "w", driver=driver, schema=schema2) as c:
-            c.writerecords(features2)
 
-        # test the second file was written correctly
-        with fiona.open(path, "r") as c:
-            self.assertEqual(len(c), 1)
-            feature = next(iter(c))
-            self.assertEqual(feature["properties"]["other"], "Three")
+def test_json_overwrite_invalid(tmpdir):
+    """Overwrite an existing file that isn't a valid GeoJSON"""
 
-    def test_json_overwrite_invalid(self):
-        """Overwrite an existing file that isn't a valid GeoJSON"""
+    # write some invalid data to a file
+    path = str(tmpdir.join('foo.json'))
+    with open(path, "w") as f:
+        f.write("This isn't a valid GeoJSON file!!!")
 
-        # write some invalid data to a file
-        path = os.path.join(self.tempdir, "foo.json")
-        with open(path, "w") as f:
-            f.write("This isn't a valid GeoJSON file!!!")
+    schema1 = {"geometry": "Unknown", "properties": [("title", "str")]}
+    features1 = [
+        {
+            "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+            "properties": {"title": "One"},
+        },
+        {
+            "geometry": {"type": "MultiPoint", "coordinates": [[0.0, 0.0]]},
+            "properties": {"title": "Two"},
+        }
+    ]
 
-        schema1 = {"geometry": "Unknown", "properties": [("title", "str")]}
-        features1 = [
-            {
-                "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
-                "properties": {"title": "One"},
-            },
-            {
-                "geometry": {"type": "MultiPoint", "coordinates": [[0.0, 0.0]]},
-                "properties": {"title": "Two"},
-            }
-        ]
+    # attempt to overwrite it with a valid file
+    with fiona.open(path, "w", driver="GeoJSON", schema=schema1) as dst:
+        dst.writerecords(features1)
 
-        # attempt to overwrite it with a valid file
-        with fiona.open(path, "w", driver="GeoJSON", schema=schema1) as dst:
-            dst.writerecords(features1)
+    # test the data was written correctly
+    with fiona.open(path, "r") as src:
+        assert len(src) == 2
 
-        # test the data was written correctly
-        with fiona.open(path, "r") as src:
-            self.assertEqual(len(src), 2)
 
-    def test_write_json_invalid_directory(self):
-        """Attempt to create a file in a directory that doesn't exist"""
-        path = os.path.join(self.tempdir, "does-not-exist", "foo.json")
-        schema = {"geometry": "Unknown", "properties": [("title", "str")]}
-        with pytest.raises(DriverError):
-            dst = fiona.open(path, "w", driver="GeoJSON", schema=schema)
+def test_write_json_invalid_directory(tmpdir):
+    """Attempt to create a file in a directory that doesn't exist"""
+    path = str(tmpdir.join('does-not-exist', 'foo.json'))
+    schema = {"geometry": "Unknown", "properties": [("title", "str")]}
+    with pytest.raises(DriverError):
+        fiona.open(path, "w", driver="GeoJSON", schema=schema)

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -12,16 +12,10 @@ from fiona.collection import supported_drivers
 from fiona.errors import FionaValueError, DriverError, SchemaError, CRSError
 
 
-class ReadingTest(unittest.TestCase):
+def test_json_read(path_coutwildrnp_json):
+    with fiona.open(path_coutwildrnp_json, 'r') as c:
+        assert len(c) == 67
 
-    def setUp(self):
-        self.c = fiona.open('tests/data/coutwildrnp.json', 'r')
-
-    def tearDown(self):
-        self.c.close()
-
-    def test_json(self):
-        self.assertEqual(len(self.c), 67)
 
 class WritingTest(unittest.TestCase):
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,59 +1,43 @@
 """Unittests to verify Fiona is functioning properly with other software."""
 
 
-import collections
-import os
-import shutil
-import tempfile
-import unittest
-
 import six
 
 import fiona
 
 
-class TestCRSNonDict(unittest.TestCase):
+def test_dict_subclass(tmpdir):
+    """Rasterio now has a `CRS()` class that subclasses
+    `collections.UserDict()`.  Make sure we can receive it.
 
-    @classmethod
-    def setUpClass(self):
-        self.tempdir = tempfile.mkdtemp()
+    `UserDict()` is a good class to test against because in Python 2 it is
+    not a subclass of `collections.Mapping()`, so it provides an edge case.
+    """
 
-    @classmethod
-    def tearDownClass(self):
-        shutil.rmtree(self.tempdir)
+    class CRS(six.moves.UserDict):
+        pass
 
-    def test_dict_subclass(self):
-        """Rasterio now has a `CRS()` class that subclasses
-        `collections.UserDict()`.  Make sure we can receive it.
+    outfile = str(tmpdir.join('test_UserDict.geojson'))
 
-        `UserDict()` is a good class to test against because in Python 2 it is
-        not a subclass of `collections.Mapping()`, so it provides an edge case.
-        """
-
-        class CRS(six.moves.UserDict):
-            pass
-
-        outfile = os.path.join(self.tempdir, 'test_UserDict.geojson')
-
-        profile = {
-            'crs': CRS(init='EPSG:4326'),
-            'driver': 'GeoJSON',
-            'schema': {
-                'geometry': 'Point',
-                'properties': {}
-            }
+    profile = {
+        'crs': CRS(init='EPSG:4326'),
+        'driver': 'GeoJSON',
+        'schema': {
+            'geometry': 'Point',
+            'properties': {}
         }
+    }
 
-        with fiona.open(outfile, 'w', **profile) as dst:
-            dst.write({
-                'type': 'Feature',
-                'properties': {},
-                'geometry': {
-                    'type': 'Point',
-                    'coordinates': (10, -10)
-                }
-            })
+    with fiona.open(outfile, 'w', **profile) as dst:
+        dst.write({
+            'type': 'Feature',
+            'properties': {},
+            'geometry': {
+                'type': 'Point',
+                'coordinates': (10, -10)
+            }
+        })
 
-        with fiona.open(outfile) as src:
-            assert len(src) == 1
-            assert src.crs == {'init': 'epsg:4326'}
+    with fiona.open(outfile) as src:
+        assert len(src) == 1
+        assert src.crs == {'init': 'epsg:4326'}

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -1,10 +1,3 @@
-import logging
-import os
-import shutil
-import sys
-import tempfile
-import unittest
-
 import pytest
 
 import fiona
@@ -71,13 +64,11 @@ class DirReadingTest(ReadingTest):
         self.assertEqual(self.c.path, self.data_dir)
 
 
-@pytest.mark.usefixtures("unittest_path_coutwildrnp_shp")
-class InvalidLayerTest(unittest.TestCase):
+def test_invalid_layer(path_coutwildrnp_shp):
+    with pytest.raises(ValueError):
+        fiona.open(path_coutwildrnp_shp, layer="foo")
 
-    def test_invalid(self):
-        self.assertRaises(ValueError, fiona.open, (self.path_coutwildrnp_shp), layer="foo")
 
-    def test_write_numeric_layer(self):
-        self.assertRaises(ValueError, fiona.open,
-                          (os.path.join(tempfile.gettempdir(), "test-no-iter.shp")),
-                          mode='w', layer=0)
+def test_write_invalid_numeric_layer(path_coutwildrnp_shp, tmpdir):
+    with pytest.raises(ValueError):
+        fiona.open(str(tmpdir.join("test-no-iter.shp")), mode='w', layer=0)

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -3,7 +3,6 @@
 import logging
 import sys
 import os
-import unittest
 
 import pytest
 
@@ -47,13 +46,16 @@ def test_list_not_existing(data_dir):
         fiona.ogrext._listlayers(path)
 
 
-class ListLayersArgsTest(unittest.TestCase):
+def test_invalid_path():
+    with pytest.raises(TypeError):
+        fiona.listlayers(1)
 
-    def test_path(self):
-        self.assertRaises(TypeError, fiona.listlayers, (1))
 
-    def test_vfs(self):
-        self.assertRaises(TypeError, fiona.listlayers, ("/"), vfs=1)
+def test_invalid_vfs():
+    with pytest.raises(TypeError):
+        fiona.listlayers("/", vfs=1)
 
-    def test_path_ioerror(self):
-        self.assertRaises(DriverError, fiona.listlayers, ("foobar"))
+
+def test_invalid_path_ioerror():
+    with pytest.raises(DriverError):
+        fiona.listlayers("foobar")

--- a/tests/test_non_counting_layer.py
+++ b/tests/test_non_counting_layer.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 
 import fiona
@@ -7,34 +5,34 @@ from fiona.errors import FionaDeprecationWarning
 
 
 @pytest.mark.usefixtures('uttc_path_gpx')
-class NonCountingLayerTest(unittest.TestCase):
-    def setUp(self):
+class TestNonCountingLayer(object):
+    def setup(self):
         self.c = fiona.open(self.path_gpx, "r", layer="track_points")
 
-    def tearDown(self):
+    def teardown(self):
         self.c.close()
 
     def test_len_fail(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             len(self.c)
 
     def test_list(self):
         features = list(self.c)
-        self.assertEqual(len(features), 19)
+        assert len(features) == 19
 
     def test_getitem(self):
         self.c[2]
 
     def test_fail_getitem_negative_index(self):
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             self.c[-1]
 
     def test_slice(self):
         with pytest.warns(FionaDeprecationWarning):
             features = self.c[2:5]
-            self.assertEqual(len(features), 3)
+            assert len(features) == 3
 
     def test_fail_slice_negative_index(self):
         with pytest.warns(FionaDeprecationWarning):
-            with self.assertRaises(IndexError):
+            with pytest.raises(IndexError):
                 self.c[2:-4]

--- a/tests/test_revolvingdoor.py
+++ b/tests/test_revolvingdoor.py
@@ -1,34 +1,17 @@
 # Test of opening and closing and opening
 
-import logging
-import os.path
-import shutil
-import subprocess
-import sys
-import tempfile
-import unittest
-
 import fiona
 
 
-class RevolvingDoorTest(unittest.TestCase):
+def test_write_revolving_door(tmpdir, path_coutwildrnp_shp):
+    with fiona.open(path_coutwildrnp_shp) as src:
+        meta = src.meta
+        features = list(src)
 
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
+    shpname = str(tmpdir.join('foo.shp'))
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+    with fiona.open(shpname, 'w', **meta) as dst:
+        dst.writerecords(features)
 
-    def test_write_revolving_door(self):
-
-        with fiona.open('tests/data/coutwildrnp.shp') as src:
-            meta = src.meta
-            features = list(src)
-
-        shpname = os.path.join(self.tempdir, 'foo.shp')
-
-        with fiona.open(shpname, 'w', **meta) as dst:
-            dst.writerecords(features)
-
-        with fiona.open(shpname) as src:
-            pass
+    with fiona.open(shpname) as src:
+        pass

--- a/tests/test_rfc3339.py
+++ b/tests/test_rfc3339.py
@@ -1,59 +1,57 @@
 """Tests for Fiona's RFC 3339 support."""
 
 
-import logging
 import re
-import sys
-import unittest
+
+import pytest
 
 from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import group_accessor, pattern_date
 
 
-class DateParseTest(unittest.TestCase):
+class TestDateParse(object):
 
     def test_yyyymmdd(self):
-        self.assertEqual(
-            parse_date("2012-01-29"), (2012, 1, 29, 0, 0, 0, 0.0))
+        assert parse_date("2012-01-29") == (2012, 1, 29, 0, 0, 0, 0.0)
 
     def test_error(self):
-        self.assertRaises(ValueError, parse_date, ("xxx"))
+        with pytest.raises(ValueError):
+            parse_date("xxx")
 
-class TimeParseTest(unittest.TestCase):
+
+class TestTimeParse(object):
 
     def test_hhmmss(self):
-        self.assertEqual(
-            parse_time("10:11:12"), (0, 0, 0, 10, 11, 12, 0.0))
+        assert parse_time("10:11:12") == (0, 0, 0, 10, 11, 12, 0.0)
 
     def test_hhmm(self):
-        self.assertEqual(
-            parse_time("10:11"), (0, 0, 0, 10, 11, 0, 0.0))
+        assert parse_time("10:11") == (0, 0, 0, 10, 11, 0, 0.0)
 
     def test_hhmmssff(self):
-        self.assertEqual(
-            parse_time("10:11:12.42"),
-            (0, 0, 0, 10, 11, 12, 0.42*1000000.0))
+        assert parse_time("10:11:12.42") == (0, 0, 0, 10, 11, 12, 0.42*1000000)
 
     def test_hhmmssz(self):
-        self.assertEqual(
-            parse_time("10:11:12Z"), (0, 0, 0, 10, 11, 12, 0.0))
+        assert parse_time("10:11:12Z") == (0, 0, 0, 10, 11, 12, 0.0)
 
     def test_hhmmssoff(self):
-        self.assertEqual(
-            parse_time("10:11:12-01:00"), (0, 0, 0, 10, 11, 12, 0.0))
+        assert parse_time("10:11:12-01:00") == (0, 0, 0, 10, 11, 12, 0.0)
 
     def test_error(self):
-        self.assertRaises(ValueError, parse_time, ("xxx"))
+        with pytest.raises(ValueError):
+            parse_time("xxx")
 
-class DatetimeParseTest(unittest.TestCase):
+
+class TestDatetimeParse(object):
 
     def test_yyyymmdd(self):
-        self.assertEqual(
-            parse_datetime("2012-01-29T10:11:12"),
+        assert (
+            parse_datetime("2012-01-29T10:11:12") ==
             (2012, 1, 29, 10, 11, 12, 0.0))
 
     def test_error(self):
-        self.assertRaises(ValueError, parse_datetime, ("xxx"))
+        with pytest.raises(ValueError):
+            parse_datetime("xxx")
+
 
 def test_group_accessor_indexerror():
     match = re.search(pattern_date, '2012-01-29')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,5 @@
 import os
-import shutil
 import tempfile
-import unittest
 
 import pytest
 
@@ -11,156 +9,132 @@ from fiona.schema import FIELD_TYPES, normalize_field_type
 from fiona.ogrext import calc_gdal_version_num, get_gdal_version_num
 
 
-class SchemaOrder(unittest.TestCase):
-
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    def test_schema_ordering_items(self):
-        items = [('title', 'str:80'), ('date', 'date')]
-        with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
-                        driver="ESRI Shapefile",
-                        schema={
-                            'geometry': 'LineString',
-                            'properties': items}) as c:
-            self.assertEqual(list(c.schema['properties'].items()), items)
-        with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
-            self.assertEqual(list(c.schema['properties'].items()), items)
+def test_schema_ordering_items(tmpdir):
+    name = str(tmpdir.join('test_scheme.shp'))
+    items = [('title', 'str:80'), ('date', 'date')]
+    with fiona.open(name, 'w',
+                    driver="ESRI Shapefile",
+                    schema={
+                        'geometry': 'LineString',
+                        'properties': items}) as c:
+        assert list(c.schema['properties'].items()) == items
+    with fiona.open(name) as c:
+        assert list(c.schema['properties'].items()) == items
 
 
-class ShapefileSchema(unittest.TestCase):
-
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    def test_schema(self):
-        items = sorted({
-            'AWATER10': 'float',
-            'CLASSFP10': 'str',
-            'ZipCodeType': 'str',
-            'EstimatedPopulation': 'float',
-            'LocationType': 'str',
-            'ALAND10': 'float',
-            'TotalWages': 'float',
-            'FUNCSTAT10': 'str',
-            'Long': 'float',
-            'City': 'str',
-            'TaxReturnsFiled': 'float',
-            'State': 'str',
-            'Location': 'str',
-            'GSrchCnt': 'float',
-            'INTPTLAT10': 'str',
-            'Lat': 'float',
-            'MTFCC10': 'str',
-            'Decommisioned': 'str',
-            'GEOID10': 'str',
-            'INTPTLON10': 'str'}.items())
-        with fiona.open(os.path.join(self.tempdir, 'test_schema.shp'), 'w',
-                        driver="ESRI Shapefile",
-                        schema={
-                            'geometry': 'Polygon',
-                            'properties': items}) as c:
-            self.assertEqual(list(c.schema['properties'].items()), items)
-            c.write(
-                {'geometry': {'coordinates': [[(-117.882442, 33.783633),
-                                               (-117.882284, 33.783817),
-                                               (-117.863348, 33.760016),
-                                               (-117.863478, 33.760016),
-                                               (-117.863869, 33.760017),
-                                               (-117.864, 33.760017999999995),
-                                               (-117.864239, 33.760019),
-                                               (-117.876608, 33.755769),
-                                               (-117.882886, 33.783114),
-                                               (-117.882688, 33.783345),
-                                               (-117.882639, 33.783401999999995),
-                                               (-117.88259, 33.78346),
-                                               (-117.882442, 33.783633)]],
-                              'type': 'Polygon'},
-                 'id': '1',
-                 'properties': {
-                    'ALAND10': 8819240.0,
-                    'AWATER10': 309767.0,
-                    'CLASSFP10': 'B5',
-                    'City': 'SANTA ANA',
-                    'Decommisioned': False,
-                    'EstimatedPopulation': 27773.0,
-                    'FUNCSTAT10': 'S',
-                    'GEOID10': '92706',
-                    'GSrchCnt': 0.0,
-                    'INTPTLAT10': '+33.7653010',
-                    'INTPTLON10': '-117.8819759',
-                    'Lat': 33.759999999999998,
-                    'Location': 'NA-US-CA-SANTA ANA',
-                    'LocationType': 'PRIMARY',
-                    'Long': -117.88,
-                    'MTFCC10': 'G6350',
-                    'State': 'CA',
-                    'TaxReturnsFiled': 14635.0,
-                    'TotalWages': 521280485.0,
-                    'ZipCodeType': 'STANDARD'},
-                 'type': 'Feature'})
-            self.assertEqual(len(c), 1)
-        with fiona.open(os.path.join(self.tempdir, 'test_schema.shp')) as c:
-            self.assertEqual(
-                list(c.schema['properties'].items()),
-                sorted([('AWATER10', 'float:24.15'),
-                        ('CLASSFP10', 'str:80'),
-                        ('ZipCodeTyp', 'str:80'),
-                        ('EstimatedP', 'float:24.15'),
-                        ('LocationTy', 'str:80'),
-                        ('ALAND10', 'float:24.15'),
-                        ('INTPTLAT10', 'str:80'),
-                        ('FUNCSTAT10', 'str:80'),
-                        ('Long', 'float:24.15'),
-                        ('City', 'str:80'),
-                        ('TaxReturns', 'float:24.15'),
-                        ('State', 'str:80'),
-                        ('Location', 'str:80'),
-                        ('GSrchCnt', 'float:24.15'),
-                        ('TotalWages', 'float:24.15'),
-                        ('Lat', 'float:24.15'),
-                        ('MTFCC10', 'str:80'),
-                        ('INTPTLON10', 'str:80'),
-                        ('GEOID10', 'str:80'),
-                        ('Decommisio', 'str:80')]))
-            f = next(iter(c))
-            self.assertEqual(f['properties']['EstimatedP'], 27773.0)
+def test_shapefile_schema(tmpdir):
+    name = str(tmpdir.join('test_schema.shp'))
+    items = sorted({
+        'AWATER10': 'float',
+        'CLASSFP10': 'str',
+        'ZipCodeType': 'str',
+        'EstimatedPopulation': 'float',
+        'LocationType': 'str',
+        'ALAND10': 'float',
+        'TotalWages': 'float',
+        'FUNCSTAT10': 'str',
+        'Long': 'float',
+        'City': 'str',
+        'TaxReturnsFiled': 'float',
+        'State': 'str',
+        'Location': 'str',
+        'GSrchCnt': 'float',
+        'INTPTLAT10': 'str',
+        'Lat': 'float',
+        'MTFCC10': 'str',
+        'Decommisioned': 'str',
+        'GEOID10': 'str',
+        'INTPTLON10': 'str'}.items())
+    with fiona.open(name, 'w',
+                    driver="ESRI Shapefile",
+                    schema={'geometry': 'Polygon', 'properties': items}) as c:
+        assert list(c.schema['properties'].items()) == items
+        c.write(
+            {'geometry': {'coordinates': [[(-117.882442, 33.783633),
+                                           (-117.882284, 33.783817),
+                                           (-117.863348, 33.760016),
+                                           (-117.863478, 33.760016),
+                                           (-117.863869, 33.760017),
+                                           (-117.864, 33.760017999999995),
+                                           (-117.864239, 33.760019),
+                                           (-117.876608, 33.755769),
+                                           (-117.882886, 33.783114),
+                                           (-117.882688, 33.783345),
+                                           (-117.882639, 33.783401999999995),
+                                           (-117.88259, 33.78346),
+                                           (-117.882442, 33.783633)]],
+                          'type': 'Polygon'},
+             'id': '1',
+             'properties': {
+                'ALAND10': 8819240.0,
+                'AWATER10': 309767.0,
+                'CLASSFP10': 'B5',
+                'City': 'SANTA ANA',
+                'Decommisioned': False,
+                'EstimatedPopulation': 27773.0,
+                'FUNCSTAT10': 'S',
+                'GEOID10': '92706',
+                'GSrchCnt': 0.0,
+                'INTPTLAT10': '+33.7653010',
+                'INTPTLON10': '-117.8819759',
+                'Lat': 33.759999999999998,
+                'Location': 'NA-US-CA-SANTA ANA',
+                'LocationType': 'PRIMARY',
+                'Long': -117.88,
+                'MTFCC10': 'G6350',
+                'State': 'CA',
+                'TaxReturnsFiled': 14635.0,
+                'TotalWages': 521280485.0,
+                'ZipCodeType': 'STANDARD'},
+             'type': 'Feature'})
+        assert len(c) == 1
+    with fiona.open(name) as c:
+        assert (
+            list(c.schema['properties'].items()) ==
+            sorted([('AWATER10', 'float:24.15'),
+                    ('CLASSFP10', 'str:80'),
+                    ('ZipCodeTyp', 'str:80'),
+                    ('EstimatedP', 'float:24.15'),
+                    ('LocationTy', 'str:80'),
+                    ('ALAND10', 'float:24.15'),
+                    ('INTPTLAT10', 'str:80'),
+                    ('FUNCSTAT10', 'str:80'),
+                    ('Long', 'float:24.15'),
+                    ('City', 'str:80'),
+                    ('TaxReturns', 'float:24.15'),
+                    ('State', 'str:80'),
+                    ('Location', 'str:80'),
+                    ('GSrchCnt', 'float:24.15'),
+                    ('TotalWages', 'float:24.15'),
+                    ('Lat', 'float:24.15'),
+                    ('MTFCC10', 'str:80'),
+                    ('INTPTLON10', 'str:80'),
+                    ('GEOID10', 'str:80'),
+                    ('Decommisio', 'str:80')]))
+        f = next(iter(c))
+        assert f['properties']['EstimatedP'] == 27773.0
 
 
-class FieldTruncationTestCase(unittest.TestCase):
+def test_field_truncation_issue177(tmpdir):
+    name = str(tmpdir.join('output.shp'))
 
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
+    kwargs = {
+        'driver': 'ESRI Shapefile',
+        'crs': 'EPSG:4326',
+        'schema': {
+            'geometry': 'Point',
+            'properties': [('a_fieldname', 'float')]}}
 
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
+    with fiona.open(name, 'w', **kwargs) as dst:
+        rec = {}
+        rec['geometry'] = {'type': 'Point', 'coordinates': (0, 0)}
+        rec['properties'] = {'a_fieldname': 3.0}
+        dst.write(rec)
 
-    def test_issue177(self):
-        name = os.path.join(self.tempdir, 'output.shp')
-
-        kwargs = {
-            'driver': 'ESRI Shapefile',
-            'crs': 'EPSG:4326',
-            'schema': {
-                'geometry': 'Point',
-                'properties': [('a_fieldname', 'float')]}}
-
-        with fiona.open(name, 'w', **kwargs) as dst:
-            rec = {}
-            rec['geometry'] = {'type': 'Point', 'coordinates': (0, 0)}
-            rec['properties'] = {'a_fieldname': 3.0}
-            dst.write(rec)
-
-        with fiona.open(name) as src:
-            first = next(iter(src))
-            assert first['geometry'] == {'type': 'Point', 'coordinates': (0, 0)}
-            assert first['properties']['a_fieldnam'] == 3.0
+    with fiona.open(name) as src:
+        first = next(iter(src))
+        assert first['geometry'] == {'type': 'Point', 'coordinates': (0, 0)}
+        assert first['properties']['a_fieldnam'] == 3.0
 
 
 def test_unsupported_geometry_type():

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -5,21 +5,21 @@ import os
 import shutil
 import sys
 import tempfile
-import unittest
 
 import pytest
 
 import fiona
 
 
-class UnicodePathTest(unittest.TestCase):
+class TestUnicodePath(object):
 
-    def setUp(self):
+    def setup(self):
         tempdir = tempfile.mkdtemp()
         self.dir = os.path.join(tempdir, u'français')
-        shutil.copytree('tests/data/', self.dir)
+        shutil.copytree(os.path.join(os.path.dirname(__file__), 'data'),
+                        self.dir)
 
-    def tearDown(self):
+    def teardown(self):
         shutil.rmtree(os.path.dirname(self.dir))
 
     def test_unicode_path(self):
@@ -39,12 +39,13 @@ class UnicodePathTest(unittest.TestCase):
             with fiona.open(path) as c:
                 assert len(c) == 67
 
-class UnicodeStringFieldTest(unittest.TestCase):
 
-    def setUp(self):
+class TestUnicodeStringField(object):
+
+    def setup(self):
         self.tempdir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def teardown(self):
         shutil.rmtree(self.tempdir)
 
     @pytest.mark.xfail(reason="OGR silently fails to convert strings")
@@ -78,7 +79,7 @@ class UnicodeStringFieldTest(unittest.TestCase):
         with fiona.open(os.path.join(self.tempdir), encoding='latin1') as c:
             f = next(iter(c))
             # Next assert fails.
-            self.assertEqual(f['properties']['label'], u'徐汇区')
+            assert f['properties']['label'] == u'徐汇区'
 
     def test_write_utf8(self):
         schema = {
@@ -95,8 +96,8 @@ class UnicodeStringFieldTest(unittest.TestCase):
 
         with fiona.open(os.path.join(self.tempdir), encoding='utf-8') as c:
             f = next(iter(c))
-            self.assertEqual(f['properties']['label'], u'Ba\u2019kelalan')
-            self.assertEqual(f['properties'][u'verit\xe9'], 0)
+            assert f['properties']['label'] == u'Ba\u2019kelalan'
+            assert f['properties'][u'verit\xe9'] == 0
 
     def test_write_gb18030(self):
         """Can write a simplified Chinese shapefile"""
@@ -113,5 +114,5 @@ class UnicodeStringFieldTest(unittest.TestCase):
 
         with fiona.open(os.path.join(self.tempdir), encoding='gb18030') as c:
             f = next(iter(c))
-            self.assertEqual(f['properties']['label'], u'徐汇区')
-            self.assertEqual(f['properties']['num'], 0)
+            assert f['properties']['label'] == u'徐汇区'
+            assert f['properties']['num'] == 0


### PR DESCRIPTION
This leaves 4 files with unittest:
$ rg -l 'import unittest'
test_collection.py
test_geometry.py
test_multiconxn.py
test_bytescollection.py

Also fixes finding of test data in the tests that don't use the fixtures because they used to be `unittest` but now aren't, and can subsequently use the fixture.