### PR TITLE
Refactor discovery of GDAL and PROJ data

### DIFF
--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -186,6 +186,59 @@ cdef class ConfigEnv(object):
         return {k: get_gdal_config(k) for k in self.options}
 
 
+class GDALDataFinder(object):
+    """Finds GDAL and PROJ data files"""
+
+    def search(self, prefix=None):
+        """Returns GDAL_DATA location"""
+        path = self.search_wheel(prefix or __file__)
+        if not path:
+            path = self.search_prefix(prefix or sys.prefix)
+            if not path:
+                path = self.search_debian(prefix or sys.prefix)
+        return path
+
+    def search_wheel(self, prefix=None):
+        """Check wheel location"""
+        if prefix is None:
+            prefix = __file__
+        datadir = os.path.abspath(os.path.join(os.path.dirname(prefix), "gdal_data"))
+        return datadir if os.path.exists(os.path.join(datadir, 'pcs.csv')) else None
+
+    def search_prefix(self, prefix=sys.prefix):
+        """Check sys.prefix location"""
+        datadir = os.path.join(prefix, 'share/gdal')
+        return datadir if os.path.exists(os.path.join(datadir, 'pcs.csv')) else None
+
+    def search_debian(self, prefix=sys.prefix):
+        """Check Debian locations"""
+        gdal_release_name = GDALVersionInfo("RELEASE_NAME")
+        datadir = os.path.join(prefix, 'share/gdal', '{}.{}'.format(*gdal_release_name.split('.')[:2]))
+        return datadir if os.path.exists(os.path.join(datadir, 'pcs.csv')) else None
+
+
+class PROJDataFinder(object):
+
+    def search(self, prefix=None):
+        """Returns PROJ_LIB location"""
+        path = self.search_wheel(prefix or __file__)
+        if not path:
+            path = self.search_prefix(prefix or sys.prefix)
+        return path
+
+    def search_wheel(self, prefix=None):
+        """Check wheel location"""
+        if prefix is None:
+            prefix = __file__
+        datadir = os.path.abspath(os.path.join(os.path.dirname(prefix), "proj_data"))
+        return datadir if os.path.exists(datadir) else None
+
+    def search_prefix(self, prefix=sys.prefix):
+        """Check sys.prefix location"""
+        datadir = os.path.join(prefix, 'share/proj')
+        return datadir if os.path.exists(datadir) else None
+
+
 cdef class GDALEnv(ConfigEnv):
     """Configuration and driver management"""
 
@@ -210,40 +263,22 @@ cdef class GDALEnv(ConfigEnv):
 
                     if 'GDAL_DATA' not in os.environ:
 
-                        # We will try a few well-known paths, starting with the
-                        # official wheel path.
-                        whl_datadir = os.path.abspath(
-                            os.path.join(os.path.dirname(__file__), "gdal_data"))
-                        fhs_share_datadir = os.path.join(sys.prefix, 'share/gdal')
+                        path = GDALDataFinder().search()
 
-                        # Debian supports multiple GDAL installs.
-                        gdal_release_name = GDALVersionInfo("RELEASE_NAME")
-                        deb_share_datadir = os.path.join(
-                            fhs_share_datadir,
-                            "{}.{}".format(*gdal_release_name.split('.')[:2]))
+                        if path:
+                            log.debug("GDAL data found in %r", path)
+                            self.update_config_options(GDAL_DATA=path)
 
-                        # If we find GDAL data at the well-known paths, we will
-                        # add a GDAL_DATA key to the config options dict.
-                        if os.path.exists(os.path.join(whl_datadir, 'pcs.csv')):
-                            self.update_config_options(GDAL_DATA=whl_datadir)
-
-                        elif os.path.exists(os.path.join(deb_share_datadir, 'pcs.csv')):
-                            self.update_config_options(GDAL_DATA=deb_share_datadir)
-
-                        elif os.path.exists(os.path.join(fhs_share_datadir, 'pcs.csv')):
-                            self.update_config_options(GDAL_DATA=fhs_share_datadir)
+                    else:
+                        self.update_config_options(GDAL_DATA=os.environ['GDAL_DATA'])
 
                     if 'PROJ_LIB' not in os.environ:
 
-                        whl_datadir = os.path.abspath(
-                            os.path.join(os.path.dirname(__file__), 'proj_data'))
-                        share_datadir = os.path.join(sys.prefix, 'share/proj')
+                        path = PROJDataFinder().search()
 
-                        if os.path.exists(whl_datadir):
-                            os.environ['PROJ_LIB'] = whl_datadir
-
-                        elif os.path.exists(share_datadir):
-                            os.environ['PROJ_LIB'] = share_datadir
+                        if path:
+                            log.debug("PROJ data found in %r", path)
+                            os.environ['PROJ_LIB'] = path
 
                     if driver_count() == 0:
                         CPLPopErrorHandler()

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -16,6 +16,8 @@ import os.path
 import sys
 import threading
 
+from fiona.ogrext import get_gdal_version_tuple
+
 
 level_map = {
     0: 0,
@@ -212,8 +214,8 @@ class GDALDataFinder(object):
 
     def search_debian(self, prefix=sys.prefix):
         """Check Debian locations"""
-        gdal_release_name = GDALVersionInfo("RELEASE_NAME")
-        datadir = os.path.join(prefix, 'share/gdal', '{}.{}'.format(*gdal_release_name.split('.')[:2]))
+        gdal_version = get_gdal_version_tuple()
+        datadir = os.path.join(prefix, 'share/gdal/{}.{}'.format(gdal_version.major, gdal_version.minor))
         return datadir if os.path.exists(os.path.join(datadir, 'pcs.csv')) else None
 
 

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -11,7 +11,7 @@ from .conftest import gdal_version
 def mock_wheel(tmpdir):
     """A fake rasterio wheel"""
     moduledir = tmpdir.mkdir("rasterio")
-    moduledir.ensure("__init__,py")
+    moduledir.ensure("__init__.py")
     moduledir.ensure("_env.py")
     moduledir.ensure("gdal_data/pcs.csv")
     moduledir.ensure("proj_data/epsg")

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -72,7 +72,7 @@ def test_search_debian_gdal_data_failure(tmpdir):
 def test_search_debian_gdal_data(mock_debian):
     """Find GDAL data under Debian locations"""
     finder = GDALDataFinder()
-    assert finder.search_debian(str(mock_debian)) == str(mock_debian.join("share/gdal/{}".format(str(gdal_version))))
+    assert finder.search_debian(str(mock_debian)) == str(mock_debian.join("share/gdal/{}.{}".format(gdal_version.major, gdal_version.minor)))
 
 
 def test_search_gdal_data_wheel(mock_wheel):
@@ -88,7 +88,7 @@ def test_search_gdal_data_fhs(mock_fhs):
 def test_search_gdal_data_debian(mock_debian):
     """Find GDAL data under Debian locations"""
     finder = GDALDataFinder()
-    assert finder.search(str(mock_debian)) == str(mock_debian.join("share/gdal/{}".format(str(gdal_version))))
+    assert finder.search(str(mock_debian)) == str(mock_debian.join("share/gdal/{}.{}".format(gdal_version.major, gdal_version.minor)))
 
 
 def test_search_wheel_proj_data_failure(tmpdir):

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -1,0 +1,125 @@
+"""Tests of _env util module"""
+
+import pytest
+
+from fiona._env import GDALDataFinder, PROJDataFinder
+
+from .conftest import gdal_version
+
+
+@pytest.fixture
+def mock_wheel(tmpdir):
+    """A fake rasterio wheel"""
+    moduledir = tmpdir.mkdir("rasterio")
+    moduledir.ensure("__init__,py")
+    moduledir.ensure("_env.py")
+    moduledir.ensure("gdal_data/pcs.csv")
+    moduledir.ensure("proj_data/epsg")
+    return moduledir
+
+
+@pytest.fixture
+def mock_fhs(tmpdir):
+    """A fake FHS system"""
+    tmpdir.ensure("share/gdal/pcs.csv")
+    tmpdir.ensure("share/proj/epsg")
+    return tmpdir
+
+
+@pytest.fixture
+def mock_debian(tmpdir):
+    """A fake Debian multi-install system"""
+    tmpdir.ensure("share/gdal/1.11/pcs.csv")
+    tmpdir.ensure("share/gdal/2.0/pcs.csv")
+    tmpdir.ensure("share/gdal/2.1/pcs.csv")
+    tmpdir.ensure("share/gdal/2.2/pcs.csv")
+    tmpdir.ensure("share/gdal/2.3/pcs.csv")
+    tmpdir.ensure("share/gdal/2.4/pcs.csv")
+    tmpdir.ensure("share/proj/epsg")
+    return tmpdir
+
+
+def test_search_wheel_gdal_data_failure(tmpdir):
+    """Fail to find GDAL data in a non-wheel"""
+    finder = GDALDataFinder()
+    assert not finder.search_wheel(str(tmpdir))
+
+
+def test_search_wheel_gdal_data(mock_wheel):
+    """Find GDAL data in a wheel"""
+    finder = GDALDataFinder()
+    assert finder.search_wheel(str(mock_wheel.join("_env.py"))) == str(mock_wheel.join("gdal_data"))
+
+
+def test_search_prefix_gdal_data_failure(tmpdir):
+    """Fail to find GDAL data in a bogus prefix"""
+    finder = GDALDataFinder()
+    assert not finder.search_prefix(str(tmpdir))
+
+
+def test_search_prefix_gdal_data(mock_fhs):
+    """Find GDAL data under prefix"""
+    finder = GDALDataFinder()
+    assert finder.search_prefix(str(mock_fhs)) == str(mock_fhs.join("share/gdal"))
+
+
+def test_search_debian_gdal_data_failure(tmpdir):
+    """Fail to find GDAL data in a bogus Debian location"""
+    finder = GDALDataFinder()
+    assert not finder.search_debian(str(tmpdir))
+
+
+def test_search_debian_gdal_data(mock_debian):
+    """Find GDAL data under Debian locations"""
+    finder = GDALDataFinder()
+    assert finder.search_debian(str(mock_debian)) == str(mock_debian.join("share/gdal/{}".format(str(gdal_version))))
+
+
+def test_search_gdal_data_wheel(mock_wheel):
+    finder = GDALDataFinder()
+    assert finder.search(str(mock_wheel.join("_env.py"))) == str(mock_wheel.join("gdal_data"))
+
+
+def test_search_gdal_data_fhs(mock_fhs):
+    finder = GDALDataFinder()
+    assert finder.search(str(mock_fhs)) == str(mock_fhs.join("share/gdal"))
+
+
+def test_search_gdal_data_debian(mock_debian):
+    """Find GDAL data under Debian locations"""
+    finder = GDALDataFinder()
+    assert finder.search(str(mock_debian)) == str(mock_debian.join("share/gdal/{}".format(str(gdal_version))))
+
+
+def test_search_wheel_proj_data_failure(tmpdir):
+    """Fail to find GDAL data in a non-wheel"""
+    finder = PROJDataFinder()
+    assert not finder.search_wheel(str(tmpdir))
+
+
+def test_search_wheel_proj_data(mock_wheel):
+    """Find GDAL data in a wheel"""
+    finder = PROJDataFinder()
+    assert finder.search_wheel(str(mock_wheel.join("_env.py"))) == str(mock_wheel.join("proj_data"))
+
+
+def test_search_prefix_proj_data_failure(tmpdir):
+    """Fail to find GDAL data in a bogus prefix"""
+    finder = PROJDataFinder()
+    assert not finder.search_prefix(str(tmpdir))
+
+
+def test_search_prefix_proj_data(mock_fhs):
+    """Find GDAL data under prefix"""
+    finder = PROJDataFinder()
+    assert finder.search_prefix(str(mock_fhs)) == str(mock_fhs.join("share/proj"))
+
+
+def test_search_proj_data_wheel(mock_wheel):
+    finder = PROJDataFinder()
+    assert finder.search(str(mock_wheel.join("_env.py"))) == str(mock_wheel.join("proj_data"))
+
+
+def test_search_proj_data_fhs(mock_fhs):
+    finder = PROJDataFinder()
+    assert finder.search(str(mock_fhs)) == str(mock_fhs.join("share/proj"))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,16 +1,20 @@
 """Tests of fiona.env"""
 
+import os
+import sys
+
 import pytest
 
 import fiona
-import fiona.env
+from fiona import _env
+from fiona.env import getenv, ensure_env, ensure_env_with_credentials
 from fiona.session import AWSSession
 
 
 def test_nested_credentials(monkeypatch):
     """Check that rasterio.open() doesn't wipe out surrounding credentials"""
 
-    @fiona.env.ensure_env_with_credentials
+    @ensure_env_with_credentials
     def fake_opener(path):
         return fiona.env.getenv()
 
@@ -23,3 +27,46 @@ def test_nested_credentials(monkeypatch):
         gdalenv = fake_opener('s3://foo/bar')
         assert gdalenv['AWS_ACCESS_KEY_ID'] == 'foo'
         assert gdalenv['AWS_SECRET_ACCESS_KEY'] == 'bar'
+
+
+def test_ensure_env_decorator(gdalenv):
+    @ensure_env
+    def f():
+        return getenv()['RASTERIO_ENV']
+    assert f() is True
+
+
+def test_ensure_env_decorator_sets_gdal_data(gdalenv, monkeypatch):
+    """fiona.env.ensure_env finds GDAL from environment"""
+    @ensure_env
+    def f():
+        return getenv()['GDAL_DATA']
+
+    monkeypatch.setenv('GDAL_DATA', '/lol/wut')
+    assert f() == '/lol/wut'
+
+
+def test_ensure_env_decorator_sets_gdal_data_prefix(gdalenv, monkeypatch, tmpdir):
+    """fiona.env.ensure_env finds GDAL data under a prefix"""
+    @ensure_env
+    def f():
+        return getenv()['GDAL_DATA']
+
+    tmpdir.ensure("share/gdal/pcs.csv")
+    monkeypatch.delenv('GDAL_DATA', raising=False)
+    monkeypatch.setattr(sys, 'prefix', str(tmpdir))
+
+    assert f() == str(tmpdir.join("share/gdal"))
+
+
+def test_ensure_env_decorator_sets_gdal_data_wheel(gdalenv, monkeypatch, tmpdir):
+    """fiona.env.ensure_env finds GDAL data in a wheel"""
+    @ensure_env
+    def f():
+        return getenv()['GDAL_DATA']
+
+    tmpdir.ensure("gdal_data/pcs.csv")
+    monkeypatch.delenv('GDAL_DATA', raising=False)
+    monkeypatch.setattr(_env, '__file__', str(tmpdir.join(os.path.basename(_env.__file__))))
+
+    assert f() == str(tmpdir.join("gdal_data"))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -70,3 +70,16 @@ def test_ensure_env_decorator_sets_gdal_data_wheel(gdalenv, monkeypatch, tmpdir)
     monkeypatch.setattr(_env, '__file__', str(tmpdir.join(os.path.basename(_env.__file__))))
 
     assert f() == str(tmpdir.join("gdal_data"))
+
+
+def test_ensure_env_with_decorator_sets_gdal_data_wheel(gdalenv, monkeypatch, tmpdir):
+    """fiona.env.ensure_env finds GDAL data in a wheel"""
+    @ensure_env_with_credentials
+    def f(*args):
+        return getenv()['GDAL_DATA']
+
+    tmpdir.ensure("gdal_data/pcs.csv")
+    monkeypatch.delenv('GDAL_DATA', raising=False)
+    monkeypatch.setattr(_env, '__file__', str(tmpdir.join(os.path.basename(_env.__file__))))
+
+    assert f("foo") == str(tmpdir.join("gdal_data"))


### PR DESCRIPTION
Towards resolving #673.

I've created GDAL and PROJ data finder classes to make the process more testable and to make it possible to test the correctness of our environment ensuring decorators by monkeypatching `sys.prefix` and `rasterio._env.__file__`.

A `GDAL_DATA` environment variable short-circuits the data search, as it did before.