### PR TITLE
Protect sequential read

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -301,7 +301,12 @@ Features of a collection may also be accessed by index.
      'properties': OrderedDict([(u'CAT', 232.0), (u'FIPS_CNTRY', u'UK'), (u'CNTRY_NAME', u'United Kingdom'), (u'AREA', 244820.0), (u'POP_CNTRY', 60270708.0)]),
      'type': 'Feature'}
 
-Note that these indices are controlled by GDAL, and do not always follow Python conventions. They can start from 0, 1 (e.g. geopackages), or even other values, and have no guarantee of contiguity. Negative indices will only function correctly if indices start from 0 and are contiguous.
+.. admonition:: Note
+
+    Note that these indices are controlled by GDAL, and do not always follow Python conventions. They can start from 0, 1 (e.g. geopackages), or even other values, and have no guarantee of contiguity. Negative indices will only function correctly if indices start from 0 and are contiguous.
+
+    Important: do not use collection indexing while simultaneously accessing a collection using next().
+
 
 Closing Files
 -------------

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -65,3 +65,7 @@ class GDALVersionError(FionaError):
 
 class FionaDeprecationWarning(UserWarning):
     """A warning about deprecation of Fiona features"""
+
+
+class SequentialReadInterrupted(FionaError):
+    """Raised if a sequential read is interrupted."""

--- a/tests/test_collection_legacy.py
+++ b/tests/test_collection_legacy.py
@@ -156,16 +156,6 @@ class ReadingTest(unittest.TestCase):
         assert f['id'] == "0"
         assert f['properties']['STATE'] == 'UT'
 
-    def test_getitem_iter_combo(self):
-        i = iter(self.c)
-        f = next(i)
-        f = next(i)
-        assert f['id'] == "1"
-        f = self.c[0]
-        assert f['id'] == "0"
-        f = next(i)
-        assert f['id'] == "2"
-
     def test_no_write(self):
         with pytest.raises(IOError):
             self.c.write({})


### PR DESCRIPTION
I had a go to implement a check when a sequential read of an iterator is interrupted. (See https://github.com/Toblerity/Fiona/issues/891) I'm not really satisfied with the result, but I think it could be used as a basis for discussion. 

First some background from gdals documentation:

OGR_L_GetFeature:
```
Sequential reads (with OGR_L_GetNextFeature()) are generally considered interrupted by a OGR_L_GetFeature() call.
```

OGR_L_GetFeatureCount:
```
Note that some implementations of this method may alter the read cursor of the layer.
```

OGR_L_GetNextFeature is used in ogrext/Iterator. Iterator knows about the collection it was created from. Thus, the idea is to add a lock/flag to collection that is set if an iterator is started and released when he is finished. This flag is checked before OGR_L_GetFeature or OGR_L_GetFeatureCount is called. If a lock is set, a SequentialReadInterrupted exception is raised.


So far so good. But there are some issues with this approach. The first one is that an Iterator does not know when he is not used anymore. This is a problem for a membership test:

```
def test_membership_releases_lock(path_coutwildrnp_json):
    with fiona.open(path_coutwildrnp_json) as c:
        assert (0 in c)
        list(c)
```

Here 0 in c would not release the lock, as never a StopIteration condition is reached. This can be fixed by implementing __contains__ in Iterator to ensure that the lock is released. But there might be a better way to do this.

I found another issue with OGR_L_GetFeatureCount:

```
path_gpx = "/home/rene/dev/Fiona/tests/data/test_gpx.gpx"
with fiona.open(path_gpx, "r", layer="track_points") as c:
    print(list(c))
```

Debug Output:
```
DEBUG:fiona.collection:Collection.__len__
DEBUG:fiona.ogrext:Session.get_length()
DEBUG:fiona.ogrext:length: -1
DEBUG:fiona.collection:Collection.__iter__
DEBUG:fiona.collection:lock sequential read
DEBUG:fiona.ogrext:Index: 0
DEBUG:fiona.collection:Collection.__len__
DEBUG:fiona.ogrext:Index: 1
DEBUG:fiona.ogrext:Index: 2
```

```
path_gpx = "/home/rene/dev/Fiona/tests/data/test_gpx.gpx"
with fiona.open(path_gpx, "r", layer="track_points") as c:
    list(c.__iter__())
```

Debug Output:
```
DEBUG:fiona.collection:Collection.__iter__
DEBUG:fiona.collection:lock sequential read
DEBUG:fiona.ogrext:Index: 0
DEBUG:fiona.ogrext:Index: 1
DEBUG:fiona.ogrext:Index: 2
```

I'm not familiar with the implementation of list() in Python. I assume in the first case collection has a __len__ method and list() tries to use it to create a list more efficiently, while Iterator has no __len__. I'm not sure why list calls __len__ the second time, though. The second __len__ is a problem as the sequential read lock is already set. This can be circumvented by checking for the lock in __len__. 