### PR TITLE
Implement transform function that accepts WKB

### DIFF
--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -124,7 +124,10 @@ cdef class GeomBuilder:
     cpdef _buildGeometryCollection(self)
     cdef build(self, void *geom)
     cpdef build_wkb(self, object wkb)
-    cdef bytes build2(self, void *geom)
+
+
+cdef class WKBGeomBuilder:
+    cdef bytes build(self, void *geom)
 
 
 cdef class OGRGeomBuilder:

--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -93,7 +93,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (OGRwkbGeometryType wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char * OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)
@@ -124,6 +124,7 @@ cdef class GeomBuilder:
     cpdef _buildGeometryCollection(self)
     cdef build(self, void *geom)
     cpdef build_wkb(self, object wkb)
+    cdef bytes build2(self, void *geom)
 
 
 cdef class OGRGeomBuilder:

--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -138,9 +138,8 @@ cdef class OGRGeomBuilder:
     cdef void * _buildMultiPolygon(self, object coordinates) except NULL
     cdef void * _buildGeometryCollection(self, object coordinates) except NULL
     cdef void * build(self, object geom) except NULL
-
+    cdef void * build_wkb(self, object wkb) except NULL
 
 cdef unsigned int geometry_type_code(object name) except? 9999
 cdef object normalize_geometry_type_code(unsigned int code)
 cdef unsigned int base_geometry_type_code(unsigned int code)
-

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -193,8 +193,12 @@ cdef class GeomBuilder:
         _deleteOgrGeom(cogr_geometry)
         return result
 
-    cdef bytes build2(self, void *geom):
-        cdef int size = OGR_G_WkbSize(geom)
+
+cdef class WKBGeomBuilder:
+    """Builds WKB strings from OGR geometries
+    """
+    cdef bytes build_ogr(self, void *geom):
+        size = OGR_G_WkbSize(geom)
         cdef unsigned char* buf = <unsigned char*>malloc(size * sizeof(char))
         if not buf:
             raise MemoryError()
@@ -312,5 +316,13 @@ def geometryRT(geometry):
     # For testing purposes only, leaks the JSON data
     cdef void *cogr_geometry = OGRGeomBuilder().build(geometry)
     result = GeomBuilder().build(cogr_geometry)
+    _deleteOgrGeom(cogr_geometry)
+    return result
+
+
+def geometry_as_wkb(geometry):
+    # For testing purposes
+    cdef void *cogr_geometry = OGRGeomBuilder().build(geometry)
+    result = WKBGeomBuilder().build(cogr_geometry)
     _deleteOgrGeom(cogr_geometry)
     return result

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -197,7 +197,7 @@ cdef class GeomBuilder:
 cdef class WKBGeomBuilder:
     """Builds WKB strings from OGR geometries
     """
-    cdef bytes build_ogr(self, void *geom):
+    cdef bytes build(self, void *geom):
         size = OGR_G_WkbSize(geom)
         cdef unsigned char* buf = <unsigned char*>malloc(size * sizeof(char))
         if not buf:

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+from libc.stdlib cimport malloc, free
+
 import logging
 
 from fiona.errors import UnsupportedGeometryTypeError
@@ -190,6 +192,16 @@ cdef class GeomBuilder:
         result = self.build(cogr_geometry)
         _deleteOgrGeom(cogr_geometry)
         return result
+
+    cdef bytes build2(self, void *geom):
+        cdef int size = OGR_G_WkbSize(geom)
+        cdef unsigned char* buf = <unsigned char*>malloc(size * sizeof(char))
+        if not buf:
+            raise MemoryError()
+        OGR_G_ExportToWkb(geom, 1, buf)
+        cdef bytes wkb = buf[:size]
+        free(buf)
+        return wkb
 
 
 cdef class OGRGeomBuilder:

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -290,6 +290,11 @@ cdef class OGRGeomBuilder:
         else:
             raise UnsupportedGeometryTypeError("Unsupported geometry type %s" % typename)
 
+    cdef void * build_wkb(self, object wkb) except NULL:
+        cdef object data = wkb
+        cdef void *cogr_geometry = _createOgrGeomFromWKB(data)
+        return cogr_geometry
+
 
 def geometryRT(geometry):
     # For testing purposes only, leaks the JSON data

--- a/fiona/_transform.pyx
+++ b/fiona/_transform.pyx
@@ -221,7 +221,7 @@ def _transform_geom(
 
 def _transform_wkb(
         src_crs, dst_crs, wkb, antimeridian_cutting, antimeridian_offset,
-        precision):
+    ):
     """Return a transformed geometry."""
     cdef char *proj_c = NULL
     cdef char *key_c = NULL
@@ -253,7 +253,7 @@ def _transform_wkb(
                         <OGRCoordinateTransformation *>transform,
                         options)
 
-        dst_wkb = _geometry.OGRGeomBuilder().build2(dst_ogr_geom)
+        dst_wkb = _geometry.WKBGeomBuilder().build(dst_ogr_geom)
 
         _geometry.OGR_G_DestroyGeometry(dst_ogr_geom)
         _geometry.OGR_G_DestroyGeometry(src_ogr_geom)

--- a/fiona/_transform.pyx
+++ b/fiona/_transform.pyx
@@ -233,7 +233,6 @@ def _transform_wkb(
     cdef OGRGeometryFactory *factory = NULL
     cdef void *src_ogr_geom = NULL
     cdef void *dst_ogr_geom = NULL
-    cdef int bufsize = NULL
 
     if src_crs and dst_crs:
         src = _crs_from_crs(src_crs)
@@ -254,13 +253,7 @@ def _transform_wkb(
                         <OGRCoordinateTransformation *>transform,
                         options)
 
-        size = OGR_G_WkbSize(dst_ogr_geom)
-        cdef unsigned char* buf = <unsigned char*>malloc(size * sizeof(char))
-        if not buf:
-            raise MemoryError()
-        OGR_G_ExportToWkb(dst_ogr_geom, 1, buf)
-        cdef bytes dst_wkb = buf[:size]
-        free(buf)
+        dst_wkb = _geometry.OGRGeomBuilder().build2(dst_ogr_geom)
 
         _geometry.OGR_G_DestroyGeometry(dst_ogr_geom)
         _geometry.OGR_G_DestroyGeometry(src_ogr_geom)

--- a/fiona/gdal.pxi
+++ b/fiona/gdal.pxi
@@ -349,7 +349,7 @@ cdef extern from "ogr_api.h" nogil:
     OGRGeometryH OGR_G_CreateGeometryFromJson(const char *json)
     void OGR_G_DestroyGeometry(OGRGeometryH geometry)
     char *OGR_G_ExportToJson(OGRGeometryH geometry)
-    void OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, char *buffer)
+    void OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, unsigned char *buffer)
     int OGR_G_GetCoordinateDimension(OGRGeometryH geometry)
     int OGR_G_GetGeometryCount(OGRGeometryH geometry)
     const char *OGR_G_GetGeometryName(OGRGeometryH geometry)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -272,7 +272,7 @@ cdef class FeatureBuilder:
 
                 if 8 <= code <= 14:  # Curves.
                     cogr_geometry = get_linear_geometry(cogr_geometry)
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 elif 15 <= code <= 17:
@@ -285,11 +285,11 @@ cdef class FeatureBuilder:
                     elif code == 17:
                         cogr_geometry = OGR_G_ForceToPolygon(org_geometry)
 
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 else:
-                    geom = GeomBuilder().build(cogr_geometry)
+                    geom = GeomBuilder().build2(cogr_geometry)
 
                 fiona_feature["geometry"] = geom
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -272,7 +272,7 @@ cdef class FeatureBuilder:
 
                 if 8 <= code <= 14:  # Curves.
                     cogr_geometry = get_linear_geometry(cogr_geometry)
-                    geom = GeomBuilder().build2(cogr_geometry)
+                    geom = GeomBuilder().build(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 elif 15 <= code <= 17:
@@ -285,11 +285,11 @@ cdef class FeatureBuilder:
                     elif code == 17:
                         cogr_geometry = OGR_G_ForceToPolygon(org_geometry)
 
-                    geom = GeomBuilder().build2(cogr_geometry)
+                    geom = GeomBuilder().build(cogr_geometry)
                     OGR_G_DestroyGeometry(cogr_geometry)
 
                 else:
-                    geom = GeomBuilder().build2(cogr_geometry)
+                    geom = GeomBuilder().build(cogr_geometry)
 
                 fiona_feature["geometry"] = geom
 

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -224,7 +224,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (int wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -286,7 +286,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (int wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    void    OGR_G_ExportToWkb (void *geometry, int endianness, unsigned char *buffer)
     int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)

--- a/fiona/transform.py
+++ b/fiona/transform.py
@@ -90,3 +90,46 @@ def transform_geom(
     return _transform_geom(
         src_crs, dst_crs, geom,
         antimeridian_cutting, antimeridian_offset, precision)
+
+
+def transform_wkb(
+        src_crs, dst_crs, geom,
+        antimeridian_cutting=False, antimeridian_offset=10.0):
+    """Transform a geometry WKB from one reference system to another.
+
+    Parameters
+    ----------
+    src_crs: str or dict
+        A string like 'EPSG:4326' or a dict of proj4 parameters like
+        {'proj': 'lcc', 'lat_0': 18.0, 'lat_1': 18.0, 'lon_0': -77.0}
+        representing the coordinate reference system on the "source"
+        or "from" side of the transformation.
+    dst_crs: str or dict
+        A string or dict representing the coordinate reference system
+        on the "destination" or "to" side of the transformation.
+    geom: bytes
+        A WKB (well-known binary) representation of the geometry.
+    antimeridian_cutting: bool, optional
+        ``True`` to cut output geometries in two at the antimeridian,
+        the default is ``False`.
+    antimeridian_offset: float, optional
+        A distance in decimal degrees from the antimeridian, outside of
+        which geometries will not be cut.
+
+    Returns
+    -------
+    bytes
+        A new WKB geometry with transformed coordinates.
+
+    Examples
+    --------
+
+    >>> transform_geom(
+    ...     'EPSG:4326', 'EPSG:26953',
+    ...     wkb)
+    wkb
+
+    """
+    # Function is implemented in the _transform C extension module.
+    return _transform_wkb(src_crs, dst_crs, geom,
+                          antimeridian_cutting, antimeridian_offset)

--- a/fiona/transform.py
+++ b/fiona/transform.py
@@ -1,6 +1,6 @@
 """Coordinate and geometry warping and reprojection"""
 
-from fiona._transform import _transform, _transform_geom
+from fiona._transform import _transform, _transform_geom, _transform_wkb
 
 
 def transform(src_crs, dst_crs, xs, ys):
@@ -119,16 +119,7 @@ def transform_wkb(
     Returns
     -------
     bytes
-        A new WKB geometry with transformed coordinates.
-
-    Examples
-    --------
-
-    >>> transform_geom(
-    ...     'EPSG:4326', 'EPSG:26953',
-    ...     wkb)
-    wkb
-
+        A new geometry as WKB with transformed coordinates.
     """
     # Function is implemented in the _transform C extension module.
     return _transform_wkb(src_crs, dst_crs, geom,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,46 +5,53 @@ import math
 import pytest
 
 from fiona import transform
+from fiona._geometry import geometry_as_wkb
 
-
-@pytest.mark.parametrize(
-    "geom",
-    [
-        {"type": "Point", "coordinates": [0.0, 0.0, 1000.0]},
-        {
-            "type": "LineString",
-            "coordinates": [[0.0, 0.0, 1000.0], [0.1, 0.1, -1000.0]],
-        },
-        {
-            "type": "MultiPoint",
-            "coordinates": [[0.0, 0.0, 1000.0], [0.1, 0.1, -1000.0]],
-        },
-        {
-            "type": "Polygon",
-            "coordinates": [
+params = [
+    {"type": "Point", "coordinates": [0.0, 0.0, 1000.0]},
+    {
+        "type": "LineString",
+        "coordinates": [[0.0, 0.0, 1000.0], [0.1, 0.1, -1000.0]],
+    },
+    {
+        "type": "MultiPoint",
+        "coordinates": [[0.0, 0.0, 1000.0], [0.1, 0.1, -1000.0]],
+    },
+    {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [0.0, 0.0, 1000.0],
+                [0.1, 0.1, -1000.0],
+                [0.1, -0.1, math.pi],
+                [0.0, 0.0, 1000.0],
+            ]
+        ],
+    },
+    {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [
                 [
                     [0.0, 0.0, 1000.0],
                     [0.1, 0.1, -1000.0],
                     [0.1, -0.1, math.pi],
                     [0.0, 0.0, 1000.0],
                 ]
-            ],
-        },
-        {
-            "type": "MultiPolygon",
-            "coordinates": [
-                [
-                    [
-                        [0.0, 0.0, 1000.0],
-                        [0.1, 0.1, -1000.0],
-                        [0.1, -0.1, math.pi],
-                        [0.0, 0.0, 1000.0],
-                    ]
-                ]
-            ],
-        },
-    ],
-)
+            ]
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("geom", params)
 def test_transform_geom_with_z(geom):
     """Transforming a geom with Z succeeds"""
     g2 = transform.transform_geom("epsg:4326", "epsg:3857", geom, precision=3)
+
+
+@pytest.mark.parametrize("geom", params)
+def test_transform_wkb(geom):
+    """Transforming a geom with Z succeeds"""
+    wkb = geometry_as_wkb(geom)
+    g2 = transform.transform_wkb("epsg:4326", "epsg:3857", wkb)


### PR DESCRIPTION
This would increase performance in workflows that use WKB to store geometries. For instance in geopandas, one would need to transform every geometry into dictionaries and back to do a transform using fiona.

The new function transform.transform_wkb just acts on the WKB representation of the geometry.

This builds onto #741 