### PR TITLE
Pass arguments when reading file-like dataset. Fixes #781.

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -202,7 +202,10 @@ def open(fp, mode='r', driver=None, schema=None, crs=None, encoding=None,
         @contextmanager
         def fp_reader(fp):
             memfile = MemoryFile(fp.read())
-            dataset = memfile.open()
+            dataset = memfile.open(
+                driver=driver, crs=crs, schema=schema, layer=layer,
+                encoding=encoding, enabled_drivers=enabled_drivers,
+                **kwargs)
             try:
                 yield dataset
             finally:


### PR DESCRIPTION
This fixes the bug reported in #781.

Is GPKG the best format for the tests?

The test probably needs to be improved before merge - I've not tested the same issue with write instead of read, although I can see it should work (because that is where the fix was copy+pasted from).