### PR TITLE
remove per-feature logging to improve performance issue#685

### DIFF
--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -283,7 +283,7 @@ cdef class OGRGeomBuilder:
             coordinates = geometry.get('geometries')
             return self._buildGeometryCollection(coordinates)
         else:
-            raise ValueError("Unsupported geometry type %s" % typename)
+            raise UnsupportedGeometryTypeError("Unsupported geometry type %s" % typename)
 
 
 def geometryRT(geometry):

--- a/fiona/compat.py
+++ b/fiona/compat.py
@@ -1,5 +1,5 @@
-import sys
 import collections
+import sys
 
 try:
     from collections import OrderedDict
@@ -24,3 +24,11 @@ else:
 # More specifically, rasterio has a CRS() class that subclasses UserDict()
 # In Python 2 UserDict() is in its own module and does not subclass Mapping()
 DICT_TYPES = (dict, Mapping, UserDict)
+
+
+def strencode(instr, encoding="utf-8"):
+    try:
+        instr = instr.encode(encoding)
+    except (UnicodeDecodeError, AttributeError):
+        pass
+    return instr

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1141,7 +1141,7 @@ cdef class WritingSession(Session):
                         collection.schema['geometry'] ))
             # Validate against collection's schema to give useful message
             if set(record['properties'].keys()) != schema_props_keys:
-                raise ValueError(
+                raise SchemaError(
                     "Record does not match collection schema: %r != %r" % (
                         record['properties'].keys(),
                         list(schema_props_keys) ))

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from fiona._geometry import (GeomBuilder, geometryRT)
+from fiona._geometry import GeomBuilder, geometryRT
 from fiona.errors import UnsupportedGeometryTypeError
 
 
@@ -16,7 +16,7 @@ def geometry_wkb(wkb):
 
 def test_ogr_builder_exceptions():
     geom = {'type': "Bogus", 'coordinates': None}
-    with pytest.raises(ValueError):
+    with pytest.raises(UnsupportedGeometryTypeError):
         geometryRT(geom)
 
 


### PR DESCRIPTION
I saw the issue #685, and so I took a stab at it based on the discussion to see if I could help move things forward.

I commented out the debug print statements instead of deleting them so that you don't have to re-create them when you are debugging (and an official decision on what to do with them has not been reached as far as I know). However, that presents the danger of being re-introduced by accident when committing changes after debugging.

Using this example:
```python
from itertools import chain, repeat
import fiona
def test_to_file():
    with fiona.Env(),fiona.open("../tests/data/coutwildrnp.shp") as collection:
        features = chain.from_iterable(repeat(list(collection), 2000))
        with fiona.open("/tmp/out.gpkg", "w", schema=collection.schema, crs=collection.crs, driver="GPKG") as dst:
            dst.writerecords(features)
```
And timing it:
```python
%%timeit
test_to_file()
```

Before:
1min 3s ± 2.32 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
After:
15.3 s ± 1.13 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
