### PR TITLE
Upgrade Travis CI testing against latest GDAL and PROJ releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,32 +23,32 @@ matrix:
         PROJVERSION="4.9.3"
     - python: "3.6"
       env:
-        GDALVERSION="2.4.3"
+        GDALVERSION="2.4.4"
         PROJVERSION="4.9.3"
     - python: "3.7"
       env:
-        GDALVERSION="2.4.3"
+        GDALVERSION="2.4.4"
         PROJVERSION="4.9.3"
     - python: "3.6"
       env:
-        GDALVERSION="3.0.2"
+        GDALVERSION="3.0.3"
         PROJVERSION="6.1.1"
     - python: "3.7"
       env:
-        GDALVERSION="3.0.2"
+        GDALVERSION="3.0.3"
         PROJVERSION="6.1.1"
     - python: "3.8"
       env:
-        GDALVERSION="3.0.2"
+        GDALVERSION="3.0.3"
         PROJVERSION="6.2.1"
     - python: "3.8"
       env:
         GDALVERSION="master"
-        PROJVERSION="6.2.1"
+        PROJVERSION="6.3.0"
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="6.2.1"
+        PROJVERSION="6.3.0"
 
 addons:
   apt:


### PR DESCRIPTION
 * GDAL 3.0.2 -> [3.0.3](https://lists.osgeo.org/pipermail/gdal-dev/2020-January/051453.html)
 * GDAL 2.4.3 -> [2.4.4](https://lists.osgeo.org/pipermail/gdal-dev/2020-January/051452.html)
 * PROJ 6.2.1 -> [6.3.0](https://lists.osgeo.org/pipermail/proj/2020-January/009178.html)