### PR TITLE
Select Python version on OSX Travis Jobs using pyenv

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+plugins = Cython.Coverage
+omit = *pxd

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,0 +1,92 @@
+
+name: MacOS CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {python-version: 3.6, GDALVERSION: "2.3.3",   PROJVERSION: "4.9.3"}
+          - {python-version: 3.6, GDALVERSION: "2.4.4",   PROJVERSION: "4.9.3"}
+          - {python-version: 3.6, GDALVERSION: "3.0.4",   PROJVERSION: "6.2.1"}
+          - {python-version: 3.6, GDALVERSION: "3.1.0",   PROJVERSION: "6.3.2"}
+          - {python-version: 3.7, GDALVERSION: "3.1.0",   PROJVERSION: "6.3.2"}
+          - {python-version: 3.8, GDALVERSION: "3.1.0",   PROJVERSION: "6.3.2"}
+#          - {python-version: 3.6, GDALVERSION: "master",  PROJVERSION: "7.0.1", continue-on-error: true}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.config.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.config.python-version }}
+
+      - name: Set env variables
+        run: |
+          touch $GITHUB_WORKSPACE/env_variables
+          echo "export MAKEFLAGS=\"-j 4 -s\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export CXXFLAGS=\"-O0\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export CFLAGS=\"-O0\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALINST=$GITHUB_WORKSPACE/gdalinstall" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALBUILD=$GITHUB_WORKSPACE/gdalbuild" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJINST=$GITHUB_WORKSPACE/gdalinstall" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJBUILD=$GITHUB_WORKSPACE/projbuild" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALVERSION=${{matrix.config.GDALVERSION}}" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJVERSION=${{matrix.config.PROJVERSION}}" >> $GITHUB_WORKSPACE/env_variables
+          echo "export TRAVIS_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_WORKSPACE/env_variables
+          echo "export TRAVIS_OS_NAME=osx" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH="/usr/local/opt/expat/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH="/usr/local/opt/libxml2/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          source $GITHUB_WORKSPACE/env_variables
+          echo "export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          echo "export DYLD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:\$DYLD_LIBRARY_PATH" >> $GITHUB_WORKSPACE/env_variables
+          cat $GITHUB_WORKSPACE/env_variables
+
+      - name: Install brew packages
+        run: |
+          brew install pkg-config expat libspatialite sqlite geos
+          brew list --versions | grep 'expat\|libspatialite\|sqlite\|geos\|curl\|libxml2\|freexl\|zstd' > $GITHUB_WORKSPACE/brew_list
+          cat $GITHUB_WORKSPACE/brew_list
+
+      - name: Dependency Cache
+        uses: actions/cache@v2
+        with:
+          path: gdalinstall
+          key: ${{ runner.os }}-gdal-${{ matrix.config.GDALVERSION }}-proj-${{ matrix.config.PROJVERSION }}-${{ hashFiles('**/brew_list')}}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          python -m pip install coveralls>=1.1 --upgrade
+
+      - name: Build PROJ
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          chmod +x scripts/travis_proj_install.sh && ./scripts/travis_proj_install.sh
+
+      - name: Build GDAL
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          chmod +x scripts/travis_gdal_install.sh && ./scripts/travis_gdal_install.sh
+          gdal-config --version
+
+      - name: Build Fiona
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $($GDALINST/gdal-$GDALVERSION/bin/gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+          GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install -v -v -v --no-deps --force-reinstall --no-use-pep517 -e .
+          fio --version
+          fio --gdal-version
+
+      - name: Test with pytest
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          python -m pytest -m "not wheel" --cov fiona --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
         GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
 
-    # OS X: Test all supported GDAL minor versions (except latest stable) with one Python version
+    # OS X: Test all supported GDAL minor versions with one Python version
     - name: "Python 3.6 / GDAL 2.3 / PROJ 4.9"
       os: osx
       osx_image: xcode9.4
@@ -118,7 +118,6 @@ matrix:
         PROJVERSION="6.2.1"
         PYTHON="3.6.9"
 
-     # OS X: Test all supported python versions with latest stable GDAL release
     - name: "Python 3.6 / GDAL 3.1 / PROJ 6.3"
       os: osx
       osx_image: xcode9.4
@@ -127,23 +126,6 @@ matrix:
         GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
         PYTHON="3.6.9"
-    - name: "Python 3.7 / GDAL 3.1 / PROJ 6.3"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="3.1.0"
-        PROJVERSION="6.3.2"
-        PYTHON="3.7.5"
-    - name: "Python 3.8 / GDAL 3.1 / PROJ 6.3"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="3.1.0"
-        PROJVERSION="6.3.2"
-        PYTHON="3.8.0"
-
 
   allow_failures:
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,40 +92,40 @@ matrix:
         GDALVERSION="3.1.0"
         PROJVERSION="6.3.2"
 
-    # OS X: Test all supported GDAL minor versions with one Python version
-    - name: "Python 3.6 / GDAL 2.3 / PROJ 4.9"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="2.3.3"
-        PROJVERSION="4.9.3"
-        PYTHON="3.6.9"
-    - name: "Python 3.6 / GDAL 2.4 / PROJ 4.9"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="2.4.4"
-        PROJVERSION="4.9.3"
-        PYTHON="3.6.9"
-    - name: "Python 3.6 / GDAL 3.0 / PROJ 6.2"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
-        PYTHON="3.6.9"
-
-    - name: "Python 3.6 / GDAL 3.1 / PROJ 6.3"
-      os: osx
-      osx_image: xcode9.4
-      language: shell
-      env:
-        GDALVERSION="3.1.0"
-        PROJVERSION="6.3.2"
-        PYTHON="3.6.9"
+#    # OS X: Test all supported GDAL minor versions with one Python version
+#    - name: "Python 3.6 / GDAL 2.3 / PROJ 4.9"
+#      os: osx
+#      osx_image: xcode9.4
+#      language: shell
+#      env:
+#        GDALVERSION="2.3.3"
+#        PROJVERSION="4.9.3"
+#        PYTHON="3.6.9"
+#    - name: "Python 3.6 / GDAL 2.4 / PROJ 4.9"
+#      os: osx
+#      osx_image: xcode9.4
+#      language: shell
+#      env:
+#        GDALVERSION="2.4.4"
+#        PROJVERSION="4.9.3"
+#        PYTHON="3.6.9"
+#    - name: "Python 3.6 / GDAL 3.0 / PROJ 6.2"
+#      os: osx
+#      osx_image: xcode9.4
+#      language: shell
+#      env:
+#        GDALVERSION="3.0.3"
+#        PROJVERSION="6.2.1"
+#        PYTHON="3.6.9"
+#
+#    - name: "Python 3.6 / GDAL 3.1 / PROJ 6.3"
+#      os: osx
+#      osx_image: xcode9.4
+#      language: shell
+#      env:
+#        GDALVERSION="3.1.0"
+#        PROJVERSION="6.3.2"
+#        PYTHON="3.6.9"
 
   allow_failures:
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   directories:
     - $GDALINST
     - ~/.cache/pip
+    - $HOME/.pyenv
 
 env:
   global:
@@ -13,12 +14,14 @@ env:
     - GDALBUILD=$HOME/gdalbuild
     - PROJINST=$HOME/gdalinstall
     - PROJBUILD=$HOME/projbuild
+    - CYTHON_COVERAGE="true"
     - MAKEFLAGS="-j 2"
+    - CXXFLAGS="-O0"
+    - CFLAGS="-O0"
 
 addons:
   apt:
     packages:
-      - libatlas-dev
       - libatlas-base-dev
       - gfortran
       - libsqlite3-dev
@@ -29,82 +32,138 @@ addons:
       - libspatialite
       - sqlite
       - geos
+      - pyenv
 
 matrix:
   fast_finish: true
   include:
+
+    # Linux: Test all supported GDAL minor versions (except latest stable) with one Python version
     - os: linux
       dist: xenial
       python: "3.6"
       env:
         GDALVERSION="2.3.3"
         PROJVERSION="4.9.3"
-
     - os: linux
       dist: xenial
       python: "3.6"
       env:
         GDALVERSION="2.4.4"
         PROJVERSION="4.9.3"
-
     - os: linux
       dist: xenial
       python: "3.6"
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
- 
-    - os: linux
-      dist: xenial
-      python: "3.7"
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
-
-    - os: linux
-      dist: xenial
-      python: "3.8"
       env:
         GDALVERSION="3.0.4"
         PROJVERSION="6.2.1"
 
+     # Linux: Test all supported Python versions with latest stable GDAL release
+    - os: linux
+      dist: xenial
+      python: "3.6"
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+    - os: linux
+      dist: xenial
+      python: "3.7"
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+    - os: linux
+      dist: xenial
+      python: "3.8"
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+
+    # Linux: Test master and Python dev
     - os: linux
       dist: xenial
       python: "3.8"
       env:
         GDALVERSION="master"
-        PROJVERSION="6.3.0"
-        
-    - os: osx
-      osx_image: xcode11.2
+        PROJVERSION="7.0.1"
+    - os: linux
+      dist: xenial
+      python: "3.9-dev"
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+
+    # OS X: Test all supported GDAL minor versions (except latest stable) with one Python version
+    - name: "Python 3.6 / GDAL 2.3 / PROJ 4.9"
+      os: osx
+      osx_image: xcode9.4
       language: shell
       env:
         GDALVERSION="2.3.3"
         PROJVERSION="4.9.3"
-
-    - os: osx
-      osx_image: xcode11.2
+        PYTHON="3.6.9"
+    - name: "Python 3.6 / GDAL 2.4 / PROJ 4.9"
+      os: osx
+      osx_image: xcode9.4
       language: shell
       env:
         GDALVERSION="2.4.4"
         PROJVERSION="4.9.3"
-
-    - os: osx
-      osx_image: xcode11.2
+        PYTHON="3.6.9"
+    - name: "Python 3.6 / GDAL 3.0 / PROJ 6.2"
+      os: osx
+      osx_image: xcode9.4
       language: shell
       env:
         GDALVERSION="3.0.3"
         PROJVERSION="6.2.1"
+        PYTHON="3.6.9"
+
+     # OS X: Test all supported python versions with latest stable GDAL release
+    - name: "Python 3.6 / GDAL 3.1 / PROJ 6.3"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+        PYTHON="3.6.9"
+    - name: "Python 3.7 / GDAL 3.1 / PROJ 6.3"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+        PYTHON="3.7.5"
+    - name: "Python 3.8 / GDAL 3.1 / PROJ 6.3"
+      os: osx
+      osx_image: xcode9.4
+      language: shell
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
+        PYTHON="3.8.0"
+
 
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="6.3.0"
-
+        PROJVERSION="7.0.1"
+    - python: "3.9-dev"
+      env:
+        GDALVERSION="3.1.0"
+        PROJVERSION="6.3.2"
 
 before_install:
-  - python3 -m pip install -U pip
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then echo 'eval "$(pyenv init -)"' >> ~/.bash_profile; source ~/.bash_profile; pyenv install --list;pyenv install --skip-existing $PYTHON; pyenv global $PYTHON; pyenv version; which python; fi
+  - python --version
+  - python -m pip install -U pip wheel==0.33.6
+  - python -m pip install -r requirements-ci.txt
+  - python -m pip wheel -r requirements-dev.txt
+  - python -m pip install -r requirements-dev.txt
+  - python -m pip install coveralls>=1.1 --upgrade
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PATH=/Users/travis/.pyenv/versions/$PYTHON/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DYLD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$DYLD_LIBRARY_PATH; fi
   - chmod +x scripts/travis_proj_install.sh && ./scripts/travis_proj_install.sh
@@ -113,19 +172,19 @@ before_install:
   - export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj
   - gdal-config --version
   - $GDALINST/gdal-$GDALVERSION/bin/gdal-config --version
-  - python3 -m pip wheel -r requirements-dev.txt
-  - python3 -m pip install -r requirements-dev.txt
-  - python3 -m pip install coveralls>=1.1 --upgrade
+
 
 install:
   - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $($GDALINST/gdal-$GDALVERSION/bin/gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
-  - GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python3 -m pip install -v -v -v --no-deps --force-reinstall --no-use-pep517 -e .
-  - python3 -m pip freeze
+  - GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install -v -v -v --no-deps --force-reinstall --no-use-pep517 -e .
+  - python -m pip freeze
   - fio --version
   - fio --gdal-version
 
 script:
-  - python3 -m pytest -m "not wheel" --cov fiona --cov-report term-missing
+  - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing
+  # Check documentation
+  #- rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .
 
 after_script:
   - python setup.py clean

--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,13 @@ Fiona reads and writes geographic data files and thereby helps Python programmer
 integrate geographic information systems with other computer systems. Fiona
 contains extension modules that link the Geospatial Data Abstraction Library (GDAL).
 
-.. image:: https://travis-ci.org/Toblerity/Fiona.png?branch=master
+.. image:: https://travis-ci.org/Toblerity/Fiona.svg?branch=master
    :target: https://travis-ci.org/Toblerity/Fiona
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/Toblerity/Fiona?svg=true
    :target: https://ci.appveyor.com/project/sgillies/fiona/branch/master
 
-.. image:: https://coveralls.io/repos/Toblerity/Fiona/badge.png
+.. image:: https://coveralls.io/repos/Toblerity/Fiona/badge.svg
    :target: https://coveralls.io/r/Toblerity/Fiona
 
 Fiona is designed to be simple and dependable. It focuses on reading and

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ contains extension modules that link the Geospatial Data Abstraction Library (GD
 .. image:: https://coveralls.io/repos/Toblerity/Fiona/badge.svg
    :target: https://coveralls.io/r/Toblerity/Fiona
 
+.. image:: https://github.com/Toblerity/Fiona/workflows/MacOS%20CI/badge.svg
+
 Fiona is designed to be simple and dependable. It focuses on reading and
 writing data in standard Python IO style and relies upon familiar Python types
 and protocols such as files, dictionaries, mappings, and iterators instead of

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,3 @@
+coveralls
+sphinx==3.0.2
+rstcheck==3.3.1

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,17 @@ ext_options = dict(
     libraries=libraries,
     extra_link_args=extra_link_args)
 
+# Enable coverage for cython pyx files.
+if os.environ.get('CYTHON_COVERAGE'):
+    from Cython.Compiler.Options import get_directive_defaults
+    directive_defaults = get_directive_defaults()
+    directive_defaults['linetrace'] = True
+    directive_defaults['binding'] = True
+
+    ext_options.update(dict(
+        define_macros=[("CYTHON_TRACE_NOGIL", "1")]))
+
+
 # GDAL 2.3+ requires C++11
 
 if language == "c++":


### PR DESCRIPTION
Using pyenv it is possible to select a Python Version on OSX. The drawback is, that the installation requires roughly 3 additional minutes, however, it can be cached. I thought about using the same build matrix for OSX as for Linux, but I did not because the build time of OSX jobs is a lot slower and it seems as there are only two concurrent jobs active. Thus, it might be good if there are fewer OSX jobs running. 

The Python version must be one listed in "pyenv install --list". I noticed that different versions of Xcode support different Python versions. Thus, if a newer Python version needs to be supported, a newer Xcode image might also be needed. I choose Xcode9.4, as it was faster compared to newer images (in a single run, so this might be arbitrary).

Furthermore, this PR syncs travis with the recent changes in maint-1.8 (rstcheck currently disabled as tests would fail) and uses SVG for the travis / coveralls / appveyor badges (I'm not sure why it irritates me that they currently do not have the same height...).

Additionally, a Python 3.9-dev job is added, which is marked as allowed to fail. A test fails due to botocore, which is currently not compatible with Python 3.9, as it imports xml.etree.cElementTree, which was removed in Python 3.9.  
 