### PR TITLE
DOC: Mention unique transaction per collection.write()

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -809,6 +809,20 @@ iterator) of records.
    write 3 duplicate records to the file, and they will be given unique
    sequential ids.
 
+.. admonition:: Transactions
+
+   Fiona uses transactions during write operations to ensure data integrity.
+   :py:meth:`writerecords` will start and commit one transaction. If there
+   are lots of records, intermediate commits will be performed at reasonable
+   intervals.
+   
+   Depending on the driver, a transaction can be a very costly operation.
+   Since :py:meth:`write` is just a thin convenience wrapper that calls
+   :py:meth:`writerecords` with a single record, you may experience significant
+   performance issue if you write lots of features one by one using this method.
+   Consider preparing your data first and then writing it in a single call to
+   :py:meth:`writerecords`.
+
 .. admonition:: Buffering
 
    Fiona's output is buffered. The records passed to :py:meth:`write` and

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -350,7 +350,11 @@ class Collection(object):
         self._bounds = self.session.get_extent()
 
     def write(self, record):
-        """Stages a record for writing to disk."""
+        """Stages a record for writing to disk.
+        
+        Note: Each call of this method will start and commit a
+        unique transaction with the data source.
+        """
         self.writerecords([record])
 
     def validate_record(self, record):


### PR DESCRIPTION
Re https://github.com/Toblerity/Fiona/issues/740 I added notes about the transactions on write operations
- as a hint to the Fiona-using programmer in the docstring and
- as a note for everyone to see in the manual.