### PR TITLE
Sync travis of maint-1.8 with master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-dist: trusty
-
 language: python
-
-python:
-  - "2.7"
-  - "3.6"
+dist: xenial
+# default gcc of bionic does not compile gdal 1.x
 
 cache:
   directories:
@@ -19,48 +15,92 @@ env:
     - GDALBUILD=$HOME/gdalbuild
     - PROJINST=$HOME/gdalinstall
     - PROJBUILD=$HOME/projbuild
-  matrix:
-    - GDALVERSION="1.11.5" PROJVERSION="4.8.0"
-    - GDALVERSION="2.0.3" PROJVERSION="4.9.3"
-    - GDALVERSION="2.1.4" PROJVERSION="4.9.3"
-    - GDALVERSION="2.2.4" PROJVERSION="4.9.3"
-    - GDALVERSION="2.3.3" PROJVERSION="4.9.3"
-    - GDALVERSION="2.4.2" PROJVERSION="4.9.3"
-    - GDALVERSION="3.0.1" PROJVERSION="6.1.1"
-    - GDALVERSION="master" PROJVERSION="6.1.1"
+    - MAKEFLAGS="-j 2"
 
 matrix:
+  include:
+    # Test all supported gdal minor versions (except latest stable) with one python version
+    - python: "3.6"
+      env:
+        GDALVERSION="1.11.5"
+        PROJVERSION="4.8.0"
+    - python: "3.6"
+      env:
+        GDALVERSION="2.0.3"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      env:
+        GDALVERSION="2.1.4"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      env:
+        GDALVERSION="2.2.4"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      env:
+        GDALVERSION="2.3.3"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      env:
+        GDALVERSION="2.4.4"
+        PROJVERSION="4.9.3"
+
+    # Test all supported python versions with latest stable gdal release
+    - python: "2.7"
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.6"
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.7"
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.8"
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+
+    # Test master
+    - python: "3.8"
+      env:
+        GDALVERSION="master"
+        PROJVERSION="6.3.1"
+
   allow_failures:
-    - env: GDALVERSION="master" PROJVERSION="6.1.1"
+    - env:
+        GDALVERSION="master"
+        PROJVERSION="6.3.1"
 
 addons:
   apt:
     packages:
-    - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev
     - gfortran
+    - libsqlite3-dev
+    - sqlite3
 
 before_install:
-  - pip install -U pip
-  - pip install wheel coveralls>=1.1 --upgrade
-  - pip install setuptools==36.0.1
-  - pip install wheel
+  - python -m pip install -U pip
+  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
+  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
   - . ./scripts/travis_gdal_install.sh
-  - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$PATH
-  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj
   - gdal-config --version
+  - python -m pip wheel -r requirements-dev.txt
+  - python -m pip install -r requirements-dev.txt
+  - python -m pip install wheel coveralls>=1.1 --upgrade
 
 install:
-  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == "$GDALVERSION" ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
-  - "python -m pip wheel -r requirements-dev.txt"
-  - "python -m pip install -r requirements-dev.txt"
-  - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --upgrade --force-reinstall --no-use-pep517 -e .[test]"
+  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+  - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --no-deps --force-reinstall --no-use-pep517 -e ."
+  - python -m pip freeze
   - fio --version
-  - gdal-config --version
   - fio --gdal-version
 
 script:
@@ -71,6 +111,3 @@ after_script:
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"
-
-before_cache:
-  - if [ "$GDALVERSION" = "trunk" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -42,7 +42,11 @@ GDALOPTS="  --with-ogr \
             --without-ruby \
             --without-perl \
             --without-php \
-            --without-python"
+            --without-python \
+            --with-oci=no \
+            --without-mrf \
+            --with-webp=no"
+
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then
@@ -60,23 +64,26 @@ if [ "$GDALVERSION" = "master" ]; then
     cd $GDALBUILD
     git clone --depth 1 https://github.com/OSGeo/gdal gdal-$GDALVERSION
     cd gdal-$GDALVERSION/gdal
+    echo $PROJVERSION > newproj.txt
     git rev-parse HEAD > newrev.txt
     BUILD=no
     # Only build if nothing cached or if the GDAL revision changed
     if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
         BUILD=yes
-    elif ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null; then
+    elif ( ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null ) || ( ! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ); then
         BUILD=yes
     fi
     if test "$BUILD" = "yes"; then
         mkdir -p $GDALINST/gdal-$GDALVERSION
         cp newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt
+        cp newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt
         ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
-        make -j 4
+        make
         make install
     fi
 
 else
+
     case "$GDALVERSION" in
         3*)
             PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
@@ -99,6 +106,9 @@ else
         1*)
             PROJOPT="--with-static-proj4=$GDALINST/gdal-$GDALVERSION"
             ;;
+        *)
+            PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
+            ;;
     esac
 
     if [ ! -d "$GDALINST/gdal-$GDALVERSION/share/gdal" ]; then
@@ -108,7 +118,7 @@ else
         tar -xzf gdal-$GDALVERSION.tar.gz
         cd gdal-$gdalver
         ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
-        make -j 4
+        make
         make install
     fi
 fi

--- a/scripts/travis_proj_install.sh
+++ b/scripts/travis_proj_install.sh
@@ -20,7 +20,7 @@ if [ ! -d "$PROJINST/gdal-$GDALVERSION/share/proj" ]; then
     tar -xzf proj-$PROJVERSION.tar.gz
     cd proj-$PROJVERSION
     ./configure --prefix=$PROJINST/gdal-$GDALVERSION
-    make -s -j 2
+    make -s
     make install
 fi
 


### PR DESCRIPTION
This PR backports changes in travis.yml applied to master to maint-1.8. 

As the build matrix with 8 gdal versions and 3 python version would be immense, I would suggest using a cross pattern:
* Testing all supported gdal versions with a single version of Python
* Testing the latest stable gdal release with all supported python versions.  