### PR TITLE
Replace unittest.assert* with plain assert in collection tests

### DIFF
--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -130,10 +130,10 @@ class ReadingTest(unittest.TestCase):
                 ['crs', 'crs_wkt', 'driver', 'schema'])
 
     def test_bounds(self):
-        self.assertAlmostEqual(self.c.bounds[0], -113.564247, 6)
-        self.assertAlmostEqual(self.c.bounds[1], 37.068981, 6)
-        self.assertAlmostEqual(self.c.bounds[2], -104.970871, 6)
-        self.assertAlmostEqual(self.c.bounds[3], 41.996277, 6)
+        assert self.c.bounds[0] == pytest.approx(-113.564247)
+        assert self.c.bounds[1] == pytest.approx(37.068981)
+        assert self.c.bounds[2] == pytest.approx(-104.970871)
+        assert self.c.bounds[3] == pytest.approx(41.996277)
 
     def test_iter_one(self):
         itr = iter(self.c)

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -23,7 +23,8 @@ class ReadingTest(unittest.TestCase):
     def test_construct_with_str(self):
         with open(self.path_coutwildrnp_json) as src:
             strbuf = src.read()
-        self.assertRaises(ValueError, fiona.BytesCollection, strbuf)
+        with pytest.raises(ValueError):
+            fiona.BytesCollection(strbuf)
 
     def test_open_repr(self):
         # I'm skipping checking the name of the virtual file as it produced by uuid.
@@ -61,7 +62,8 @@ class ReadingTest(unittest.TestCase):
 
     def test_closed_no_iter(self):
         self.c.close()
-        self.assertRaises(ValueError, iter, self.c)
+        with pytest.raises(ValueError):
+            iter(self.c)
 
     def test_len(self):
         assert len(self.c) == 67
@@ -156,7 +158,8 @@ class ReadingTest(unittest.TestCase):
         assert f['properties']['STATE'] == 'UT'
 
     def test_no_write(self):
-        self.assertRaises(IOError, self.c.write, {})
+        with pytest.raises(IOError):
+            self.c.write({})
 
     def test_iter_items_list(self):
         i, f = list(self.c.items())[0]

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -28,27 +28,27 @@ class ReadingTest(unittest.TestCase):
     def test_open_repr(self):
         # I'm skipping checking the name of the virtual file as it produced by uuid.
         print(repr(self.c))
-        self.assertTrue(repr(self.c).startswith("<open BytesCollection '/vsimem/"))
+        assert repr(self.c).startswith("<open BytesCollection '/vsimem/")
 
     def test_closed_repr(self):
         # I'm skipping checking the name of the virtual file as it produced by uuid.
         self.c.close()
         print(repr(self.c))
-        self.assertTrue(repr(self.c).startswith("<closed BytesCollection '/vsimem/"))
+        assert repr(self.c).startswith("<closed BytesCollection '/vsimem/")
 
     def test_path(self):
         assert self.c.path == self.c.virtual_file
 
     def test_closed_virtual_file(self):
         self.c.close()
-        self.assertTrue(self.c.virtual_file is None)
+        assert self.c.virtual_file is None
 
     def test_closed_buf(self):
         self.c.close()
-        self.assertTrue(self.c.bytesbuf is None)
+        assert self.c.bytesbuf is None
 
     def test_name(self):
-        self.assertTrue(len(self.c.name) > 0)
+        assert len(self.c.name) > 0
 
     def test_mode(self):
         assert self.c.mode == 'r'
@@ -57,7 +57,7 @@ class ReadingTest(unittest.TestCase):
         assert self.c.encoding == 'utf-8'
 
     def test_iter(self):
-        self.assertTrue(iter(self.c))
+        assert iter(self.c)
 
     def test_closed_no_iter(self):
         self.c.close()
@@ -111,8 +111,7 @@ class ReadingTest(unittest.TestCase):
         assert self.c.crs['init'] == 'epsg:4326'
 
     def test_crs_wkt(self):
-        crs = self.c.crs_wkt
-        self.assertTrue(crs.startswith('GEOGCS["WGS 84"'))
+        assert self.c.crs_wkt.startswith('GEOGCS["WGS 84"')
 
     def test_closed_crs(self):
         # Crs is lazy too, never computed in this case. TODO?
@@ -170,8 +169,8 @@ class ReadingTest(unittest.TestCase):
         assert i == 0
 
     def test_in_keys(self):
-        self.assertTrue(0 in self.c.keys())
-        self.assertTrue(0 in self.c)
+        assert 0 in self.c.keys()
+        assert 0 in self.c
 
 
 @pytest.mark.usefixtures('uttc_path_coutwildrnp_json')

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -37,7 +37,7 @@ class ReadingTest(unittest.TestCase):
         self.assertTrue(repr(self.c).startswith("<closed BytesCollection '/vsimem/"))
 
     def test_path(self):
-        self.assertEqual(self.c.path, self.c.virtual_file)
+        assert self.c.path == self.c.virtual_file
 
     def test_closed_virtual_file(self):
         self.c.close()
@@ -51,10 +51,10 @@ class ReadingTest(unittest.TestCase):
         self.assertTrue(len(self.c.name) > 0)
 
     def test_mode(self):
-        self.assertEqual(self.c.mode, 'r')
+        assert self.c.mode == 'r'
 
     def test_collection(self):
-        self.assertEqual(self.c.encoding, 'utf-8')
+        assert self.c.encoding == 'utf-8'
 
     def test_iter(self):
         self.assertTrue(iter(self.c))
@@ -64,54 +64,51 @@ class ReadingTest(unittest.TestCase):
         self.assertRaises(ValueError, iter, self.c)
 
     def test_len(self):
-        self.assertEqual(len(self.c), 67)
+        assert len(self.c) == 67
 
     def test_closed_len(self):
         # Len is lazy, it's never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(len(self.c), 0)
+        assert len(self.c) == 0
 
     def test_len_closed_len(self):
         # Lazy len is computed in this case and sticks.
         len(self.c)
         self.c.close()
-        self.assertEqual(len(self.c), 67)
+        assert len(self.c) == 67
 
     def test_driver(self):
-        self.assertEqual(self.c.driver, "GeoJSON")
+        assert self.c.driver == "GeoJSON"
 
     def test_closed_driver(self):
         self.c.close()
-        self.assertEqual(self.c.driver, None)
+        assert self.c.driver is None
 
     def test_driver_closed_driver(self):
         self.c.driver
         self.c.close()
-        self.assertEqual(self.c.driver, "GeoJSON")
+        assert self.c.driver == "GeoJSON"
 
     def test_schema(self):
         s = self.c.schema['properties']
-        self.assertEqual(s['PERIMETER'], "float")
-        self.assertEqual(s['NAME'], "str")
-        self.assertEqual(s['URL'], "str")
-        self.assertEqual(s['STATE_FIPS'], "str")
-        self.assertEqual(s['WILDRNP020'], "int")
+        assert s['PERIMETER'] == "float"
+        assert s['NAME'] == "str"
+        assert s['URL'] == "str"
+        assert s['STATE_FIPS'] == "str"
+        assert s['WILDRNP020'] == "int"
 
     def test_closed_schema(self):
         # Schema is lazy too, never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(self.c.schema, None)
+        assert self.c.schema is None
 
     def test_schema_closed_schema(self):
         self.c.schema
         self.c.close()
-        self.assertEqual(
-            sorted(self.c.schema.keys()),
-            ['geometry', 'properties'])
+        assert sorted(self.c.schema.keys()) == ['geometry', 'properties']
 
     def test_crs(self):
-        crs = self.c.crs
-        self.assertEqual(crs['init'], 'epsg:4326')
+        assert self.c.crs['init'] == 'epsg:4326'
 
     def test_crs_wkt(self):
         crs = self.c.crs_wkt
@@ -120,19 +117,16 @@ class ReadingTest(unittest.TestCase):
     def test_closed_crs(self):
         # Crs is lazy too, never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(self.c.crs, None)
+        assert self.c.crs is None
 
     def test_crs_closed_crs(self):
         self.c.crs
         self.c.close()
-        self.assertEqual(
-            sorted(self.c.crs.keys()),
-            ['init'])
+        assert sorted(self.c.crs.keys()) == ['init']
 
     def test_meta(self):
-        self.assertEqual(
-            sorted(self.c.meta.keys()),
-            ['crs', 'crs_wkt', 'driver', 'schema'])
+        assert (sorted(self.c.meta.keys()) ==
+                ['crs', 'crs_wkt', 'driver', 'schema'])
 
     def test_bounds(self):
         self.assertAlmostEqual(self.c.bounds[0], -113.564247, 6)
@@ -143,37 +137,37 @@ class ReadingTest(unittest.TestCase):
     def test_iter_one(self):
         itr = iter(self.c)
         f = next(itr)
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_iter_list(self):
         f = list(self.c)[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_re_iter_list(self):
         f = list(self.c)[0]  # Run through iterator
         f = list(self.c)[0]  # Run through a new, reset iterator
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_getitem_one(self):
         f = self.c[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_no_write(self):
         self.assertRaises(IOError, self.c.write, {})
 
     def test_iter_items_list(self):
         i, f = list(self.c.items())[0]
-        self.assertEqual(i, 0)
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert i == 0
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_iter_keys_list(self):
         i = list(self.c.keys())[0]
-        self.assertEqual(i, 0)
+        assert i == 0
 
     def test_in_keys(self):
         self.assertTrue(0 in self.c.keys())
@@ -193,16 +187,16 @@ class FilterReadingTest(unittest.TestCase):
 
     def test_filter_1(self):
         results = list(self.c.filter(bbox=(-120.0, 30.0, -100.0, 50.0)))
-        self.assertEqual(len(results), 67)
+        assert len(results) == 67
         f = results[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_filter_reset(self):
         results = list(self.c.filter(bbox=(-112.0, 38.0, -106.0, 40.0)))
-        self.assertEqual(len(results), 26)
+        assert len(results) == 26
         results = list(self.c.filter())
-        self.assertEqual(len(results), 67)
+        assert len(results) == 67
 
     def test_filter_mask(self):
         mask = {
@@ -210,7 +204,7 @@ class FilterReadingTest(unittest.TestCase):
             'coordinates': (
                 ((-112, 38), (-112, 40), (-106, 40), (-106, 38), (-112, 38)),)}
         results = list(self.c.filter(mask=mask))
-        self.assertEqual(len(results), 26)
+        assert len(results) == 26
 
 
 def test_zipped_bytes_collection(bytes_coutwildrnp_zip):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -25,13 +25,11 @@ class SupportedDriversTest(unittest.TestCase):
 
     def test_shapefile(self):
         self.assertTrue("ESRI Shapefile" in supported_drivers)
-        self.assertEqual(
-            set(supported_drivers["ESRI Shapefile"]), set("raw"))
+        assert set(supported_drivers["ESRI Shapefile"]) == set("raw")
 
     def test_map(self):
         self.assertTrue("MapInfo File" in supported_drivers)
-        self.assertEqual(
-            set(supported_drivers["MapInfo File"]), set("raw"))
+        assert set(supported_drivers["MapInfo File"]) == set("raw")
 
 
 class CollectionArgsTest(unittest.TestCase):
@@ -101,29 +99,29 @@ class ReadingTest(unittest.TestCase):
         self.c.close()
 
     def test_open_repr(self):
-        self.assertEqual(
-            repr(self.c),
+        assert (
+            repr(self.c) ==
             ("<open Collection '{path}:coutwildrnp', mode 'r' "
              "at {hexid}>".format(hexid=hex(id(self.c)), path=self.path_coutwildrnp_shp)))
 
     def test_closed_repr(self):
         self.c.close()
-        self.assertEqual(
-            repr(self.c),
+        assert (
+            repr(self.c) ==
             ("<closed Collection '{path}:coutwildrnp', mode 'r' "
              "at {hexid}>".format(hexid=hex(id(self.c)), path=self.path_coutwildrnp_shp)))
 
     def test_path(self):
-        self.assertEqual(self.c.path, self.path_coutwildrnp_shp)
+        assert self.c.path == self.path_coutwildrnp_shp
 
     def test_name(self):
-        self.assertEqual(self.c.name, 'coutwildrnp')
+        assert self.c.name == 'coutwildrnp'
 
     def test_mode(self):
-        self.assertEqual(self.c.mode, 'r')
+        assert self.c.mode == 'r'
 
     def test_collection(self):
-        self.assertEqual(self.c.encoding, 'iso-8859-1')
+        assert self.c.encoding == 'iso-8859-1'
 
     def test_iter(self):
         self.assertTrue(iter(self.c))
@@ -133,54 +131,52 @@ class ReadingTest(unittest.TestCase):
         self.assertRaises(ValueError, iter, self.c)
 
     def test_len(self):
-        self.assertEqual(len(self.c), 67)
+        assert len(self.c) == 67
 
     def test_closed_len(self):
         # Len is lazy, it's never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(len(self.c), 0)
+        assert len(self.c) == 0
 
     def test_len_closed_len(self):
         # Lazy len is computed in this case and sticks.
         len(self.c)
         self.c.close()
-        self.assertEqual(len(self.c), 67)
+        assert len(self.c) == 67
 
     def test_driver(self):
-        self.assertEqual(self.c.driver, "ESRI Shapefile")
+        assert self.c.driver == "ESRI Shapefile"
 
     def test_closed_driver(self):
         self.c.close()
-        self.assertEqual(self.c.driver, None)
+        assert self.c.driver is None
 
     def test_driver_closed_driver(self):
         self.c.driver
         self.c.close()
-        self.assertEqual(self.c.driver, "ESRI Shapefile")
+        assert self.c.driver == "ESRI Shapefile"
 
     def test_schema(self):
         s = self.c.schema['properties']
-        self.assertEqual(s['PERIMETER'], "float:24.15")
-        self.assertEqual(s['NAME'], "str:80")
-        self.assertEqual(s['URL'], "str:101")
-        self.assertEqual(s['STATE_FIPS'], "str:80")
-        self.assertEqual(s['WILDRNP020'], "int:10")
+        assert s['PERIMETER'] == "float:24.15"
+        assert s['NAME'] == "str:80"
+        assert s['URL'] == "str:101"
+        assert s['STATE_FIPS'] == "str:80"
+        assert s['WILDRNP020'] == "int:10"
 
     def test_closed_schema(self):
         # Schema is lazy too, never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(self.c.schema, None)
+        assert self.c.schema is None
 
     def test_schema_closed_schema(self):
         self.c.schema
         self.c.close()
-        self.assertEqual(
-            sorted(self.c.schema.keys()),
-            ['geometry', 'properties'])
+        assert sorted(self.c.schema.keys()) == ['geometry', 'properties']
 
     def test_crs(self):
         crs = self.c.crs
-        self.assertEqual(crs['init'], 'epsg:4326')
+        assert crs['init'] == 'epsg:4326'
 
     def test_crs_wkt(self):
         crs = self.c.crs_wkt
@@ -189,24 +185,20 @@ class ReadingTest(unittest.TestCase):
     def test_closed_crs(self):
         # Crs is lazy too, never computed in this case. TODO?
         self.c.close()
-        self.assertEqual(self.c.crs, None)
+        assert self.c.crs is None
 
     def test_crs_closed_crs(self):
         self.c.crs
         self.c.close()
-        self.assertEqual(
-            sorted(self.c.crs.keys()),
-            ['init'])
+        assert sorted(self.c.crs.keys()) == ['init']
 
     def test_meta(self):
-        self.assertEqual(
-            sorted(self.c.meta.keys()),
-            ['crs', 'crs_wkt', 'driver', 'schema'])
+        assert (sorted(self.c.meta.keys()) ==
+                ['crs', 'crs_wkt', 'driver', 'schema'])
 
     def test_profile(self):
-        self.assertEqual(
-            sorted(self.c.profile.keys()),
-            ['crs', 'crs_wkt', 'driver', 'schema'])
+        assert (sorted(self.c.profile.keys()) ==
+                ['crs', 'crs_wkt', 'driver', 'schema'])
 
     def test_bounds(self):
         self.assertAlmostEqual(self.c.bounds[0], -113.564247, 6)
@@ -216,54 +208,54 @@ class ReadingTest(unittest.TestCase):
 
     def test_context(self):
         with fiona.open(self.path_coutwildrnp_shp, "r") as c:
-            self.assertEqual(c.name, 'coutwildrnp')
-            self.assertEqual(len(c), 67)
-        self.assertEqual(c.closed, True)
+            assert c.name == 'coutwildrnp'
+            assert len(c) == 67
+        assert c.closed
 
     def test_iter_one(self):
         itr = iter(self.c)
         f = next(itr)
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_iter_list(self):
         f = list(self.c)[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_re_iter_list(self):
         f = list(self.c)[0]  # Run through iterator
         f = list(self.c)[0]  # Run through a new, reset iterator
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_getitem_one(self):
         f = self.c[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_getitem_iter_combo(self):
         i = iter(self.c)
         f = next(i)
         f = next(i)
-        self.assertEqual(f['id'], "1")
+        assert f['id'] == "1"
         f = self.c[0]
-        self.assertEqual(f['id'], "0")
+        assert f['id'] == "0"
         f = next(i)
-        self.assertEqual(f['id'], "2")
+        assert f['id'] == "2"
 
     def test_no_write(self):
         self.assertRaises(IOError, self.c.write, {})
 
     def test_iter_items_list(self):
         i, f = list(self.c.items())[0]
-        self.assertEqual(i, 0)
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert i == 0
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_iter_keys_list(self):
         i = list(self.c.keys())[0]
-        self.assertEqual(i, 0)
+        assert i == 0
 
     def test_in_keys(self):
         self.assertTrue(0 in self.c.keys())
@@ -341,16 +333,16 @@ class FilterReadingTest(unittest.TestCase):
 
     def test_filter_1(self):
         results = list(self.c.filter(bbox=(-120.0, 30.0, -100.0, 50.0)))
-        self.assertEqual(len(results), 67)
+        assert len(results) == 67
         f = results[0]
-        self.assertEqual(f['id'], "0")
-        self.assertEqual(f['properties']['STATE'], 'UT')
+        assert f['id'] == "0"
+        assert f['properties']['STATE'] == 'UT'
 
     def test_filter_reset(self):
         results = list(self.c.filter(bbox=(-112.0, 38.0, -106.0, 40.0)))
-        self.assertEqual(len(results), 26)
+        assert len(results) == 26
         results = list(self.c.filter())
-        self.assertEqual(len(results), 67)
+        assert len(results) == 67
 
     def test_filter_mask(self):
         mask = {
@@ -358,7 +350,7 @@ class FilterReadingTest(unittest.TestCase):
             'coordinates': (
                 ((-112, 38), (-112, 40), (-106, 40), (-106, 38), (-112, 38)),)}
         results = list(self.c.filter(mask=mask))
-        self.assertEqual(len(results), 26)
+        assert len(results) == 26
 
 
 class UnsupportedDriverTest(unittest.TestCase):
@@ -392,7 +384,7 @@ class GenericWritingTest(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_encoding(self):
-        self.assertEqual(self.c.encoding, 'Windows-1252')
+        assert self.c.encoding == 'Windows-1252'
 
     def test_no_iter(self):
         self.assertRaises(IOError, iter, self.c)
@@ -459,12 +451,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12, rf1['properties']['property1'])
-            self.assertEqual(12, rf2['properties']['property1'])
+            assert 12 == rf1['properties']['property1']
+            assert 12 == rf2['properties']['property1']
 
     def test_shape_driver_rounds_float_property_to_requested_digits_number(self):
         driver = "ESRI Shapefile"
@@ -475,12 +467,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12.2, rf1['properties']['property1'])
-            self.assertEqual(12.9, rf2['properties']['property1'])
+            assert 12.2 == rf1['properties']['property1']
+            assert 12.9 == rf2['properties']['property1']
 
     def test_string_is_converted_to_number_and_truncated_to_requested_int_by_shape_driver(self):
         driver = "ESRI Shapefile"
@@ -491,12 +483,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12, rf1['properties']['property1'])
-            self.assertEqual(12, rf2['properties']['property1'])
+            assert 12 == rf1['properties']['property1']
+            assert 12 == rf2['properties']['property1']
 
     def test_string_is_converted_to_number_and_rounded_to_requested_digits_number_by_shape_driver(self):
         driver = "ESRI Shapefile"
@@ -507,12 +499,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12.2, rf1['properties']['property1'])
-            self.assertEqual(12.9, rf2['properties']['property1'])
+            assert 12.2 == rf1['properties']['property1']
+            assert 12.9 == rf2['properties']['property1']
 
     def test_invalid_number_is_converted_to_0_and_written_by_shape_driver(self):
         driver = "ESRI Shapefile"
@@ -524,11 +516,11 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(1, len(c))
+            assert 1 == len(c)
 
             rf1 = c[0]
 
-            self.assertEqual(0, rf1['properties']['property1'])
+            assert 0 == rf1['properties']['property1']
 
     def test_geojson_driver_truncates_float_property_to_requested_int_format(self):
         driver = "GeoJSON"
@@ -539,12 +531,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12, rf1['properties']['property1'])
-            self.assertEqual(12, rf2['properties']['property1'])
+            assert 12 == rf1['properties']['property1']
+            assert 12 == rf2['properties']['property1']
 
     def test_geojson_driver_does_not_round_float_property_to_requested_digits_number(self):
         driver = "GeoJSON"
@@ -555,14 +547,14 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
             # ****************************************
             # FLOAT FORMATTING IS NOT RESPECTED...
-            self.assertEqual(12.22, rf1['properties']['property1'])
-            self.assertEqual(12.88, rf2['properties']['property1'])
+            assert 12.22 == rf1['properties']['property1']
+            assert 12.88 == rf2['properties']['property1']
 
     def test_string_is_converted_to_number_and_truncated_to_requested_int_by_geojson_driver(self):
         driver = "GeoJSON"
@@ -573,12 +565,12 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
-            self.assertEqual(12, rf1['properties']['property1'])
-            self.assertEqual(12, rf2['properties']['property1'])
+            assert 12 == rf1['properties']['property1']
+            assert 12 == rf2['properties']['property1']
 
     def test_string_is_converted_to_number_but_not_rounded_to_requested_digits_number_by_geojson_driver(self):
         driver = "GeoJSON"
@@ -589,14 +581,14 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(2, len(c))
+            assert 2 == len(c)
 
             rf1, rf2 = list(c)
 
             # ****************************************
             # FLOAT FORMATTING IS NOT RESPECTED...
-            self.assertEqual(12.22, rf1['properties']['property1'])
-            self.assertEqual(12.88, rf2['properties']['property1'])
+            assert 12.22 == rf1['properties']['property1']
+            assert 12.88 == rf2['properties']['property1']
 
     def test_invalid_number_is_converted_to_0_and_written_by_geojson_driver(self):
         driver = "GeoJSON"
@@ -608,11 +600,11 @@ class PropertiesNumberFormattingTest(unittest.TestCase):
         )
 
         with fiona.open(self.filename, driver=driver, encoding='utf-8') as c:
-            self.assertEqual(1, len(c))
+            assert 1 == len(c)
 
             rf1 = c[0]
 
-            self.assertEqual(0, rf1['properties']['property1'])
+            assert 0 == rf1['properties']['property1']
 
 
 class PointWritingTest(unittest.TestCase):
@@ -639,22 +631,22 @@ class PointWritingTest(unittest.TestCase):
         self.sink.close()
         with open(os.path.join(self.tempdir, "point_writing_test.cpg")) as f:
             encoding = f.readline()
-        self.assertTrue(encoding == "UTF-8")
+        assert encoding == "UTF-8"
 
     def test_write_one(self):
-        self.assertEqual(len(self.sink), 0)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 0
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
         f = {
             'geometry': {'type': 'Point', 'coordinates': (0.0, 0.1)},
             'properties': {'title': 'point one', 'date': "2012-01-29"}}
         self.sink.writerecords([f])
-        self.assertEqual(len(self.sink), 1)
-        self.assertEqual(self.sink.bounds, (0.0, 0.1, 0.0, 0.1))
+        assert len(self.sink) == 1
+        assert self.sink.bounds == (0.0, 0.1, 0.0, 0.1)
         self.sink.close()
 
     def test_write_two(self):
-        self.assertEqual(len(self.sink), 0)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 0
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
         f1 = {
             'geometry': {'type': 'Point', 'coordinates': (0.0, 0.1)},
             'properties': {'title': 'point one', 'date': "2012-01-29"}}
@@ -662,18 +654,18 @@ class PointWritingTest(unittest.TestCase):
             'geometry': {'type': 'Point', 'coordinates': (0.0, -0.1)},
             'properties': {'title': 'point two', 'date': "2012-01-29"}}
         self.sink.writerecords([f1, f2])
-        self.assertEqual(len(self.sink), 2)
-        self.assertEqual(self.sink.bounds, (0.0, -0.1, 0.0, 0.1))
+        assert len(self.sink) == 2
+        assert self.sink.bounds == (0.0, -0.1, 0.0, 0.1)
 
     def test_write_one_null_geom(self):
-        self.assertEqual(len(self.sink), 0)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 0
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
         f = {
             'geometry': None,
             'properties': {'title': 'point one', 'date': "2012-01-29"}}
         self.sink.writerecords([f])
-        self.assertEqual(len(self.sink), 1)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 1
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
 
     def test_validate_record(self):
         fvalid = {
@@ -704,19 +696,19 @@ class LineWritingTest(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_write_one(self):
-        self.assertEqual(len(self.sink), 0)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 0
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
         f = {
             'geometry': {'type': 'LineString',
                          'coordinates': [(0.0, 0.1), (0.0, 0.2)]},
             'properties': {'title': 'line one', 'date': "2012-01-29"}}
         self.sink.writerecords([f])
-        self.assertEqual(len(self.sink), 1)
-        self.assertEqual(self.sink.bounds, (0.0, 0.1, 0.0, 0.2))
+        assert len(self.sink) == 1
+        assert self.sink.bounds == (0.0, 0.1, 0.0, 0.2)
 
     def test_write_two(self):
-        self.assertEqual(len(self.sink), 0)
-        self.assertEqual(self.sink.bounds, (0.0, 0.0, 0.0, 0.0))
+        assert len(self.sink) == 0
+        assert self.sink.bounds == (0.0, 0.0, 0.0, 0.0)
         f1 = {
             'geometry': {'type': 'LineString',
                          'coordinates': [(0.0, 0.1), (0.0, 0.2)]},
@@ -727,8 +719,8 @@ class LineWritingTest(unittest.TestCase):
                                          [(0.0, -0.1), (0.0, -0.2)]]},
             'properties': {'title': 'line two', 'date': "2012-01-29"}}
         self.sink.writerecords([f1, f2])
-        self.assertEqual(len(self.sink), 2)
-        self.assertEqual(self.sink.bounds, (0.0, -0.2, 0.0, 0.2))
+        assert len(self.sink) == 2
+        assert self.sink.bounds == (0.0, -0.2, 0.0, 0.2)
 
 
 @pytest.mark.usefixtures("unittest_path_coutwildrnp_shp")
@@ -754,7 +746,7 @@ class PointAppendTest(unittest.TestCase):
 
     def test_append_point(self):
         with fiona.open(os.path.join(self.tempdir, "test_append_point.shp"), "a") as c:
-            self.assertEqual(c.schema['geometry'], '3D Point')
+            assert c.schema['geometry'] == '3D Point'
             c.write({'geometry': {'type': 'Point', 'coordinates': (0.0, 45.0)},
                      'properties': {'PERIMETER': 1.0,
                                     'FEATURE2': None,
@@ -766,7 +758,7 @@ class PointAppendTest(unittest.TestCase):
                                     'STATE_FIPS': 1,
                                     'WILDRNP020': 1,
                                     'STATE': 'XL'}})
-            self.assertEqual(len(c), 68)
+            assert len(c) == 68
 
 
 class LineAppendTest(unittest.TestCase):
@@ -791,7 +783,7 @@ class LineAppendTest(unittest.TestCase):
 
     def test_append_line(self):
         with fiona.open(os.path.join(self.tempdir, "test_append_line.shp"), "a") as c:
-            self.assertEqual(c.schema['geometry'], 'LineString')
+            assert c.schema['geometry'] == 'LineString'
             f1 = {
                 'geometry': {'type': 'LineString',
                              'coordinates': [(0.0, 0.1), (0.0, 0.2)]},
@@ -802,8 +794,8 @@ class LineAppendTest(unittest.TestCase):
                                              [(0.0, -0.1), (0.0, -0.2)]]},
                 'properties': {'title': 'line two', 'date': "2012-01-29"}}
             c.writerecords([f1, f2])
-            self.assertEqual(len(c), 3)
-            self.assertEqual(c.bounds, (0.0, -0.2, 0.0, 0.2))
+            assert len(c) == 3
+            assert c.bounds == (0.0, -0.2, 0.0, 0.2)
 
 
 class ShapefileFieldWidthTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -35,58 +35,60 @@ class SupportedDriversTest(unittest.TestCase):
 class CollectionArgsTest(unittest.TestCase):
 
     def test_path(self):
-        self.assertRaises(TypeError, Collection, (0))
+        with pytest.raises(TypeError):
+            Collection(0)
 
     def test_mode(self):
-        self.assertRaises(TypeError, Collection, ("foo"), mode=0)
+        with pytest.raises(TypeError):
+            Collection("foo", mode=0)
 
     def test_driver(self):
-        self.assertRaises(TypeError, Collection, ("foo"), mode='w', driver=1)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='w', driver=1)
 
     def test_schema(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='w',
-            driver="ESRI Shapefile", schema=1)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='w', driver="ESRI Shapefile", schema=1)
 
     def test_crs(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='w',
-            driver="ESRI Shapefile", schema=0, crs=1)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='w', driver="ESRI Shapefile", schema=0,
+                       crs=1)
 
     def test_encoding(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='r',
-            encoding=1)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='r', encoding=1)
 
     def test_layer(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='r',
-            layer=0.5)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='r', layer=0.5)
 
     def test_vsi(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='r',
-            vsi='git')
+        with pytest.raises(TypeError):
+            Collection("foo", mode='r', vsi='git')
 
     def test_archive(self):
-        self.assertRaises(
-            TypeError, Collection, ("foo"), mode='r',
-            archive=1)
+        with pytest.raises(TypeError):
+            Collection("foo", mode='r', archive=1)
 
     def test_write_numeric_layer(self):
-        self.assertRaises(ValueError, Collection, ("foo"), mode='w', layer=1)
+        with pytest.raises(ValueError):
+            Collection("foo", mode='w', layer=1)
 
     def test_write_geojson_layer(self):
-        self.assertRaises(ValueError, Collection, ("foo"), mode='w', driver='GeoJSON', layer='foo')
+        with pytest.raises(ValueError):
+            Collection("foo", mode='w', driver='GeoJSON', layer='foo')
 
     def test_append_geojson(self):
-        self.assertRaises(ValueError, Collection, ("foo"), mode='w', driver='ARCGEN')
+        with pytest.raises(ValueError):
+            Collection("foo", mode='w', driver='ARCGEN')
 
 
 class OpenExceptionTest(unittest.TestCase):
 
     def test_no_archive(self):
-        self.assertRaises(DriverError, fiona.open, ("/"), mode='r', vfs="zip:///foo.zip")
+        with pytest.raises(DriverError):
+            fiona.open("/", mode='r', vfs="zip:///foo.zip")
 
 
 @pytest.mark.usefixtures("unittest_path_coutwildrnp_shp")
@@ -128,7 +130,8 @@ class ReadingTest(unittest.TestCase):
 
     def test_closed_no_iter(self):
         self.c.close()
-        self.assertRaises(ValueError, iter, self.c)
+        with pytest.raises(ValueError):
+            iter(self.c)
 
     def test_len(self):
         assert len(self.c) == 67
@@ -245,7 +248,8 @@ class ReadingTest(unittest.TestCase):
         assert f['id'] == "2"
 
     def test_no_write(self):
-        self.assertRaises(IOError, self.c.write, {})
+        with pytest.raises(IOError):
+            self.c.write({})
 
     def test_iter_items_list(self):
         i, f = list(self.c.items())[0]
@@ -304,7 +308,7 @@ class IgnoreFieldsAndGeometryTest(unittest.TestCase):
             pass
 
     def test_ignore_invalid_field_not_string(self):
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             with fiona.open(self.path_coutwildrnp_shp, "r", ignore_fields=[42]):
                 pass
 
@@ -359,9 +363,9 @@ class UnsupportedDriverTest(unittest.TestCase):
         schema = {
             'geometry': 'Point',
             'properties': {'label': 'str', u'verit\xe9': 'int'}}
-        self.assertRaises(
-            DriverError,
-            fiona.open, os.path.join(TEMPDIR, "foo"), "w", "Bogus", schema=schema)
+        with pytest.raises(DriverError):
+            fiona.open(os.path.join(TEMPDIR, "foo"), "w", "Bogus",
+                       schema=schema)
 
 
 class GenericWritingTest(unittest.TestCase):
@@ -387,10 +391,12 @@ class GenericWritingTest(unittest.TestCase):
         assert self.c.encoding == 'Windows-1252'
 
     def test_no_iter(self):
-        self.assertRaises(IOError, iter, self.c)
+        with pytest.raises(IOError):
+            iter(self.c)
 
     def test_no_filter(self):
-        self.assertRaises(IOError, self.c.filter)
+        with pytest.raises(IOError):
+            self.c.filter()
 
 
 class PropertiesNumberFormattingTest(unittest.TestCase):
@@ -822,23 +828,29 @@ class ShapefileFieldWidthTest(unittest.TestCase):
 class CollectionTest(unittest.TestCase):
 
     def test_invalid_mode(self):
-        self.assertRaises(ValueError, fiona.open, os.path.join(TEMPDIR, "bogus.shp"), "r+")
+        with pytest.raises(ValueError):
+            fiona.open(os.path.join(TEMPDIR, "bogus.shp"), "r+")
 
     def test_w_args(self):
-        self.assertRaises(FionaValueError, fiona.open, os.path.join(TEMPDIR, "test-no-iter.shp"), "w")
-        self.assertRaises(
-            FionaValueError, fiona.open, os.path.join(TEMPDIR, "test-no-iter.shp"), "w", "Driver")
+        with pytest.raises(FionaValueError):
+            fiona.open(os.path.join(TEMPDIR, "test-no-iter.shp"), "w")
+        with pytest.raises(FionaValueError):
+            fiona.open(os.path.join(TEMPDIR, "test-no-iter.shp"), "w",
+                       "Driver")
 
     def test_no_path(self):
-        self.assertRaises(Exception, fiona.open, "no-path.shp", "a")
+        with pytest.raises(Exception):
+            fiona.open("no-path.shp", "a")
 
     def test_no_read_conn_str(self):
-        self.assertRaises(DriverError, fiona.open, "PG:dbname=databasename", "r")
+        with pytest.raises(DriverError):
+            fiona.open("PG:dbname=databasename", "r")
 
     @pytest.mark.skipif(sys.platform.startswith("win"),
                      reason="test only for *nix based system")
     def test_no_read_directory(self):
-        self.assertRaises(DriverError, fiona.open, "/dev/null", "r")
+        with pytest.raises(DriverError):
+            fiona.open("/dev/null", "r")
 
 
 class GeoJSONCRSWritingTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -24,11 +24,11 @@ TEMPDIR = tempfile.gettempdir()
 class SupportedDriversTest(unittest.TestCase):
 
     def test_shapefile(self):
-        self.assertTrue("ESRI Shapefile" in supported_drivers)
+        assert "ESRI Shapefile" in supported_drivers
         assert set(supported_drivers["ESRI Shapefile"]) == set("raw")
 
     def test_map(self):
-        self.assertTrue("MapInfo File" in supported_drivers)
+        assert "MapInfo File" in supported_drivers
         assert set(supported_drivers["MapInfo File"]) == set("raw")
 
 
@@ -124,7 +124,7 @@ class ReadingTest(unittest.TestCase):
         assert self.c.encoding == 'iso-8859-1'
 
     def test_iter(self):
-        self.assertTrue(iter(self.c))
+        assert iter(self.c)
 
     def test_closed_no_iter(self):
         self.c.close()
@@ -258,8 +258,8 @@ class ReadingTest(unittest.TestCase):
         assert i == 0
 
     def test_in_keys(self):
-        self.assertTrue(0 in self.c.keys())
-        self.assertTrue(0 in self.c)
+        assert 0 in self.c.keys()
+        assert 0 in self.c
 
 
 @pytest.mark.usefixtures("unittest_path_coutwildrnp_shp")
@@ -674,8 +674,8 @@ class PointWritingTest(unittest.TestCase):
         finvalid = {
             'geometry': {'type': 'Point', 'coordinates': (0.0, -0.1)},
             'properties': {'not-a-title': 'point two', 'date': "2012-01-29"}}
-        self.assertTrue(self.sink.validate_record(fvalid))
-        self.assertFalse(self.sink.validate_record(finvalid))
+        assert self.sink.validate_record(fvalid)
+        assert not self.sink.validate_record(finvalid)
 
 
 class LineWritingTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -204,10 +204,10 @@ class ReadingTest(unittest.TestCase):
                 ['crs', 'crs_wkt', 'driver', 'schema'])
 
     def test_bounds(self):
-        self.assertAlmostEqual(self.c.bounds[0], -113.564247, 6)
-        self.assertAlmostEqual(self.c.bounds[1], 37.068981, 6)
-        self.assertAlmostEqual(self.c.bounds[2], -104.970871, 6)
-        self.assertAlmostEqual(self.c.bounds[3], 41.996277, 6)
+        assert self.c.bounds[0] == pytest.approx(-113.564247)
+        assert self.c.bounds[1] == pytest.approx(37.068981)
+        assert self.c.bounds[2] == pytest.approx(-104.970871)
+        assert self.c.bounds[3] == pytest.approx(41.996277)
 
     def test_context(self):
         with fiona.open(self.path_coutwildrnp_shp, "r") as c:


### PR DESCRIPTION
Something of a corollary to #651 but for collections. It doesn't drop `unittest` entirely, but does drop the use of its class methods.