### PR TITLE
Add model module and tests

### DIFF
--- a/fiona/model.py
+++ b/fiona/model.py
@@ -7,9 +7,19 @@ from fiona.errors import FionaDeprecationWarning
 
 
 class Object(MutableMapping):
+    """Base class for CRS, geometry, and feature objects
+
+    In Fiona 2.0, the implementation of those objects will change.  They
+    will no longer be dicts or derive from dict, and will lose some
+    features like mutability and default JSON serialization.
+
+    Object will be used for these objects in Fiona 1.9. This class warns
+    about future deprecation of features.
+    """
 
     def __init__(self, **data):
-        self._data = data.copy()
+        self._data = {}
+        self._data.update(data)
 
     def __getitem__(self, item):
         return self._data[item]
@@ -21,9 +31,17 @@ class Object(MutableMapping):
         return len(self._data)
 
     def __setitem__(self, key, value):
-        warn("Object will become immutable in version 2.0", FionaDeprecationWarning, stacklevel=2)
+        warn(
+            "instances of this class -- CRS, geometry, and feature objects -- will become immutable in fiona version 2.0",
+            FionaDeprecationWarning,
+            stacklevel=2,
+        )
         self._data[key] = value
 
     def __delitem__(self, key):
-        warn("Object will become immutable in version 2.0", FionaDeprecationWarning, stacklevel=2)
+        warn(
+            "instances of this class -- CRS, geometry, and feature objects -- will become immutable in fiona version 2.0",
+            FionaDeprecationWarning,
+            stacklevel=2,
+        )
         del self._data[key]

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -1,0 +1,29 @@
+"""Fiona data model"""
+
+from collections.abc import MutableMapping
+from warnings import warn
+
+from fiona.errors import FionaDeprecationWarning
+
+
+class Object(MutableMapping):
+
+    def __init__(self, **data):
+        self._data = data.copy()
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __setitem__(self, key, value):
+        warn("Object will become immutable in version 2.0", FionaDeprecationWarning, stacklevel=2)
+        self._data[key] = value
+
+    def __delitem__(self, key):
+        warn("Object will become immutable in version 2.0", FionaDeprecationWarning, stacklevel=2)
+        del self._data[key]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,22 @@
+"""Test of deprecations following RFC 1"""
+
+import pytest
+
+from fiona.errors import FionaDeprecationWarning
+from fiona.model import Object
+
+
+def test_setitem_warning():
+    """Warn about __setitem__"""
+    obj = Object()
+    with pytest.warns(FionaDeprecationWarning):
+        obj['g'] = 1
+    assert obj['g'] == 1
+
+
+def test_delitem_warning():
+    """Warn about __delitem__"""
+    obj = Object(g=1)
+    with pytest.warns(FionaDeprecationWarning):
+        del obj['g']
+    assert 'g' not in obj

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,17 +6,30 @@ from fiona.errors import FionaDeprecationWarning
 from fiona.model import Object
 
 
+def test_object_len():
+    """object len is correct"""
+    obj = Object(g=1)
+    assert len(obj) == 1
+
+
+def test_object_iter():
+    """object iter is correct"""
+    obj = Object(g=1)
+    assert [obj[k] for k in obj] == [1]
+
+
 def test_setitem_warning():
     """Warn about __setitem__"""
     obj = Object()
-    with pytest.warns(FionaDeprecationWarning):
-        obj['g'] = 1
-    assert obj['g'] == 1
+    with pytest.warns(FionaDeprecationWarning, match="immutable"):
+        obj["g"] = 1
+    assert "g" in obj
+    assert obj["g"] == 1
 
 
 def test_delitem_warning():
     """Warn about __delitem__"""
     obj = Object(g=1)
-    with pytest.warns(FionaDeprecationWarning):
-        del obj['g']
-    assert 'g' not in obj
+    with pytest.warns(FionaDeprecationWarning, match="immutable"):
+        del obj["g"]
+    assert "g" not in obj


### PR DESCRIPTION
model.Object is the dict with deprecation warnings class. I'm not entirely certain that "model" is the best name for this module. Resolves #758.