### PR TITLE
Add gdal 3.1.0 to travis of maint-1.8, improve compile time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,31 +54,31 @@ matrix:
     # Test all supported python versions with latest stable gdal release
     - python: "2.7"
       env:
-        GDALVERSION="3.1.0rc3"
+        GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
     - python: "3.6"
       env:
-        GDALVERSION="3.1.0rc3"
+        GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
     - python: "3.7"
       env:
-        GDALVERSION="3.1.0rc3"
+        GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
     - python: "3.8"
       env:
-        GDALVERSION="3.1.0rc3"
+        GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
 
     # Test master
     - python: "3.8"
       env:
         GDALVERSION="master"
-        PROJVERSION="6.3.2"
+        PROJVERSION="7.0.1"
 
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="6.3.2"
+        PROJVERSION="7.0.1"
 
 addons:
   apt:
@@ -91,6 +91,9 @@ addons:
 
 before_install:
   - python -m pip install -U pip
+  - python -m pip wheel -r requirements-dev.txt
+  - python -m pip install -r requirements-dev.txt
+  - python -m pip install wheel coveralls>=1.1 --upgrade
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
@@ -98,9 +101,6 @@ before_install:
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj
   - gdal-config --version
-  - python -m pip wheel -r requirements-dev.txt
-  - python -m pip install -r requirements-dev.txt
-  - python -m pip install wheel coveralls>=1.1 --upgrade
 
 install:
   - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
     - PROJINST=$HOME/gdalinstall
     - PROJBUILD=$HOME/projbuild
     - MAKEFLAGS="-j 2"
+    - CXXFLAGS="-O0"
+    - CFLAGS="-O0"
 
 matrix:
   include:
@@ -44,35 +46,39 @@ matrix:
       env:
         GDALVERSION="2.4.4"
         PROJVERSION="4.9.3"
-
-    # Test all supported python versions with latest stable gdal release
-    - python: "2.7"
-      env:
-        GDALVERSION="3.0.4"
-        PROJVERSION="6.2.1"
     - python: "3.6"
       env:
         GDALVERSION="3.0.4"
         PROJVERSION="6.2.1"
+
+    # Test all supported python versions with latest stable gdal release
+    - python: "2.7"
+      env:
+        GDALVERSION="3.1.0rc3"
+        PROJVERSION="6.3.2"
+    - python: "3.6"
+      env:
+        GDALVERSION="3.1.0rc3"
+        PROJVERSION="6.3.2"
     - python: "3.7"
       env:
-        GDALVERSION="3.0.4"
-        PROJVERSION="6.2.1"
+        GDALVERSION="3.1.0rc3"
+        PROJVERSION="6.3.2"
     - python: "3.8"
       env:
-        GDALVERSION="3.0.4"
-        PROJVERSION="6.2.1"
+        GDALVERSION="3.1.0rc3"
+        PROJVERSION="6.3.2"
 
     # Test master
     - python: "3.8"
       env:
         GDALVERSION="master"
-        PROJVERSION="6.3.1"
+        PROJVERSION="6.3.2"
 
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="6.3.1"
+        PROJVERSION="6.3.2"
 
 addons:
   apt:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [tool:pytest]
 testpaths = tests
+markers =
+    slow
+    network
+    iconv
+    wheel

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -33,13 +33,8 @@ def mock_fhs(tmpdir):
 @pytest.fixture
 def mock_debian(tmpdir):
     """A fake Debian multi-install system"""
-    tmpdir.ensure("share/gdal/1.11/header.dxf")
-    tmpdir.ensure("share/gdal/2.0/header.dxf")
-    tmpdir.ensure("share/gdal/2.1/header.dxf")
-    tmpdir.ensure("share/gdal/2.2/header.dxf")
-    tmpdir.ensure("share/gdal/2.3/header.dxf")
-    tmpdir.ensure("share/gdal/2.4/header.dxf")
-    tmpdir.ensure("share/gdal/3.0/header.dxf")
+    tmpdir.ensure("share/gdal/{}.{}/header.dxf".format(gdal_version.major,
+                                                       gdal_version.minor))
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 

--- a/tests/test_compound_crs.py
+++ b/tests/test_compound_crs.py
@@ -8,4 +8,4 @@ def test_compound_crs(data):
     prj = data.join("coutwildrnp.prj")
     prj.write("""COMPD_CS["unknown",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]],VERT_CS["unknown",VERT_DATUM["unknown",2005],UNIT["metre",1.0,AUTHORITY["EPSG","9001"]],AXIS["Up",UP]]]""")
     with fiona.open(str(data.join("coutwildrnp.shp"))) as collection:
-        assert collection.crs == {}
+        assert isinstance(collection.crs, dict)


### PR DESCRIPTION
As gdal 3.1.0rc3 is out I thought it would be good to enable it on travis. 

Furthermore, the PR backports the test fixes already applied to master and optimizes the compile time by disabling compiler optimizations (-O0). 

As currently the compile time of gdal, proj and fiona is >> the run time of the tests it decreases total run time of the travis build jobs. 
Compilation time of Fiona decreases from roughly 30 seconds to 15 seconds.
Compilation time of gdal master decreases from  20 minutes to 15 minutes. 
