### PR TITLE
[WIP] Protect sequential read alternative

### DIFF
--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -63,5 +63,9 @@ class GDALVersionError(FionaError):
     """
 
 
+class IteratorStoppedError(FionaError):
+    """Raised if iterator is accessed after it was stopped."""
+
+
 class FionaDeprecationWarning(UserWarning):
     """A warning about deprecation of Fiona features"""

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -63,8 +63,8 @@ class GDALVersionError(FionaError):
     """
 
 
-class IteratorStoppedError(FionaError):
-    """Raised if iterator is accessed after it was stopped."""
+class IteratorAlreadyExistsError(FionaError):
+    """Raised if multiple Iterators per Session are attempted to be created."""
 
 
 class FionaDeprecationWarning(UserWarning):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -934,9 +934,10 @@ def test_iterator_sequential_read_interrupted(slice_dataset, args):
         iterator = c.items(start, stop, step)
         for _ in range(interrupted_index):
             _ = next(iterator)
-        iterator.interrupt_sequential_read()
+        # Interrupt sequential read
+        c[-1]
+        assert iterator.is_interrupted()
         item = next(iterator)
-
         assert int(item[1]['properties']['position']) == positions[interrupted_index]
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,16 +9,9 @@ import pytest
 import fiona
 from fiona.collection import Collection
 from fiona.env import getenv, GDALVersion
-from fiona.errors import FionaValueError, DriverError, FionaDeprecationWarning, IteratorStoppedError
+from fiona.errors import FionaValueError, DriverError, FionaDeprecationWarning, IteratorAlreadyExistsError
 from .conftest import WGS84PATTERN, get_temp_filename
 from fiona.drvsupport import supported_drivers, driver_mode_mingdal
-import tempfile
-import os
-import shutil
-
-
-gdal_version = GDALVersion.runtime()
-
 
 
 class TestSupportedDrivers(object):
@@ -884,7 +877,7 @@ def test_collection_zip_http():
     )
     assert (
         ds.path
-        == "/vsizip/vsicurl/https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.zip",
+        == "/vsizip/vsicurl/https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.zip"
     )
     assert len(ds) == 67
 
@@ -920,56 +913,19 @@ def test_collection_env(path_coutwildrnp_shp):
         assert 'FIONA_ENV' in getenv()
 
 
-def test_interrupted_sequential_read(path_coutwildrnp_json):
-        with fiona.open(path_coutwildrnp_json) as c:
-            for key in c.keys():
-                c[key]
-
-
-def test_membership_releases_lock(path_coutwildrnp_json):
-    with fiona.open(path_coutwildrnp_json) as c:
-        5 in c.keys()
-        assert (0 in c)
-
-
-@pytest.fixture(scope="module", params=[driver for driver, raw in supported_drivers.items() if 'w' in raw
-                                        and (driver not in driver_mode_mingdal['w'] or
-                                             gdal_version >= GDALVersion(*driver_mode_mingdal['w'][driver][:2]))
-                                        and driver not in {'DGN', 'MapInfo File', 'GPSTrackMaker', 'GPX', 'BNA', 'DXF',
-                                                           'GML'}])
-def slice_dataset_path(request):
-    """ Create temporary datasets for test_collection_iterator_items_slice()"""
-
-    driver = request.param
-    min_id = 0
-    max_id = 9
-    schema = {'geometry': 'Point', 'properties': [('position', 'int')]}
-    records = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i
-               in range(min_id, max_id + 1)]
-
-    tmpdir = tempfile.mkdtemp()
-    path = os.path.join(tmpdir, get_temp_filename(driver))
-
-    with fiona.open(path, 'w',
-                    driver=driver,
-                    schema=schema) as c:
-        c.writerecords(records)
-    yield path
-    shutil.rmtree(tmpdir)
-
-
-@pytest.mark.parametrize("args", [(0, None, None, 4),
+@pytest.mark.parametrize("args", [(0, None, None, 0),
+                                  (0, None, None, 1),
+                                  (0, None, None, 4),
                                   (0, None, 2, 3),
                                   ])
 @pytest.mark.filterwarnings('ignore:.*OLC_FASTFEATURECOUNT*')
 @pytest.mark.filterwarnings('ignore:.*OLCFastSetNextByIndex*')
-def test_iterator_sequential_read_interrupted(slice_dataset_path, args):
+def test_iterator_sequential_read_interrupted(slice_dataset, args):
     """ Test if iterator resumes at correct position after sequential read is interrupted
     """
 
     start, stop, step, interrupted_index = args
-    min_id = 0
-    max_id = 9
+    slice_dataset_path, min_id, max_id = slice_dataset
 
     positions = list(range(min_id, max_id + 1))[start:stop:step]
 
@@ -984,20 +940,13 @@ def test_iterator_sequential_read_interrupted(slice_dataset_path, args):
         assert int(item[1]['properties']['position']) == positions[interrupted_index]
 
 
-def test_multiple_iterators(slice_dataset_path):
+def test_multiple_iterators(path_coutwildrnp_shp):
     """Test that only one iterator at any time can be active"""
 
-    with fiona.open(slice_dataset_path, 'r') as c:
+    with fiona.open(path_coutwildrnp_shp, 'r') as c:
 
         item_iterator = c.items()
         item = next(item_iterator)
         item = next(item_iterator)
-        filter_iterator = c.filter()
-        with pytest.raises(IteratorStoppedError):
-            item = next(item_iterator)
-
-
-def test_collection_iterator_keys_next(path_coutwildrnp_shp):
-    with fiona.open(path_coutwildrnp_shp) as src:
-        k = next(src.keys(5, None))
-        assert k == 5
+        with pytest.raises(IteratorAlreadyExistsError):
+            filter_iterator = c.filter()


### PR DESCRIPTION
This is an outline of an alternative approach to protect sequential read that has fewer issues compared to https://github.com/Toblerity/Fiona/pull/892

The main idea is that `Collection` should know about all iterators. When OGR_L_GetFeature() or OGR_L_GetFeatureCount() are called, who potentially interrupt a sequential read, Collection notifies all Iterators that they are interrupted. 
In Iterator.__next__() it is first checked if the sequential read is interrupted. If yes, the correct position is set with OGR_L_SetNextByIndex. 

This has the advantage that we do not need to know about the lifecycle of the iterators (are they still active or not). The drawback is, that in a worst-case the performance is bad as often OGR_L_SetNextByIndex is executed, which is potentially costly. 

Another issue that is currently not addressed is that a user can potentially create multiple iterators, which can influence each other:

```
@pytest.fixture(scope="module", params=[driver for driver, raw in supported_drivers.items() if 'w' in raw
                                        and (driver not in driver_mode_mingdal['w'] or
                                             gdal_version >= GDALVersion(*driver_mode_mingdal['w'][driver][:2]))
                                        and driver not in {'DGN', 'MapInfo File', 'GPSTrackMaker', 'GPX', 'BNA', 'DXF',
                                                           'GML'}])
def slice_dataset_path(request):
    """ Create temporary datasets for test_collection_iterator_items_slice()"""

    driver = request.param
    min_id = 0
    max_id = 9
    schema = {'geometry': 'Point', 'properties': [('position', 'int')]}
    records = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i
               in range(min_id, max_id + 1)]

    tmpdir = tempfile.mkdtemp()
    path = os.path.join(tmpdir, get_temp_filename(driver))

    with fiona.open(path, 'w',
                    driver=driver,
                    schema=schema) as c:
        c.writerecords(records)
    yield path
    shutil.rmtree(tmpdir)

def test_multiple_iterators(slice_dataset_path):
    start = 0
    stop = 9
    step = 1

    with fiona.open(slice_dataset_path, 'r') as c:

        item_iterator = c.items(start, stop, step)
        filter_iterator = c.filter(start, stop, step)

        item = next(item_iterator)
        item = next(item_iterator)
        filter_item = next(filter_iterator)
        item = next(item_iterator)

       # This will fail, as next(filter_iterator) can also increase the position of item_iterator
        assert int(item[1]['properties']['position']) == 2
```
