### PR TITLE
Filling Range Gaps

### DIFF
--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -69,10 +69,10 @@ cdef unsigned int geometry_type_code(name) except? 9999:
 cdef object normalize_geometry_type_code(unsigned int code):
     """Normalize M geometry type codes."""
     # Normalize 'M' types to 2D types.
-    if 2000 < code < 3000:
+    if 2000 <= code < 3000:
         code = code % 1000
     # Normalize 'ZM' types to 3D types.
-    elif 3000 < code < 4000:
+    elif 3000 <= code < 4000:
         code = (code % 1000) | 0x80000000
     if code not in GEOMETRY_TYPES:
         raise UnsupportedGeometryTypeError(code)


### PR DESCRIPTION
error occured loading gpkg file containing polygons same file worked fine with previous versions of fiona failure points to this pyx file extending the ranges to have no gaps would stop error being raised and allow code to run. modulo would be 0 returning unknown rather than unsupported.