### PR TITLE
Search wheel first to find GDAL_DATA

### DIFF
--- a/fiona/env.py
+++ b/fiona/env.py
@@ -589,8 +589,14 @@ def require_gdal_version(version, param=None, values=None, is_max_version=False,
 
 if "GDAL_DATA" not in os.environ:
 
+    path = GDALDataFinder().search_wheel()
+
+    if path:
+        os.environ['GDAL_DATA'] = path
+        log.debug("GDAL data found in package, GDAL_DATA set to %r.", path)
+
     # See https://github.com/mapbox/rasterio/issues/1631.
-    if GDALDataFinder().find_file("header.dxf"):
+    elif GDALDataFinder().find_file("header.dxf"):
         log.debug("GDAL data files are available at built-in paths")
 
     else:


### PR DESCRIPTION
Fix for https://github.com/Toblerity/Fiona/issues/897

The `path = GDALDataFinder().search_wheel()` from rasterio is missing in Fiona: https://github.com/mapbox/rasterio/commit/059ad3e01c0da363c99cd1f2ca6c4e3353c1485c#diff-bcec099fb5186938da74b5bfc04c1476
