### PR TITLE
Added the append mode to GPKG and GeoJSON

### DIFF
--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -49,7 +49,7 @@ supported_drivers = dict([
     ("ESRI Shapefile", "raw"),
     # FMEObjects Gateway 	FMEObjects Gateway 	No 	Yes 	No, needs FME
     # GeoJSON 	GeoJSON 	Yes 	Yes 	Yes
-    ("GeoJSON", "rw"),
+    ("GeoJSON", "raw"),
     # GeoJSONSeq 	GeoJSON sequences 	Yes 	Yes 	Yes 
     ("GeoJSONSeq", "rw"),
     # Géoconcept Export 	Geoconcept 	Yes 	Yes 	Yes
@@ -57,7 +57,7 @@ supported_drivers = dict([
     #   ("Geoconcept", "raw"),
     # Geomedia .mdb 	Geomedia 	No 	No 	No, needs ODBC library
     # GeoPackage	GPKG	Yes	Yes	No, needs libsqlite3
-    ("GPKG", "rw"),
+    ("GPKG", "raw"),
     # GeoRSS 	GeoRSS 	Yes 	Yes 	Yes (read support needs libexpat)
     # Google Fusion Tables 	GFT 	Yes 	Yes 	No, needs libcurl
     # GML 	GML 	Yes 	Yes 	Yes (read support needs Xerces or libexpat)


### PR DESCRIPTION
I was trying to append to a GeoPackage file but I was receiving a DriverError: unsupported mode: 'a'. I found it strange since the append operations seems to be supported by GDAL/OGR. Searching the issues page I found issues #839 and #840 and decided to figure out a way to make it work.

I decided to start by simply trying to add the append mode to the GPKG and GeoJSON lines in fiona/drvsupport.py and then I started doing some tests. It seems it is now able to append correctly to those two formats.

This is my first PR so feel free to guide me in the right direction if I'm doing something wrong.