### PR TITLE
Remove packaging from test requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,5 @@ cython==0.28.3
 pytest==3.4.2
 pytest-cov==2.5.1
 setuptools==39.0.1
-packaging==18.0
 boto3==1.9.19
 wheel==0.31.1

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ if sys.version_info < (3, 4):
 extras_require = {
     'calc': ['shapely'],
     's3': ['boto3>=1.2.4'],
-    'test': ['pytest>=3', 'pytest-cov', 'boto3>=1.2.4', 'packaging'],
+    'test': ['pytest>=3', 'pytest-cov', 'boto3>=1.2.4'],
 }
 
 extras_require['all'] = list(set(it.chain(*extras_require.values())))

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -3,7 +3,6 @@ import sys
 import os
 
 import pytest
-from packaging.version import parse
 import boto3
 
 import fiona


### PR DESCRIPTION
Its only use is an import that is never used for anything.