### PR TITLE
Adapt travis tests to gdal master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - GDALBUILD=$HOME/gdalbuild
     - PROJINST=$HOME/gdalinstall
     - PROJBUILD=$HOME/projbuild
+    - MAKEFLAGS="-j 2"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,5 +84,5 @@ script:
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"
 
-before_cache:
-  - if [ "$GDALVERSION" = "master" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi
+#before_cache:
+  #- if [ "$GDALVERSION" = "master" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,5 +85,3 @@ script:
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"
 
-#before_cache:
-  #- if [ "$GDALVERSION" = "master" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -78,7 +78,7 @@ if [ "$GDALVERSION" = "master" ]; then
         cp newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt
         cp newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt
         ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
-        make -j 4
+        make
         make install
     fi
 
@@ -98,7 +98,7 @@ else
         tar -xzf gdal-$GDALVERSION.tar.gz
         cd gdal-$gdalver
         ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
-        make -j 4
+        make
         make install
     fi
 fi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -84,12 +84,32 @@ if [ "$GDALVERSION" = "master" ]; then
 
 else
 
-    if $(dpkg --compare-versions "$GDALVERSION" "lt" "2.3"); then
-        PROJOPT="--with-static-proj4=$PROJINST/proj-$PROJVERSION";
-    else
-        PROJOPT="--with-proj=$PROJINST/proj-$PROJVERSION";
-
-    fi
+    case "$GDALVERSION" in
+        3*)
+            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        2.4*)
+            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        2.3*)
+            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        2.2*)
+            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        2.1*)
+            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        2.0*)
+            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        1*)
+            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
+            ;;
+        *)
+            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
+            ;;
+    esac
 
     if [ ! -d "$GDALINST/gdal-$GDALVERSION/share/gdal" ]; then
         cd $GDALBUILD

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -70,7 +70,7 @@ if [ "$GDALVERSION" = "master" ]; then
     # Only build if nothing cached or if the GDAL revision changed
     if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
         BUILD=yes
-    elif [! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null] || [! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ]; then
+    elif [ ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null] || [ ! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ]; then
         BUILD=yes
     fi
     if test "$BUILD" = "yes"; then

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -70,7 +70,7 @@ if [ "$GDALVERSION" = "master" ]; then
     # Only build if nothing cached or if the GDAL revision changed
     if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
         BUILD=yes
-    elif [ ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null] || [ ! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ]; then
+    elif ( ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null ) || ( ! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ); then
         BUILD=yes
     fi
     if test "$BUILD" = "yes"; then

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -64,46 +64,32 @@ if [ "$GDALVERSION" = "master" ]; then
     cd $GDALBUILD
     git clone --depth 1 https://github.com/OSGeo/gdal gdal-$GDALVERSION
     cd gdal-$GDALVERSION/gdal
+    echo $PROJVERSION > newproj.txt
     git rev-parse HEAD > newrev.txt
     BUILD=no
     # Only build if nothing cached or if the GDAL revision changed
     if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
         BUILD=yes
-    elif ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null; then
+    elif [! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null] || [! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ]; then
         BUILD=yes
     fi
     if test "$BUILD" = "yes"; then
         mkdir -p $GDALINST/gdal-$GDALVERSION
         cp newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt
+        cp newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt
         ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
         make -j 4
         make install
     fi
 
 else
-    case "$GDALVERSION" in
-        3*)
-            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        2.4*)
-            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        2.3*)
-            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        2.2*)
-            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        2.1*)
-            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        2.0*)
-            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
-            ;;
-        1*)
-            PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
-            ;;
-    esac
+
+    if $(dpkg --compare-versions "$GDALVERSION" "lt" "2.3"); then
+        PROJOPT="--with-static-proj4=$PROJINST/proj-$PROJVERSION";
+    else
+        PROJOPT="--with-proj=$PROJINST/proj-$PROJVERSION";
+
+    fi
 
     if [ ! -d "$GDALINST/gdal-$GDALVERSION/share/gdal" ]; then
         cd $GDALBUILD

--- a/scripts/travis_proj_install.sh
+++ b/scripts/travis_proj_install.sh
@@ -20,7 +20,7 @@ if [ ! -d "$PROJINST/gdal-$GDALVERSION/share/proj" ]; then
     tar -xzf proj-$PROJVERSION.tar.gz
     cd proj-$PROJVERSION
     ./configure --prefix=$PROJINST/gdal-$GDALVERSION
-    make -s -j 2
+    make -s
     make install
 fi
 

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -34,7 +34,7 @@ def mock_fhs(tmpdir):
 def mock_debian(tmpdir):
     """A fake Debian multi-install system"""
     tmpdir.ensure("share/gdal/{}.{}/header.dxf".format(gdal_version.major,
-                                                       gdal_version.minor)
+                                                       gdal_version.minor))
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -33,13 +33,8 @@ def mock_fhs(tmpdir):
 @pytest.fixture
 def mock_debian(tmpdir):
     """A fake Debian multi-install system"""
-    tmpdir.ensure("share/gdal/1.11/header.dxf")
-    tmpdir.ensure("share/gdal/2.0/header.dxf")
-    tmpdir.ensure("share/gdal/2.1/header.dxf")
-    tmpdir.ensure("share/gdal/2.2/header.dxf")
-    tmpdir.ensure("share/gdal/2.3/header.dxf")
-    tmpdir.ensure("share/gdal/2.4/header.dxf")
-    tmpdir.ensure("share/gdal/3.0/header.dxf")
+    tmpdir.ensure("share/gdal/{}.{}/header.dxf".format(gdal_version.major,
+                                                       gdal_version.minor)
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 

--- a/tests/test_compound_crs.py
+++ b/tests/test_compound_crs.py
@@ -8,4 +8,5 @@ def test_compound_crs(data):
     prj = data.join("coutwildrnp.prj")
     prj.write("""COMPD_CS["unknown",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]],VERT_CS["unknown",VERT_DATUM["unknown",2005],UNIT["metre",1.0,AUTHORITY["EPSG","9001"]],AXIS["Up",UP]]]""")
     with fiona.open(str(data.join("coutwildrnp.shp"))) as collection:
-        assert collection.crs == {}
+        assert isinstance(collection.crs, dict)
+


### PR DESCRIPTION
There are currently two issues with the tests and gdal master. 

The mock debian tmpdir is missing a path for gdal 3.1. I changed the creation of the mockdir to use gdal_version. However, I'm not sure if there was a reason that the paths were hardcoded and I did not notice.

The second issue is, that gdal now something returns for the  COMPD_CS projection. As far as I understand the test_compound_crs test, it is only important that a crs (empty or not) is returned and no crash happens. Thus I changed it to just test if a dict is returned. 

Finally, the PR disables that the gdal master installation is always deleted and not cached. 