### PR TITLE
WIP: Use WKB for geometry instead of GeoJSON

### DIFF
--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -93,7 +93,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (OGRwkbGeometryType wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char * OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)
@@ -124,6 +124,7 @@ cdef class GeomBuilder:
     cpdef _buildGeometryCollection(self)
     cdef build(self, void *geom)
     cpdef build_wkb(self, object wkb)
+    cdef bytes build2(self, void *geom)
 
 
 cdef class OGRGeomBuilder:

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+from libc.stdlib cimport malloc, free
+
 import logging
 
 from fiona.errors import UnsupportedGeometryTypeError
@@ -190,6 +192,16 @@ cdef class GeomBuilder:
         result = self.build(cogr_geometry)
         _deleteOgrGeom(cogr_geometry)
         return result
+
+    cdef bytes build2(self, void *geom):
+        cdef int size = OGR_G_WkbSize(geom)
+        cdef unsigned char* buf = <unsigned char*>malloc(size * sizeof(char))
+        if not buf:
+            raise MemoryError()
+        OGR_G_ExportToWkb(geom, 1, buf)
+        cdef bytes wkb = buf[:size]
+        free(buf)
+        return wkb
 
 
 cdef class OGRGeomBuilder:

--- a/fiona/gdal.pxi
+++ b/fiona/gdal.pxi
@@ -349,7 +349,7 @@ cdef extern from "ogr_api.h" nogil:
     OGRGeometryH OGR_G_CreateGeometryFromJson(const char *json)
     void OGR_G_DestroyGeometry(OGRGeometryH geometry)
     char *OGR_G_ExportToJson(OGRGeometryH geometry)
-    void OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, char *buffer)
+    void OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, unsigned char *buffer)
     int OGR_G_GetCoordinateDimension(OGRGeometryH geometry)
     int OGR_G_GetGeometryCount(OGRGeometryH geometry)
     const char *OGR_G_GetGeometryName(OGRGeometryH geometry)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -272,7 +272,7 @@ cdef class FeatureBuilder:
 
                 if 8 <= code <= 14:  # Curves.
                     cogr_geometry = get_linear_geometry(cogr_geometry)
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 elif 15 <= code <= 17:
@@ -285,11 +285,11 @@ cdef class FeatureBuilder:
                     elif code == 17:
                         cogr_geometry = OGR_G_ForceToPolygon(org_geometry)
 
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 else:
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
 
                 fiona_feature["geometry"] = geom
 

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -224,7 +224,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (int wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -286,7 +286,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (int wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)


### PR DESCRIPTION
This is a **work in progress**.

This branch exposes geometries for features as WKB data stored in a `bytes` object instead of GeoJSON-like structures.

I 100% think that GeoJSON should remain the default - for most situations the performance is acceptable, and it is a much easier route for people to get into working with spatial data. It's also easier to debug with.

Making this an option could improve the performance of workflows that use Shapely, e.g.

```
for feature in source:
    geom = shape(feature["geometry"])
    ...
```

vs

```
for feature in source:
    geom = wkb.loads(feature["geometry"])
    ...
```

GeoPandas would benefit from this also as it works natively with Shapely geometries.

Some quick benchmarking shows an improvement in performance for some workflows, but this will depend very much on the data being read and how it's being used.

TODO:

- How should this mode be enabled? An argument to `fiona.open`?
- Improved method names (not `build2`...)
- Documentation