### PR TITLE
Skip Path test for zip files on Windows

### DIFF
--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -68,6 +68,7 @@ def test_path_object(path_coutwildrnp_shp):
     assert fiona.listlayers(path_obj) == ['coutwildrnp']
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Path doesn't support URI-style locations on Windows")
 def test_zip_path_arch(path_coutwildrnp_zip):
     vfs = Path('zip://{}'.format(path_coutwildrnp_zip))
     assert fiona.listlayers('/coutwildrnp.shp', vfs=vfs) == ['coutwildrnp']


### PR DESCRIPTION
This avoids the Windows build failure introduced in #769 by skipping this test.

The problem is that on Windows the `Path` will try to convert `zip://` so you end up with a path string passed to GDAL like `zip:\C:\Users\Snorfalorpagus\Desktop\Fiona\tests\data\coutwildrnp.zip` which isn't correct.