### PR TITLE
Update drvsupport test (PCIDSK, GMT, PDS)

### DIFF
--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from fiona._env import get_gdal_version_num, calc_gdal_version_num
 
 from fiona.env import Env
 
@@ -159,6 +160,19 @@ driver_mode_mingdal = {
           'GeoJSON': (2, 1, 0),
           'MapInfo File': (2, 0, 0)}
 }
+
+
+def driver_supports_mode(driver, mode):
+    """ Returns True if driver supports mode, False otherwise"""
+
+    if driver not in supported_drivers:
+        return False
+    if mode not in supported_drivers[driver]:
+        return False
+    if driver in driver_mode_mingdal[mode]:
+        if get_gdal_version_num() < calc_gdal_version_num(*driver_mode_mingdal[mode][driver]):
+            return False
+    return True
 
 
 # Removes drivers in the supported_drivers dictionary that the

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -63,7 +63,8 @@ supported_drivers = dict([
     # GML 	GML 	Yes 	Yes 	Yes (read support needs Xerces or libexpat)
     ("GML", "rw"),
     # GMT 	GMT 	Yes 	Yes 	Yes
-    ("GMT", "raw"),
+    ("GMT", "rw"),
+    ("OGR_GMT", "rw"),
     # GPSBabel 	GPSBabel 	Yes 	Yes 	Yes (needs GPSBabel and GPX driver)
     # GPX 	GPX 	Yes 	Yes 	Yes (read support needs libexpat)
     ("GPX", "rw"),
@@ -96,7 +97,7 @@ supported_drivers = dict([
     # multi-layer
     #   ("OpenAir", "r"),
     # PCI Geomatics Database File 	PCIDSK 	No 	No 	Yes, using internal PCIDSK SDK (from GDAL 1.7.0)
-    ("PCIDSK", "raw"),
+    ("PCIDSK", "rw"),
     # PDS 	PDS 	No 	Yes 	Yes
     ("PDS", "r"),
     # PGDump 	PostgreSQL SQL dump 	Yes 	Yes 	Yes
@@ -151,11 +152,9 @@ driver_mode_mingdal = {
           'PCIDSK': (2, 0, 0),
           'GeoJSONSeq': (2, 4, 0)},
 
-    'a': {'GMT': (2, 0, 0),
-          'GPKG': (1, 11, 0),
+    'a': {'GPKG': (1, 11, 0),
           'GeoJSON': (2, 1, 0),
-          'MapInfo File': (2, 0, 0),
-          'PCIDSK': (2, 0, 0)}    
+          'MapInfo File': (2, 0, 0)}
 }
 
 

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -64,6 +64,7 @@ supported_drivers = dict([
     ("GML", "rw"),
     # GMT 	GMT 	Yes 	Yes 	Yes
     ("GMT", "rw"),
+    # GMT renamed to OGR_GMT for GDAL 2.x
     ("OGR_GMT", "rw"),
     # GPSBabel 	GPSBabel 	Yes 	Yes 	Yes (needs GPSBabel and GPX driver)
     # GPX 	GPX 	Yes 	Yes 	Yes (read support needs libexpat)
@@ -100,6 +101,8 @@ supported_drivers = dict([
     ("PCIDSK", "rw"),
     # PDS 	PDS 	No 	Yes 	Yes
     ("PDS", "r"),
+    # PDS renamed to OGR_PDS for GDAL 2.x
+    ("OGR_PDS", "r"),
     # PGDump 	PostgreSQL SQL dump 	Yes 	Yes 	Yes
     # PostgreSQL/PostGIS 	PostgreSQL/PostGIS 	Yes 	Yes 	No, needs PostgreSQL client library (libpq)
     # EPIInfo .REC 	REC 	No 	No 	Yes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ driver_extensions = {'DXF': 'dxf',
                      'GeoJSON': 'json',
                      'GeoJSONSeq': 'geojsons',
                      'GMT': 'gmt',
+                     'OGR_GMT': 'gmt',
                      'BNA': 'bna'}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,7 +322,7 @@ def unittest_path_coutwildrnp_shp(path_coutwildrnp_shp, request):
 
 @pytest.fixture()
 def testdata_generator():
-    """ Helper function to create test datasets for ideally all supported drivers
+    """ Helper function to create test data sets for ideally all supported drivers
     """
 
     def get_schema(driver):
@@ -406,6 +406,33 @@ def testdata_generator():
         return is_good
 
     def _testdata_generator(driver, range1, range2):
+        """ Generate test data and helper methods for a specific driver. Each set of generated set of records
+        contains the position specified with range. These positions are either encoded as field or in the geometry
+        of the record, depending of the driver characteristics.
+
+        Parameters
+        ----------
+            driver: str
+                Name of drive to generate tests for
+            range1: list of integer
+                Range of positions for first set of records
+            range2: list of integer
+                Range  of positions for second set of records
+
+        Returns
+        -------
+        schema
+            A schema for the records
+        crs
+            A crs for the records
+        records1
+            A set of records containing the positions of range1
+        records2
+            A set of records containing the positions of range2
+        test_equal
+            A function that returns True if the geometry is equal between the generated records and a record and if
+            the properties of the generated records can be found in a record
+        """
         return get_schema(driver), get_crs(driver), get_records(driver, range1), get_records2(driver, range2),\
                test_equal
 

--- a/tests/test_drvsupport.py
+++ b/tests/test_drvsupport.py
@@ -15,100 +15,77 @@ blacklist_append_drivers = {}
 
 
 def get_schema(driver):
-    """
-    Generate schema for each driver
-    """
-    schemas = {
-        'GPX': {'properties': OrderedDict([('ele', 'float'),
-                                           ('time', 'datetime')]),
-                'geometry': 'Point'},
-        'GPSTrackMaker': {'properties': OrderedDict([]),
-                          'geometry': 'Point'},
-        'DXF': {'properties': OrderedDict(
-            [('Layer', 'str'),
-             ('SubClasses', 'str'),
-             ('Linetype', 'str'),
-             ('EntityHandle', 'str'),
-             ('Text', 'str')]),
-            'geometry': 'Point'},
-        'CSV': {'properties': OrderedDict([('ele', 'float')]),
-                'geometry': None},
-        'DGN': {'properties': OrderedDict([]),
-                'geometry': 'LineString'}
+    special_schemas = {'CSV': {'geometry': None, 'properties': OrderedDict([('position', 'int')])},
+                       'BNA': {'geometry': 'Point', 'properties': {}},
+                       'DXF': {'properties': OrderedDict(
+                           [('Layer', 'str'),
+                            ('SubClasses', 'str'),
+                            ('Linetype', 'str'),
+                            ('EntityHandle', 'str'),
+                            ('Text', 'str')]),
+                           'geometry': 'Point'},
+                       'GPX': {'geometry': 'Point',
+                               'properties': OrderedDict([('ele', 'float'), ('time', 'datetime')])},
+                       'GPSTrackMaker': {'properties': OrderedDict([]), 'geometry': 'Point'},
+                       'DGN': {'properties': OrderedDict([]), 'geometry': 'LineString'},
+                       'MapInfo File': {'geometry': 'Point', 'properties': OrderedDict([('position', 'str')])}
+                       }
+
+    return special_schemas.get(driver, {'geometry': 'Point', 'properties': OrderedDict([('position', 'int')])})
+
+
+def get_records(driver, range):
+    special_records1 = {'CSV': [{'geometry': None, 'properties': {'position': i}} for i in range],
+                        'BNA': [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {}} for i
+                                in range],
+                        'DXF': [
+                            {'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': OrderedDict(
+                                [('Layer', '0'),
+                                 ('SubClasses', 'AcDbEntity:AcDbPoint'),
+                                 ('Linetype', None),
+                                 ('EntityHandle', '20000'),
+                                 ('Text', None)])} for i in range],
+                        'GPX': [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))},
+                                 'properties': {'ele': 0.0, 'time': '2020-03-24T16:08:40'}} for i
+                                in range],
+                        'GPSTrackMaker': [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))},
+                                           'properties': {}} for i in range],
+                        'DGN': [
+                            {'geometry': {'type': 'LineString', 'coordinates': [(float(i), 0.0), (0.0, 0.0)]},
+                             'properties': {}} for i in range],
+                        'MapInfo File': [
+                            {'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))},
+                             'properties': {'position': str(i)}} for i in range],
+                        }
+    return special_records1.get(driver, [
+        {'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i in
+        range])
+
+
+def get_records2(driver, range):
+    special_records2 = {'DGN': [
+        {'geometry': {'type': 'LineString', 'coordinates': [(float(i), 0.0), (0.0, 0.0)]},
+         'properties': OrderedDict(
+             [('Type', 3),
+              ('Level', 0),
+              ('GraphicGroup', 0),
+              ('ColorIndex', 0),
+              ('Weight', 0),
+              ('Style', 0),
+              ('EntityNum', None),
+              ('MSLink', None),
+              ('Text', None)])} for i in range],
     }
-    default_schema = {'geometry': 'LineString',
-                      'properties': [('title', 'str')]}
-    return schemas.get(driver, default_schema)
+    return special_records2.get(driver, get_records(driver, range))
 
 
-def get_record1(driver):
-    """
-    Generate first record to write depending on driver
-    """
-    records = {
-        'GPX': {'properties': OrderedDict([('ele', 386.3),
-                                           ('time', '2020-03-24T16:08:40')]),
-                'geometry': {'type': 'Point', 'coordinates': (8.306711, 47.475623)}},
-        'GPSTrackMaker': {'properties': OrderedDict([]),
-                          'geometry': {'type': 'Point', 'coordinates': (8.306711, 47.475623)}},
-        'DXF': {'properties': OrderedDict(
-            [('Layer', '0'),
-             ('SubClasses', 'AcDbEntity:AcDbPoint'),
-             ('Linetype', None),
-             ('EntityHandle', '20000'),
-             ('Text', None)]),
-            'geometry': {'type': 'Point', 'coordinates': (8.306711, 47.475623)}},
-        'CSV': {'properties': OrderedDict([('ele', 386.3)]),
-                'geometry': None},
-        'DGN': {'properties': OrderedDict(
-            []),
-            'geometry': {'type': 'LineString', 'coordinates': [
-                (1.0, 0.0), (0.0, 0.0)]}}
-    }
-
-    default_record = {'geometry': {'type': 'LineString', 'coordinates': [
-        (1.0, 0.0), (0.0, 0.0)]}, 'properties': {'title': 'One'}}
-
-    return records.get(driver, default_record)
-
-
-def get_record2(driver):
-    """
-    Generate second record to write depending on driver
-    """
-    records = {
-        'GPX': {'properties': OrderedDict([('ele', 386.3),
-                                           ('time', '2020-03-24T16:19:14')]),
-                'geometry': {'type': 'Point', 'coordinates': (8.307451, 47.474996)}},
-        'GPSTrackMaker': {'properties': OrderedDict([]),
-                          'geometry': {'type': 'Point', 'coordinates': (8.307451, 47.474996)}},
-        'DXF': {'properties': OrderedDict(
-            [('Layer', '0'),
-             ('SubClasses', 'AcDbEntity:AcDbPoint'),
-             ('Linetype', None),
-             ('EntityHandle', '20000'),
-             ('Text', None)]),
-            'geometry': {'type': 'Point', 'coordinates': (8.307451, 47.474996)}},
-        'CSV': {'properties': OrderedDict([('ele', 386.8)]),
-                'geometry': None},
-        'DGN': {'properties': OrderedDict(
-            [('Type', 3),
-             ('Level', 0),
-             ('GraphicGroup', 0),
-             ('ColorIndex', 0),
-             ('Weight', 0),
-             ('Style', 0),
-             ('EntityNum', None),
-             ('MSLink', None),
-             ('Text', None)]),
-            'geometry': {'type': 'LineString', 'coordinates': [
-                (2.0, 0.0), (0.0, 0.0)]}}
-    }
-
-    default_record = {'geometry': {'type': 'LineString', 'coordinates': [
-        (2.0, 0.0), (0.0, 0.0)]}, 'properties': {'title': 'Two'}}
-
-    return records.get(driver, default_record)
+def get_pos(f, driver):
+    if driver in {'DXF', 'BNA', 'GPX', 'GPSTrackMaker'}:
+        return f['geometry']['coordinates'][1]
+    elif driver == 'DGN':
+        return f['geometry']['coordinates'][0][0]
+    else:
+        return f['properties']['position']
 
 
 @requires_gdal24
@@ -130,6 +107,7 @@ def test_write_or_driver_error(tmpdir, driver):
         # BNA driver segfaults with gdal 1.11
         return
 
+    positions = list(range(0, 10))
     path = str(tmpdir.join(get_temp_filename(driver)))
 
     if driver in driver_mode_mingdal['w'] and GDALVersion.runtime() < GDALVersion(
@@ -140,7 +118,7 @@ def test_write_or_driver_error(tmpdir, driver):
             with fiona.open(path, 'w',
                             driver=driver,
                             schema=get_schema(driver)) as c:
-                c.write(get_record1(driver))
+                c.writerecords(get_records(driver, positions))
 
     else:
 
@@ -149,11 +127,14 @@ def test_write_or_driver_error(tmpdir, driver):
                         driver=driver,
                         schema=get_schema(driver)) as c:
 
-            c.write(get_record1(driver))
+            c.writerecords(get_records(driver, positions))
 
         with fiona.open(path) as c:
             assert c.driver == driver
-            assert len([f for f in c]) == 1
+            items = list(c)
+            assert len(items) == len(positions)
+            for val_in, val_out in zip(positions, items):
+                assert val_in == int(get_pos(val_out, driver))
 
 
 @pytest.mark.parametrize('driver', [driver for driver in driver_mode_mingdal['w'].keys()
@@ -171,6 +152,7 @@ def test_write_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, monkeypat
         # BNA driver segfaults with gdal 1.11
         return
 
+    positions = list(range(0, 10))
     path = str(tmpdir.join(get_temp_filename(driver)))
 
     if driver in driver_mode_mingdal['w'] and GDALVersion.runtime() < GDALVersion(
@@ -181,7 +163,7 @@ def test_write_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, monkeypat
             with fiona.open(path, 'w',
                             driver=driver,
                             schema=get_schema(driver)) as c:
-                c.write(get_record1(driver))
+                c.writerecords(get_records(driver, positions))
 
 
 @pytest.mark.parametrize('driver', [driver for driver, raw in supported_drivers.items() if 'a' in raw
@@ -198,6 +180,11 @@ def test_append_or_driver_error(tmpdir, driver):
         return
 
     path = str(tmpdir.join(get_temp_filename(driver)))
+    range1 = list(range(0, 5))
+    range2 = list(range(5, 10))
+    records1 = get_records(driver, range1)
+    records2 = get_records2(driver, range2)
+    positions = range1 + range2
 
     # If driver is not able to write, we cannot test append
     if driver in driver_mode_mingdal['w'] and GDALVersion.runtime() < GDALVersion(
@@ -209,7 +196,7 @@ def test_append_or_driver_error(tmpdir, driver):
                     driver=driver,
                     schema=get_schema(driver)) as c:
 
-        c.write(get_record1(driver))
+        c.writerecords(records1)
 
     if driver in driver_mode_mingdal['a'] and GDALVersion.runtime() < GDALVersion(
             *driver_mode_mingdal['a'][driver][:2]):
@@ -218,17 +205,20 @@ def test_append_or_driver_error(tmpdir, driver):
         with pytest.raises(DriverError):
             with fiona.open(path, 'a',
                             driver=driver) as c:
-                c.write(get_record2(driver))
+                c.writerecords(records2)
 
     else:
         # Test if we can append
         with fiona.open(path, 'a',
                         driver=driver) as c:
-            c.write(get_record2(driver))
+            c.writerecords(records2)
 
         with fiona.open(path) as c:
             assert c.driver == driver
-            assert len([f for f in c]) == 2
+            items = list(c)
+            assert len(items) == len(positions)
+            for val_in, val_out in zip(positions, items):
+                assert val_in == int(get_pos(val_out, driver))
 
 
 @pytest.mark.parametrize('driver', [driver for driver in driver_mode_mingdal['a'].keys()
@@ -248,6 +238,11 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, monkeypa
         return
 
     path = str(tmpdir.join(get_temp_filename(driver)))
+    range1 = list(range(0, 5))
+    range2 = list(range(5, 10))
+    records1 = get_records(driver, range1)
+    records2 = get_records2(driver, range2)
+    positions = range1 + range2
 
     # If driver is not able to write, we cannot test append
     if driver in driver_mode_mingdal['w'] and GDALVersion.runtime() < GDALVersion(
@@ -259,7 +254,7 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, monkeypa
                     driver=driver,
                     schema=get_schema(driver)) as c:
 
-        c.write(get_record1(driver))
+        c.writerecords(records1)
 
     if driver in driver_mode_mingdal['a'] and GDALVersion.runtime() < GDALVersion(
             *driver_mode_mingdal['a'][driver][:2]):
@@ -270,11 +265,14 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, monkeypa
         with pytest.raises(Exception):
             with fiona.open(path, 'a',
                             driver=driver) as c:
-                c.write(get_record2(driver))
+                c.writerecords(records2)
 
             with fiona.open(path) as c:
                 assert c.driver == driver
-                assert len([f for f in c]) == 2
+                items = list(c)
+                assert len(items) == len(positions)
+                for val_in, val_out in zip(positions, items):
+                    assert val_in == int(get_pos(val_out, driver))
 
 
 @pytest.mark.parametrize('driver', [driver for driver, raw in supported_drivers.items() if
@@ -298,7 +296,7 @@ def test_no_write_driver_cannot_write(tmpdir, driver, monkeypatch):
         with fiona.open(path, 'w',
                         driver=driver,
                         schema=get_schema(driver)) as c:
-            c.write(get_record1(driver))
+            c.writerecords(get_records(driver, range(0, 10)))
 
 
 @pytest.mark.parametrize('driver', [driver for driver, raw in supported_drivers.items() if
@@ -318,6 +316,11 @@ def test_no_append_driver_cannot_append(tmpdir, driver, monkeypatch):
         return
 
     path = str(tmpdir.join(get_temp_filename(driver)))
+    range1 = list(range(0, 5))
+    range2 = list(range(5, 10))
+    records1 = get_records(driver, range1)
+    records2 = get_records2(driver, range2)
+    positions = range1 + range2
 
     # If driver is not able to write, we cannot test append
     if driver in driver_mode_mingdal['w'] and GDALVersion.runtime() < GDALVersion(
@@ -329,16 +332,19 @@ def test_no_append_driver_cannot_append(tmpdir, driver, monkeypatch):
                     driver=driver,
                     schema=get_schema(driver)) as c:
 
-        c.write(get_record1(driver))
+        c.writerecords(records1)
 
     with pytest.raises(Exception):
         with fiona.open(path, 'a',
                         driver=driver) as c:
-            c.write(get_record2(driver))
+            c.writerecords(records2)
 
         with fiona.open(path) as c:
             assert c.driver == driver
-            assert len([f for f in c]) == 2
+            items = list(c)
+            assert len(items) == len(positions)
+            for val_in, val_out in zip(positions, items):
+                assert val_in == int(get_pos(val_out, driver))
 
 
 def test_mingdal_drivers_are_supported():

--- a/tests/test_drvsupport.py
+++ b/tests/test_drvsupport.py
@@ -91,8 +91,6 @@ def test_write_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, testdata_
 def test_append_or_driver_error(tmpdir, testdata_generator, driver):
     """ Test if driver supports append mode.
 
-    Some driver only allow a specific schema. These drivers can be excluded by adding them to blacklist_append_drivers.
-
     """
 
     if driver == "BNA" and GDALVersion.runtime() < GDALVersion(2, 0):
@@ -143,8 +141,6 @@ def test_append_or_driver_error(tmpdir, testdata_generator, driver):
                                     if driver in supported_drivers])
 def test_append_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, testdata_generator, monkeypatch):
     """ Test if driver supports append mode.
-
-    Some driver only allow a specific schema. These drivers can be excluded by adding them to blacklist_append_drivers.
 
     If this test fails, it should be considered to update driver_mode_mingdal in drvsupport.py.
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -8,7 +8,7 @@ from fiona.env import GDALVersion
 import fiona
 from fiona.errors import FionaDeprecationWarning
 from .conftest import get_temp_filename
-from fiona.drvsupport import supported_drivers, driver_mode_mingdal
+from fiona.drvsupport import supported_drivers, driver_mode_mingdal, driver_supports_mode
 
 gdal_version = GDALVersion.runtime()
 
@@ -43,9 +43,8 @@ def test_collection_iterator_next(path_coutwildrnp_shp):
         assert v['id'] == '5'
 
 
-@pytest.fixture(scope="module", params=[driver for driver, raw in supported_drivers.items() if 'w' in raw
-                                        and (driver not in driver_mode_mingdal['w'] or
-                                             gdal_version >= GDALVersion(*driver_mode_mingdal['w'][driver][:2]))
+@pytest.fixture(scope="module", params=[driver for driver in supported_drivers if
+                                        driver_supports_mode(driver, 'w')
                                         and driver not in {'DGN', 'MapInfo File', 'GPSTrackMaker', 'GPX', 'BNA', 'DXF',
                                                            'GML'}])
 def slice_dataset_path(request):


### PR DESCRIPTION
I noticed that the test to append data only looks at the number of features is not enough to test the PCIDSK driver correctly. 

This PR modifies the drvsupport tests to compare the written data with the result. Ideally, the input records would be compared to the output records, but this is tricky, as some drivers add fields (e.g. the Shapefile driver adds a FID field). This PR only looks at one property (if the field type is supported), respectively checks if the coordinate is correct otherwise. 

Additionally, this PR enables the OGR_PDS and OGR_GMT drivers. It looks as they were renamed with GDAL 2.x. Thus I suppose they are not often used in combination with Fiona. 


```
from collections import OrderedDict
import pprint
import fiona
import os

schema = {'geometry': 'Point', 'properties': OrderedDict([('position', 'int')])}
records1 = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i in range(0, 2)]
records2 = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i in range(5, 10)]
filename = '/tmp/test.pix'
driver = "PCIDSK"

if os.path.exists(filename):
    os.unlink(filename)

with fiona.open(filename,
                mode='w',
                driver=driver,
                schema=schema) as out:
    out.writerecords(records1)

with fiona.open(filename,
                mode='a',
                driver=driver,
                schema=schema) as out:
    out.writerecords(records2)

with fiona.open(filename) as c:
    for f in c:
        pprint.pprint(f)
```

Output:
```
{'geometry': {'coordinates': (0.0, 5.0, 0.0), 'type': 'Point'},
 'id': '0',
 'properties': OrderedDict([('position', '5')]),
 'type': 'Feature'}
{'geometry': {'coordinates': (0.0, 6.0, 0.0), 'type': 'Point'},
 'id': '1',
 'properties': OrderedDict([('position', '6')]),
 'type': 'Feature'}
{'geometry': {'coordinates': (0.0, 7.0, 0.0), 'type': 'Point'},
 'id': '0',
 'properties': OrderedDict([('position', '7')]),
 'type': 'Feature'}
{'geometry': {'coordinates': (0.0, 8.0, 0.0), 'type': 'Point'},
 'id': '1',
 'properties': OrderedDict([('position', '8')]),
 'type': 'Feature'}
{'geometry': {'coordinates': (0.0, 9.0, 0.0), 'type': 'Point'},
 'id': '2',
 'properties': OrderedDict([('position', '9')]),
 'type': 'Feature'}
{'geometry': None,
 'id': '3',
 'properties': OrderedDict([('position', '')]),
 'type': 'Feature'}
{'geometry': None,
 'id': '4',
 'properties': OrderedDict([('position', '')]),
 'type': 'Feature'}
```