### PR TITLE
Fix access violation on Windows

### DIFF
--- a/fiona/_shim3.pyx
+++ b/fiona/_shim3.pyx
@@ -153,7 +153,7 @@ cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
 
 
 cdef void set_proj_search_path(object path):
-    cdef const char *const *paths = NULL
+    cdef char **paths = NULL
     cdef const char *path_c = NULL
     path_b = path.encode("utf-8")
     path_c = path_b


### PR DESCRIPTION
Fix crash when importing Fiona-1.8.10 + with GDAL 3.0.2 on Windows.