### PR TITLE
Readd coveralls to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ before_install:
   - gdal-config --version
   - python -m pip wheel -r requirements-dev.txt
   - python -m pip install -r requirements-dev.txt
+  - python -m pip install coveralls>=1.1 --upgrade
 
 install:
   - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
@@ -81,6 +82,9 @@ install:
 
 script:
   - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing
+
+after_script:
+  - python setup.py clean
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,8 +118,8 @@ install:
   - cd C:\projects\fiona
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - cmd: python -m pip install --disable-pip-version-check --user --upgrade pip
-  - cmd: python -m pip --version
+  - ps: python -m pip install --upgrade pip
+  - ps: python -m pip --version
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
@@ -130,11 +130,9 @@ install:
   # Install coverage testing dependencies
   - ps: python -m pip install coveralls>=1.1 --upgrade
 
-
 build_script:
   # Build the compiled extension
   - cmd: echo %PATH%
-
   - cmd: echo %PYTHONPATH%
 
   # copy gisinternal gdal librarys into .libs
@@ -145,7 +143,6 @@ build_script:
   - "%CMD_IN_ENV% python setup.py build_ext -IC:\\gdal\\include -lgdal_i -LC:\\gdal\\lib bdist_wheel --gdalversion %GDAL_VERSION%"
 
   # install the wheel
-  - ps: python -m pip install --upgrade pip
   - ps: python -m pip install --no-deps --ignore-installed (gci dist\*.whl | % { "$_" })
   - ps: python -m pip freeze
   - ps: move fiona fiona.build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,6 +127,9 @@ install:
   # target Python version and architecture
   - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
 
+  # Install coverage testing dependencies
+  - ps: python -m pip install coveralls>=1.1 --upgrade
+
 
 build_script:
   # Build the compiled extension
@@ -156,6 +159,9 @@ test_script:
 
   # Our Windows GDAL doesn't have iconv and can't support certain tests.
   - "%CMD_IN_ENV% python -m pytest -m \"not iconv and not wheel\" --cov fiona --cov-report term-missing"
+
+after_test:
+  - coveralls || echo "!! intermittent coveralls failure"
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,7 +128,7 @@ install:
   - "%CMD_IN_ENV% pip install -r requirements-dev.txt"
 
   # Install coverage testing dependencies
-  - ps: python -m pip install coveralls>=1.1 --upgrade
+#  - ps: python -m pip install coveralls>=1.1 --upgrade
 
 build_script:
   # Build the compiled extension
@@ -158,7 +158,7 @@ test_script:
   - "%CMD_IN_ENV% python -m pytest -m \"not iconv and not wheel\" --cov fiona --cov-report term-missing"
 
 after_test:
-  - coveralls || echo "!! intermittent coveralls failure"
+#  - coveralls || echo "!! intermittent coveralls failure"
 
 matrix:
   allow_failures:

--- a/setup.py
+++ b/setup.py
@@ -170,8 +170,7 @@ if 'clean' not in sys.argv:
     gdal_version_parts = gdalversion.split('.')
     gdal_major_version = int(gdal_version_parts[0])
     gdal_minor_version = int(gdal_version_parts[1])
-
-log.info("GDAL version major=%r minor=%r", gdal_major_version, gdal_minor_version)
+    log.info("GDAL version major=%r minor=%r", gdal_major_version, gdal_minor_version)
 
 ext_options = dict(
     include_dirs=include_dirs,


### PR DESCRIPTION
https://github.com/Toblerity/Fiona/commit/724e355a9d54a883a4ae7160321275a70861fd0d removed coveralls from travis.

In case this was accidental, this PR adds coveralls to travis and appveyor. Although, it is disabled on appveyor for now as it  requires a token. 

Furthermore the PR includes https://github.com/Toblerity/Fiona/pull/874.
