### PR TITLE
setup.py: Use requirement specifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,14 +271,11 @@ requirements = [
     'cligj>=0.5',
     'click-plugins>=1.0',
     'six>=1.7',
-    'munch']
-
-if sys.version_info < (2, 7):
-    requirements.append('argparse')
-    requirements.append('ordereddict')
-
-if sys.version_info < (3, 4):
-    requirements.append('enum34')
+    'munch',
+    'argparse; python_version <= "3.4"',
+    'ordereddict; python_version <= "2.7"',
+    'enum34; python_version < "3.4"',
+]
 
 extras_require = {
     'calc': ['shapely'],


### PR DESCRIPTION
With the previous implementation, tools like poetry were pulling all the dependencies (e.g. enum34) even on newer Python versions

BTW, according to setup.py `argparse` is supposed to be installed for Python 2 only, while according to the requirements.txt it is supposed to be installed on < 3.4. Not sure which is the correct one. I opted for the requirements one