### PR TITLE
Test unpinned python dependencies using travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ cache:
     - $GDALINST
     - ~/.cache/pip
 
+git:
+  depth: 3    
+
 env:
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
@@ -23,10 +26,18 @@ env:
     - GDALVERSION="2.2.4"
     - GDALVERSION="2.3.3"
     - GDALVERSION="2.4.1"
-    - GDALVERSION="3.0.0"
-    - GDALVERSION="trunk"
 
 matrix:
+
+  include:
+   - python: "3.7"
+     env: GDALVERSION="3.0.0"
+     if: type != cron
+
+   - python: "3.7"
+     env: GDALVERSION="trunk"
+     if: type != cron
+
   allow_failures:
     - env: GDALVERSION="trunk"
     - env: GDALVERSION="3.0.0"
@@ -46,25 +57,39 @@ python:
 
 before_install:
   - pip install -U pip
-  - pip install wheel coveralls>=1.1 --upgrade
-  - pip install setuptools==36.0.1
-  - pip install wheel
+  - pip install --upgrade coveralls>=1.1
+  
+  # Export environment variables and install proj and gdal from source
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
   - . ./scripts/travis_gdal_install.sh
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/proj-$PROJVERSION/share/proj
-  - gdal-config --version
 
 install:
+
+  # If event type is cron, remove version constraints from python dependencies 
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then cat requirements.txt | python scripts/remove_version.py | tee requirements.txt; fi
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then cat requirements-dev.txt | python scripts/remove_version.py | tee requirements-dev.txt; fi
+  - cat requirements.txt
+  - cat requirements-dev.txt
+  
+  # Install python dependencies 
   - pip install --upgrade --force-reinstall -r requirements-dev.txt
   - pip uninstall -y fiona
+
+  # Check if the installed version of gdal is correct. Fail if not.
   - if [ "$GDALVERSION" = "trunk" ]; then echo "Using gdal trunk"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+
+  # Install fiona
   - pip install --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e .[test]
+
+  # Print installation information
   - fio --version
   - gdal-config --version
   - fio --gdal-version
+  - pip freeze
 
 script:
   - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ gdal``).
 Python Requirements
 -------------------
 
-Fiona depends on the modules ``enum34``, ``six``, ``cligj``,  ``munch``, ``argparse``, and
+Fiona depends on the modules ``six``, ``cligj``,  ``munch``, ``argparse``, and
 ``ordereddict`` (the two latter modules are standard in Python 2.7+). Pip will
 fetch these requirements for you, but users installing Fiona from a Windows
 installer must get them separately.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,5 @@ argparse==1.4.0
 attrs==18.2.0
 click-plugins==1.0.4
 cligj==0.5.0
-enum34==1.1.6 ; python_version < '3.4'
 munch==2.3.2
-ordereddict==1.1 ; python_version <= '2.7'
 six==1.11.0

--- a/scripts/remove_version.py
+++ b/scripts/remove_version.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Remove set versions of python dependencies from requirements.txt"""
+
+import sys
+
+for line in sys.stdin:
+    python_dep = None
+
+    splits = line.split(";")
+    if len(splits) > 1:
+        python_dep = splits[-1].strip()
+    
+    new_line = splits[0].split("=")[0].strip()
+    
+    if python_dep is not None:
+        new_line += " ; " + python_dep
+    
+    sys.stdout.write(new_line + "\n")


### PR DESCRIPTION
Since some time, requirements*.txt include pinned versions of python dependencies.  Thus, we do not check compatibility against updated dependencies and thus can miss potential issues.  Unpinning the versions is also not great, as dependencies update asynchronously to Fiona commits triggering the CI.

This PR updates the travis configuration so that when a build is triggered using a travis cron job, the pinned versions in the requirements*.txt are removed, thus installing the latest dependencies.  For cron jobs, only known working builds are included (currently excluding gdal 3.0 and trunk). 
In order to use these changes, a travis cron job needs to be configured: More options -> settings -> cron jobs: branch: master, interval: daily, options: always run

Potentials caveats are:
- a cron job can only be executed for roughly 1000 times for the same commit.
- a broken dependency can invalidate the proj/gdal cache and thus increase the build time for commits

Furthermore, this PR contains some cleanup in the travis configuration and removes enum34 and ordereddict as dependencies (drop of support for python < 3.5). Probably, six could also be removed, but this needs some refactoring.

 