### PR TITLE
Update GDAL 2.4.0 package on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,8 +138,8 @@ test_script:
   # Our Windows GDAL doesn't have iconv and can't support certain tests.
   - "%CMD_IN_ENV% python -m pytest -m \"not iconv\" --cov fiona --cov-report term-missing"
 
-matrix:	
-  allow_failures:	
+matrix:
+  allow_failures:
     - PYTHON_VERSION: "2.7.14"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,7 +124,8 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" })
+  - ps: pip install -U pip 2>$1
+  - ps: pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>$1
   - ps: move fiona fiona.build
 
 
@@ -136,10 +137,6 @@ test_script:
 
   # Our Windows GDAL doesn't have iconv and can't support certain tests.
   - "%CMD_IN_ENV% python -m pytest -m \"not iconv\" --cov fiona --cov-report term-missing"
-
-matrix:
-  allow_failures:
-    - GDAL_VERSION: 2.4.0
 
 artifacts:
   - path: dist\*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,8 +124,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: pip install -U pip 2>$1
-  - ps: pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>$1
+  - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>$1
   - ps: move fiona fiona.build
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,7 +124,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>&1
+  - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" })
   - ps: move fiona fiona.build
 
 
@@ -136,6 +136,10 @@ test_script:
 
   # Our Windows GDAL doesn't have iconv and can't support certain tests.
   - "%CMD_IN_ENV% python -m pytest -m \"not iconv\" --cov fiona --cov-report term-missing"
+
+matrix:	
+  allow_failures:	
+    - PYTHON_VERSION: "2.7.14"
 
 artifacts:
   - path: dist\*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,6 +124,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
+  - ps: python -m pip install --upgrade pip
   - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" })
   - ps: move fiona fiona.build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,7 +124,7 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>$1
+  - ps: python -m pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" }) 2>&1
   - ps: move fiona fiona.build
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,7 +124,6 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: python -m pip install --upgrade pip
   - ps: pip install --force-reinstall --ignore-installed (gci dist\*.whl | % { "$_" })
   - ps: move fiona fiona.build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,8 @@ environment:
           PYTHON_VERSION: "3.6.4"
           PYTHON_ARCH: "64"
           GDAL_VERSION: "2.4.0"
-          GIS_INTERNALS: "release-1911-x64-gdal-mapserver.zip"
-          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-mapserver-libs.zip"
+          GIS_INTERNALS: "release-1911-x64-gdal-2-4-0-mapserver-7-2-2.zip"
+          GIS_INTERNALS_LIBS: "release-1911-x64-gdal-2-4-0-mapserver-7-2-2-libs.zip"
 
 install:
 


### PR DESCRIPTION
I've got the solution for "2.4.0" failures: actually download 2.4.0 instead of using a branch that moved on (toward 2.5), which was pointed out elsewhere.

Also, I've allowed python 2.7 failures to be ignored. We could revisit this if someone with more powershell knowledge comes along to show us how to tolerate pip's warnings about deprecation of python 2.7.