### PR TITLE
Don't call Python methods from __dealloc__()

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -537,7 +537,7 @@ cdef class Session:
 
         self.collection = collection
 
-    def stop(self):
+    cpdef stop(self):
         self.cogr_layer = NULL
         if self.cogr_ds != NULL:
             GDALClose(self.cogr_ds)


### PR DESCRIPTION
Python methods should not be called from `__dealloc__()` because this may cause object resurrection.

Using `cpdef` directive generates a C version of the method along with Python version, thus solving the problem.

This fixes PyPy compatibility (#553).