### PR TITLE
travis bump gdal to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - GDALVERSION="2.2.4"
     - GDALVERSION="2.3.3"
     - GDALVERSION="2.4.1"
-    - GDALVERSION="2.5.0beta1"
+    - GDALVERSION="3.0.0"
     - GDALVERSION="trunk"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
 matrix:
   allow_failures:
     - env: GDALVERSION="trunk"
+    - env: GDALVERSION="3.0.0"
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,20 +18,6 @@ environment:
         # the libraries. It does not need to match the version of MSVC used to build Python.
         # https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
 
-        # Python 2.7, GDAL 1.11
-        - PYTHON: "C:\\Python27-x64"
-          PYTHON_VERSION: "2.7.14"
-          GDAL_VERSION: "1.11.4"
-          GIS_INTERNALS: "release-1800-x64-gdal-1-11-4-mapserver-6-4-3.zip"
-          GIS_INTERNALS_LIBS: "release-1800-x64-gdal-1-11-4-mapserver-6-4-3-libs.zip"
-
-        # Python 3.6, GDAL 1.11
-        - PYTHON: "C:\\Python36-x64"
-          PYTHON_VERSION: "3.6.4"
-          GDAL_VERSION: "1.11.4"
-          GIS_INTERNALS: "release-1800-x64-gdal-1-11-4-mapserver-6-4-3.zip"
-          GIS_INTERNALS_LIBS: "release-1800-x64-gdal-1-11-4-mapserver-6-4-3-libs.zip"
-
         # Python 3.6, GDAL 2.2
         - PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ test_script:
   - ps: python -c "import fiona"
 
   # Our Windows GDAL doesn't have iconv and can't support certain tests.
-  - "%CMD_IN_ENV% python -m pytest -m \"not iconv\" --cov fiona --cov-report term-missing"
+  - "%CMD_IN_ENV% python -m pytest -m \"not iconv and not wheel\" --cov fiona --cov-report term-missing"
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Gdal 3.0.0 was released. This PR switches gdal 2.5.0beta1 with gdal 3.0.0.