### PR TITLE
Fix optional keys required

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -256,7 +256,14 @@ def open(fp, mode='r', driver=None, schema=None, crs=None, encoding=None,
             if schema:
                 # Make an ordered dict of schema properties.
                 this_schema = schema.copy()
-                this_schema['properties'] = OrderedDict(schema['properties'])
+                if 'properties' in schema:
+                    this_schema['properties'] = OrderedDict(schema['properties'])
+                else:
+                    this_schema['properties'] = OrderedDict()
+
+                if 'geometry' not in this_schema:
+                    this_schema['geometry'] = None
+
             else:
                 this_schema = None
             c = Collection(path, mode, crs=crs, driver=driver, schema=this_schema,

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1179,6 +1179,13 @@ cdef class WritingSession(Session):
         schema_props_keys = set(collection.schema['properties'].keys())
         for record in records:
             log.debug("Creating feature in layer: %s" % record)
+
+            # Check for optional elements
+            if 'properties' not in record:
+                record['properties'] = {}
+            if 'geometry' not in record:
+                record['geometry'] = None
+
             # Validate against collection's schema.
             if set(record['properties'].keys()) != schema_props_keys:
                 raise ValueError(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -323,6 +323,8 @@ def test_property_only_schema_write(tmpdir, driver):
         assert len(data) == 1
         assert len(data[0].get('properties', {})) == 1
         assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
+        for f in data:
+            assert 'geometry' not in data[0] or data[0]['geometry'] is None
 
 
 @pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
@@ -363,5 +365,6 @@ def test_property_only_schema_update(tmpdir, driver):
         assert len(data) == 2
         for f in data:
             assert len(f.get('properties', {})) == 1
+            assert 'geometry' not in data[0] or data[0]['geometry'] is None
         assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
         assert 'prop1' in data[1]['properties'] and data[1]['properties']['prop1'] == 'two'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -324,7 +324,7 @@ def test_property_only_schema_write(tmpdir, driver):
         assert len(data[0].get('properties', {})) == 1
         assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
         for f in data:
-            assert 'geometry' not in data[0] or data[0]['geometry'] is None
+            assert 'geometry' not in f or f['geometry'] is None
 
 
 @pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
@@ -365,6 +365,6 @@ def test_property_only_schema_update(tmpdir, driver):
         assert len(data) == 2
         for f in data:
             assert len(f.get('properties', {})) == 1
-            assert 'geometry' not in data[0] or data[0]['geometry'] is None
+            assert 'geometry' not in f or f['geometry'] is None
         assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
         assert 'prop1' in data[1]['properties'] and data[1]['properties']['prop1'] == 'two'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,9 @@ from fiona.errors import SchemaError, UnsupportedGeometryTypeError, \
 from fiona.schema import FIELD_TYPES, normalize_field_type
 import os
 import tempfile
-
+from .conftest import get_temp_filename
+from fiona.drvsupport import driver_mode_mingdal
+from fiona.env import GDALVersion
 import pytest
 
 from .conftest import requires_only_gdal1, requires_gdal2
@@ -223,3 +225,143 @@ def test_check_schema_driver_support_gpkg(tmpdir):
                             'geometry': 'LineString',
                             'properties': items}) as c:
             pass
+
+
+@pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
+def test_geometry_only_schema_write(tmpdir, driver):
+    schema = {
+        "geometry": "Polygon",
+        # No properties defined here.
+    }
+
+    record = {'geometry': {'type': 'Polygon', 'coordinates': [[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]]}}
+
+    path = str(tmpdir.join(get_temp_filename(driver)))
+
+    with fiona.open(path,
+                    mode='w',
+                    driver=driver,
+                    schema=schema) as c:
+        c.write(record)
+
+    with fiona.open(path,
+                    mode='r',
+                    driver=driver) as c:
+        data = [f for f in c]
+        assert len(data) == 1
+        assert len(data[0].get('properties', {})) == 0
+        assert data[0]['geometry'] == record['geometry']
+
+
+@pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
+def test_geometry_only_schema_update(tmpdir, driver):
+
+    # Guard unsupported drivers
+    if driver in driver_mode_mingdal['a'] and GDALVersion.runtime() < GDALVersion(
+            *driver_mode_mingdal['a'][driver][:2]):
+        return
+
+    schema = {
+        "geometry": "Polygon",
+        # No properties defined here.
+    }
+
+    record1 = {
+        'geometry': {'type': 'Polygon', 'coordinates': [[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]]}}
+    record2 = {
+        'geometry': {'type': 'Polygon', 'coordinates': [[(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (2.0, 0.0), (0.0, 0.0)]]}}
+
+    path = str(tmpdir.join(get_temp_filename(driver)))
+
+    # Create file
+    with fiona.open(path,
+                    mode='w',
+                    driver=driver,
+                    schema=schema) as c:
+        c.write(record1)
+
+    # Append record
+    with fiona.open(path,
+                    mode='a',
+                    driver=driver) as c:
+        c.write(record2)
+
+    with fiona.open(path,
+                    mode='r',
+                    driver=driver) as c:
+        data = [f for f in c]
+        assert len(data) == 2
+
+        for f in data:
+            assert len(f.get('properties', {})) == 0
+        assert data[0]['geometry'] == record1['geometry']
+        assert data[1]['geometry'] == record2['geometry']
+
+
+@pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
+def test_property_only_schema_write(tmpdir, driver):
+
+    schema = {
+        # No geometry defined here.
+        "properties": {'prop1': 'str'}
+    }
+
+    record1 = {'properties': {'prop1': 'one'}}
+
+    path = str(tmpdir.join(get_temp_filename(driver)))
+
+    with fiona.open(path,
+                    mode='w',
+                    driver=driver,
+                    schema=schema) as c:
+        c.write(record1)
+
+    with fiona.open(path,
+                    mode='r',
+                    driver=driver) as c:
+        data = [f for f in c]
+        assert len(data) == 1
+        assert len(data[0].get('properties', {})) == 1
+        assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
+
+
+@pytest.mark.parametrize('driver', ['GPKG', 'GeoJSON'])
+def test_property_only_schema_update(tmpdir, driver):
+
+    # Guard unsupported drivers
+    if driver in driver_mode_mingdal['a'] and GDALVersion.runtime() < GDALVersion(
+            *driver_mode_mingdal['a'][driver][:2]):
+        return
+
+    schema = {
+        # No geometry defined here.
+        "properties": {'prop1': 'str'}
+    }
+
+    record1 = {'properties': {'prop1': 'one'}}
+    record2 = {'properties': {'prop1': 'two'}}
+
+    path = str(tmpdir.join(get_temp_filename(driver)))
+
+    # Create file
+    with fiona.open(path,
+                    mode='w',
+                    driver=driver,
+                    schema=schema) as c:
+        c.write(record1)
+
+    # Append record
+    with fiona.open(path,
+                    mode='a',
+                    driver=driver) as c:
+        c.write(record2)
+
+    with fiona.open(path,
+                    mode='r',
+                    driver=driver) as c:
+        data = [f for f in c]
+        assert len(data) == 2
+        for f in data:
+            assert len(f.get('properties', {})) == 1
+        assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
+        assert 'prop1' in data[1]['properties'] and data[1]['properties']['prop1'] == 'two'


### PR DESCRIPTION
Fix for https://github.com/Toblerity/Fiona/issues/848

The properties, as well as the geometry key are optional according to https://gist.github.com/sgillies/2217756#__geo_interface__ However, they are currently required by fiona. 

This PR follows the "easy" route, it checks if a schema or record has one of these keys and if not, adds either an empty dictionary for properties or 'geometry' = None for the geometry case.
