### PR TITLE
Add io module to sphinx documentation

### DIFF
--- a/docs/fiona.rst
+++ b/docs/fiona.rst
@@ -51,6 +51,14 @@ fiona.errors module
     :undoc-members:
     :show-inheritance:
 
+fiona.io module
+---------------
+
+.. automodule:: fiona.io
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 fiona.inspector module
 ----------------------
 


### PR DESCRIPTION
`io` module was missing in the online docs