### PR TITLE
Some minor modifications to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ python:
   - "3.8"
 
 before_install:
-  - pip install -U pip
+  - python -m pip install -U pip
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
@@ -56,6 +56,7 @@ before_install:
 install:
   - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
   - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --no-deps --force-reinstall --no-use-pep517 -e ."
+  - python -m pip freeze
   - fio --version
   - fio --gdal-version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
   - python -m pip install -r requirements-dev.txt
 
 install:
-  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == "$GDALVERSION" ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
   - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --no-deps --force-reinstall --no-use-pep517 -e ."
   - fio --version
   - fio --gdal-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
 addons:
   apt:
     packages:
-    - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev
     - gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ after_success:
   - coveralls || echo "!! intermittent coveralls failure"
 
 before_cache:
-  - if [ "$GDALVERSION" = "trunk" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi
+  - if [ "$GDALVERSION" = "master" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -42,7 +42,11 @@ GDALOPTS="  --with-ogr \
             --without-ruby \
             --without-perl \
             --without-php \
-            --without-python"
+            --without-python \
+            --with-oci=no \
+            --without-mrf \
+            --with-webp=no"
+
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then


### PR DESCRIPTION
Just some minor modifications to travis.yml:
- A  rename from "trunk" to "master" was missing
- libgdal-dev is not needed
- I assume the gdal version check supporting beta and rc versions went missing somewhere

The current matrix produces three builds for master, which takes quite some time to build. I would suggest using an explicit matrix as proposed in https://github.com/Toblerity/Fiona/pull/770 and only test master for one Python version.  Alternatives would be to not test master on travis and only on appveyor, or to try to cache the master gdal builds somehow. 