### PR TITLE
Add support for travis to build [beta|rc] versions of gdal and fiona rfc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,19 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
+    - PROJBUILD=$HOME/projbuild
+    - PROJVERSION="6.0.0"
+    
+    
   matrix:
-    - GDALVERSION="1.11.5"
-    - GDALVERSION="2.0.3"
-    - GDALVERSION="2.1.4"
-    - GDALVERSION="2.2.4"
+#    - GDALVERSION="1.11.5"
+#    - GDALVERSION="2.0.3"
+#    - GDALVERSION="2.1.4"
+#    - GDALVERSION="2.2.4"
     - GDALVERSION="2.3.3"
     - GDALVERSION="2.4.1"
     - GDALVERSION="2.5.0beta1"
-    - GDALVERSION="trunk"
+#    - GDALVERSION="trunk"
 
 matrix:
   allow_failures:
@@ -29,15 +33,16 @@ addons:
   apt:
     packages:
     - gdal-bin
-    - libproj-dev
     - libhdf5-serial-dev
     - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev
     - gfortran
+    - libsqlite3-dev
+    - sqlite3
 
 python:
-  - "2.7"
+#  - "2.7"
   - "3.6"
 
 before_install:
@@ -45,11 +50,12 @@ before_install:
   - pip install wheel coveralls>=1.1 --upgrade
   - pip install setuptools==36.0.1
   - pip install wheel
+  - . ./scripts/travis_proj_install.sh
   - . ./scripts/travis_gdal_install.sh
-  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$PATH
-  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
+  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
+  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib::$LD_LIBRARY_PATH
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
-  - export PROJ_LIB=/usr/share/proj
+  - export PROJ_LIB=$GDALINST/proj-$PROJVERSION/share/proj
   - gdal-config --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
     - GDALVERSION="2.1.4"
     - GDALVERSION="2.2.4"
     - GDALVERSION="2.3.3"
-    - GDALVERSION="2.4.0"
+    - GDALVERSION="2.4.1"
+    - GDALVERSION="2.5.0beta1"
     - GDALVERSION="trunk"
 
 matrix:
@@ -52,10 +53,10 @@ before_install:
   - gdal-config --version
 
 install:
-  - pip install -r requirements-dev.txt
-  - if [ "$GDALVERSION" = "trunk" ]; then echo "Using gdal trunk"; elif [ $(gdal-config --version) == "$GDALVERSION" ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
-  - pip install --upgrade --force-reinstall --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e .
-  - pip install -e .[test]
+  - pip install --upgrade --force-reinstall -r requirements-dev.txt
+  - pip uninstall -y fiona
+  - if [ "$GDALVERSION" = "trunk" ]; then echo "Using gdal trunk"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+  - pip install --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e .[test]
   - fio --version
   - gdal-config --version
   - fio --gdal-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+dist: xenial
+
 language: python
+
 sudo: false
+
 cache:
   directories:
     - $GDALINST
@@ -14,16 +18,13 @@ env:
     - PROJBUILD=$HOME/projbuild
     - PROJVERSION="6.0.0"
     
-    
   matrix:
-#    - GDALVERSION="1.11.5"
-#    - GDALVERSION="2.0.3"
-#    - GDALVERSION="2.1.4"
-#    - GDALVERSION="2.2.4"
+
+    - GDALVERSION="2.2.4"
     - GDALVERSION="2.3.3"
     - GDALVERSION="2.4.1"
     - GDALVERSION="2.5.0beta1"
-#    - GDALVERSION="trunk"
+    - GDALVERSION="trunk"
 
 matrix:
   allow_failures:
@@ -32,9 +33,7 @@ matrix:
 addons:
   apt:
     packages:
-    - gdal-bin
     - libhdf5-serial-dev
-    - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev
     - gfortran
@@ -42,18 +41,17 @@ addons:
     - sqlite3
 
 python:
-#  - "2.7"
-  - "3.6"
+  - "3.7"
 
 before_install:
   - pip install -U pip
   - pip install wheel coveralls>=1.1 --upgrade
   - pip install setuptools==36.0.1
   - pip install wheel
+  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
+  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
   - . ./scripts/travis_gdal_install.sh
-  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
-  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib::$LD_LIBRARY_PATH
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/proj-$PROJVERSION/share/proj
   - gdal-config --version

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -43,7 +43,8 @@ GDALOPTS="  --with-ogr \
             --without-python
             --with-oci=no \
             --without-mrf \
-            --with-webp=no"
+            --with-webp=no \
+            --with-proj=$GDALINST/proj-$PROJVERSION"
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -40,7 +40,10 @@ GDALOPTS="  --with-ogr \
             --without-perl \
             --without-php \
             --without-ruby \
-            --without-python"
+            --without-python
+            --with-oci=no \
+            --without-mrf \
+            --with-webp=no"
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then
@@ -60,15 +63,25 @@ if [ "$GDALVERSION" = "trunk" ]; then
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -j 2
   make install
+  rm -rf $GDALBUILD
+  
 elif [ ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   # only build if not already installed
   cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/$GDALVERSION/gdal-$GDALVERSION.tar.gz
+
+  BASE_GDALVERSION=$(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION)
+
+  if ( curl -o/dev/null -sfI "http://download.osgeo.org/gdal/$BASE_GDALVERSION/gdal-$GDALVERSION.tar.gz" ); then
+    wget http://download.osgeo.org/gdal/$BASE_GDALVERSION/gdal-$GDALVERSION.tar.gz
+  else
+    wget http://download.osgeo.org/gdal/old_releases/gdal-$GDALVERSION.tar.gz
+  fi
   tar -xzf gdal-$GDALVERSION.tar.gz
-  cd gdal-$GDALVERSION
+  cd gdal-$BASE_GDALVERSION
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -j 2
   make install
+  rm -rf $GDALBUILD
 fi
 
 # change back to travis build dir

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -77,7 +77,14 @@ elif [ ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
     wget http://download.osgeo.org/gdal/old_releases/gdal-$GDALVERSION.tar.gz
   fi
   tar -xzf gdal-$GDALVERSION.tar.gz
-  cd gdal-$BASE_GDALVERSION
+
+  
+  if [ -d "gdal-$BASE_GDALVERSION" ]; 
+    cd gdal-$BASE_GDALVERSION
+  elif [ -d "gdal-$GDALVERSION" ];
+    cd gdal-$GDALVERSION
+  fi
+  
   ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
   make -j 2
   make install

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -79,9 +79,9 @@ elif [ ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   tar -xzf gdal-$GDALVERSION.tar.gz
 
   
-  if [ -d "gdal-$BASE_GDALVERSION" ]; 
+  if [ -d "gdal-$BASE_GDALVERSION" ]; then
     cd gdal-$BASE_GDALVERSION
-  elif [ -d "gdal-$GDALVERSION" ];
+  elif [ -d "gdal-$GDALVERSION" ]; then
     cd gdal-$GDALVERSION
   fi
   

--- a/scripts/travis_proj_install.sh
+++ b/scripts/travis_proj_install.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+# Create build dir if not exists
+if [ ! -d "$PROJBUILD" ]; then
+  mkdir $PROJBUILD;
+fi
+
+if [ ! -d "$GDALINST" ]; then
+  mkdir $GDALINST;
+fi
+
+ls -l $GDALINST
+
+if [ ! -d "$GDALINST/proj-$PROJVERSION" ]; then
+    cd $PROJBUILD
+
+    wget http://download.osgeo.org/proj/proj-$PROJVERSION.tar.gz
+    tar -xzf proj-$PROJVERSION.tar.gz
+    cd proj-$PROJVERSION
+    ./configure --prefix=$GDALINST/proj-$PROJVERSION
+    make -j 2
+    make install
+    rm -rf $PROJBUILD
+fi
+
+# change back to travis build dir
+cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Gdal 2.5.0beta1 is released and Fiona fails to build against it: https://github.com/Toblerity/Fiona/issues/745

This PR includes the work I did in https://github.com/Toblerity/Fiona/pull/696 to support the installation of beta and rc versions of GDAL on travis.

However, GDAL 2.5.0beta1 fails to build because it has now a dependency on proj6, which I did not yet find an ubuntu package for. 