### PR TITLE
Bounds can not always be calculated

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -340,7 +340,7 @@ class Collection(object):
             raise IOError("collection not open for writing")
         self.session.writerecs(records, self)
         self._len = self.session.get_length()
-        self._bounds = self.session.get_extent()
+        self._bounds = None
 
     def write(self, record):
         """Stages a record for writing to disk."""
@@ -428,7 +428,7 @@ class Collection(object):
             self.session.sync(self)
             new_len = self.session.get_length()
             self._len = new_len > self._len and new_len or self._len
-            self._bounds = self.session.get_extent()
+            self._bounds = None
 
     def close(self):
         """In append or write mode, flushes data to disk, then ends

--- a/fiona/fio/info.py
+++ b/fiona/fio/info.py
@@ -10,7 +10,7 @@ from cligj import indent_opt
 import fiona
 import fiona.crs
 from fiona.fio import options, with_context_env
-
+from fiona.errors import DriverError
 
 @click.command()
 # One or more files.
@@ -47,7 +47,16 @@ def info(ctx, input, indent, meta_member, layer):
     try:
         with fiona.open(input, layer=layer) as src:
             info = src.meta
-            info.update(bounds=src.bounds, name=src.name)
+
+            info.update(name=src.name)
+            
+            try:
+                info.update(bounds=src.bounds)
+            except DriverError:
+                info.update(bounds=None)
+                logger.debug("Setting 'bounds' to None - driver "
+                             "was not able to calculate bounds")
+
             try:
                 info.update(count=len(src))
             except TypeError:

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -777,7 +777,8 @@ cdef class Session:
         result = OGR_L_GetExtent(self.cogr_layer, &extent, 1)
         
         if result != OGRERR_NONE:
-            raise DriverError("Driver was not able to calculate extent")
+            raise DriverError("Driver was not able to calculate bounds")
+
         return (extent.MinX, extent.MinY, extent.MaxX, extent.MaxY)
 
     def has_feature(self, fid):

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -775,7 +775,11 @@ cdef class Session:
             raise ValueError("Null layer")
 
         result = OGR_L_GetExtent(self.cogr_layer, &extent, 1)
-        return (extent.MinX, extent.MinY, extent.MaxX, extent.MaxY)
+        
+        if result == OGRERR_NONE:
+            return (extent.MinX, extent.MinY, extent.MaxX, extent.MaxY)
+        else:
+            raise DriverError("Driver was not able to calculate extent")
 
     def has_feature(self, fid):
         """Provides access to feature data by FID.

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -776,10 +776,9 @@ cdef class Session:
 
         result = OGR_L_GetExtent(self.cogr_layer, &extent, 1)
         
-        if result == OGRERR_NONE:
-            return (extent.MinX, extent.MinY, extent.MaxX, extent.MaxY)
-        else:
+        if result != OGRERR_NONE:
             raise DriverError("Driver was not able to calculate extent")
+        return (extent.MinX, extent.MinY, extent.MaxX, extent.MaxY)
 
     def has_feature(self, fid):
         """Provides access to feature data by FID.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,18 @@ import pytest
 import fiona
 from fiona.env import GDALVersion
 
+driver_extensions = {'DXF': 'dxf',
+                     'CSV': 'csv',
+                     'ESRI Shapefile': 'shp',
+                     'GML': 'gml',
+                     'GPX': 'gpx',
+                     'GPSTrackMaker': 'gtm',
+                     'MapInfo File': 'tab',
+                     'DGN': 'dgn',
+                     'GPKG': 'gpkg',
+                     'GeoJSON': 'json',
+                     'GMT': 'gmt'}
+
 
 def pytest_report_header(config):
     headers = []

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -2,7 +2,7 @@ import pytest
 import fiona
 from fiona.drvsupport import supported_drivers
 from fiona.errors import DriverError
-from .conftest import driver_extensions, requires_gdal2
+from .conftest import driver_extensions
 from fiona.env import GDALVersion
 
 def test_bounds_point():

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -2,7 +2,7 @@ import pytest
 import fiona
 from fiona.drvsupport import supported_drivers
 from fiona.errors import DriverError
-from .conftest import driver_extensions
+from .conftest import driver_extensions, requires_gdal2
 
 def test_bounds_point():
     g = {'type': 'Point', 'coordinates': [10, 10]}
@@ -26,6 +26,9 @@ def test_bounds_z():
 
 blacklist_write_drivers = set(['CSV', 'GPX', 'GPSTrackMaker', 'DXF', 'DGN', 'MapInfo File'])
 write_drivers = [driver for driver, raw in supported_drivers.items() if 'w' in raw and driver not in blacklist_write_drivers]
+
+# Segfault with gdal 1.11, thus only enabling test with gdal2 and above
+@requires_gdal2
 @pytest.mark.parametrize('driver', write_drivers)
 def test_bounds(tmpdir, driver):
     """Test if bounds are correctly calculated after writing

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,6 +1,7 @@
-import fiona
 import pytest
+import fiona
 from fiona.drvsupport import supported_drivers
+from fiona.errors import DriverError
 from .conftest import driver_extensions
 
 def test_bounds_point():
@@ -42,9 +43,17 @@ def test_bounds(tmpdir, driver):
         c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (1.0, 10.0)},
                             'properties': {'title': 'One'}}])
 
-        assert c.bounds == (1.0, 10.0, 1.0, 10.0)
+        try: 
+            bounds = c.bounds
+            assert bounds == (1.0, 10.0, 1.0, 10.0)
+        except Exception as e:
+            assert isinstance(e, DriverError) 
 
         c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (2.0, 20.0)},
                             'properties': {'title': 'One'}}])
         
-        assert c.bounds == (1.0, 10.0, 2.0, 20.0)
+        try: 
+            bounds = c.bounds
+            assert bounds == (1.0, 10.0, 2.0, 20.0)
+        except Exception as e:
+            assert isinstance(e, DriverError) 

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -24,7 +24,7 @@ def test_bounds_z():
     assert fiona.bounds(g) == (10, 10, 10, 10)
 
 
-blacklist_write_drivers = set(['CSV', 'GPX', 'GPSTrackMaker', 'DXF', 'DGN'])
+blacklist_write_drivers = set(['CSV', 'GPX', 'GPSTrackMaker', 'DXF', 'DGN', 'MapInfo File'])
 write_drivers = [driver for driver, raw in supported_drivers.items() if 'w' in raw and driver not in blacklist_write_drivers]
 @pytest.mark.parametrize('driver', write_drivers)
 def test_bounds(tmpdir, driver):
@@ -50,7 +50,7 @@ def test_bounds(tmpdir, driver):
             assert isinstance(e, DriverError) 
 
         c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (2.0, 20.0)},
-                            'properties': {'title': 'One'}}])
+                            'properties': {'title': 'Two'}}])
         
         try: 
             bounds = c.bounds

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,5 +1,7 @@
 import fiona
-
+import pytest
+from fiona.drvsupport import supported_drivers
+from .conftest import driver_extensions
 
 def test_bounds_point():
     g = {'type': 'Point', 'coordinates': [10, 10]}
@@ -19,3 +21,30 @@ def test_bounds_polygon():
 def test_bounds_z():
     g = {'type': 'Point', 'coordinates': [10,10,10]}
     assert fiona.bounds(g) == (10, 10, 10, 10)
+
+
+blacklist_write_drivers = set(['CSV', 'GPX', 'GPSTrackMaker', 'DXF', 'DGN'])
+write_drivers = [driver for driver, raw in supported_drivers.items() if 'w' in raw and driver not in blacklist_write_drivers]
+@pytest.mark.parametrize('driver', write_drivers)
+def test_bounds(tmpdir, driver):
+    """Test if bounds are correctly calculated after writing
+    
+    """
+    extension = driver_extensions.get(driver, "bar")
+    path = str(tmpdir.join('foo.{}'.format(extension)))
+
+    with fiona.open(path, 'w',
+                    driver=driver,
+                    schema={'geometry': 'Point',
+                            'properties': [('title', 'str')]},
+                    fiona_force_driver=True) as c:
+
+        c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (1.0, 10.0)},
+                            'properties': {'title': 'One'}}])
+
+        assert c.bounds == (1.0, 10.0, 1.0, 10.0)
+
+        c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (2.0, 20.0)},
+                            'properties': {'title': 'One'}}])
+        
+        assert c.bounds == (1.0, 10.0, 2.0, 20.0)


### PR DESCRIPTION
Follow up to https://github.com/Toblerity/Fiona/pull/866 regarding OGR_L_GetExtent after writing of features. 

Currently, there are two issues:
1. Calculation of extents can fail
2. Correct calculation of extents after writing a record is driver dependant: https://github.com/OSGeo/gdal/issues/2269

Regarding 1:
- This PR disables the computations of bounds after records are written. They are lazy evaluated.
- When a bound cannot be calculated, a DriverError is raised. This leads to failed tests.

Regarding 2:
- We probably should detect cases when the calculation of bounds is not possible. ~Unfortunately, it seems as GDAL does not raise an error in this case. We could blacklist drivers.~
 
