### PR TITLE
Add google cloud storage support

### DIFF
--- a/fiona/path.py
+++ b/fiona/path.py
@@ -17,13 +17,14 @@ SCHEMES = {
     's3': 's3',
     'tar': 'tar',
     'zip': 'zip',
-    'file': 'file'
+    'file': 'file',
+    'gs': 'gs',
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'gs')])
 
 
 class Path(object):

--- a/fiona/session.py
+++ b/fiona/session.py
@@ -186,3 +186,52 @@ class AWSSession(Session):
             return {'AWS_NO_SIGN_REQUEST': 'YES'}
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
+
+class GSSession(Session):
+    """Configures access to secured resources stored in Google Cloud Storage
+    """
+    def __init__(self, google_application_credentials=None):
+        """Create new Google Cloude Storage session
+
+        Parameters
+        ----------
+        google_application_credentials: string
+            Path to the google application credentials JSON file.
+        """
+
+        self._creds = {}
+        if google_application_credentials is not None:
+            self._creds['google_application_credentials'] = google_application_credentials
+
+    @classmethod
+    def hascreds(cls, config):
+        """Determine if the given configuration has proper credentials
+
+        Parameters
+        ----------
+        cls : class
+            A Session class.
+        config : dict
+            GDAL configuration as a dict.
+
+        Returns
+        -------
+        bool
+
+        """
+        return 'GOOGLE_APPLICATION_CREDENTIALS' in config
+
+    @property
+    def credentials(self):
+        """The session credentials as a dict"""
+        return self._creds
+
+    def get_credential_options(self):
+        """Get credentials as GDAL configuration options
+
+        Returns
+        -------
+        dict
+
+        """
+        return {k.upper(): v for k, v in self.credentials.items()}

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -16,12 +16,13 @@ SCHEMES = {
     's3': 's3',
     'tar': 'tar',
     'zip': 'zip',
+    'gs': 'gs',
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'gs')])
 
 
 def valid_vsi(vsi):


### PR DESCRIPTION
Adds the appropriate prefix to support Google Cloud Storage.

Requires support in GDAL (2.3 or newer).