### PR TITLE
Expose driver metadata, refactor dataset creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ fiona/_env.c
 fiona/ogrext1.c
 fiona/ogrext2.c
 fiona/schema.c
+fiona/_meta.c

--- a/fiona/_meta.pyx
+++ b/fiona/_meta.pyx
@@ -34,10 +34,15 @@ def _get_metadata_item(driver, metadata_item):
     cdef char* metadata_c = NULL
     cdef void *cogr_driver
 
-    metadata = ""
     cogr_driver = exc_wrap_pointer(GDALGetDriverByName(driver.encode('utf-8')))
     metadata_c = GDALGetMetadataItem(cogr_driver, strencode(metadata_item), NULL)
+
+    metadata = None
     if metadata_c != NULL:
         metadata = metadata_c
         metadata = metadata.decode('utf-8')
+
+        if len(metadata) == 0:
+            metadata = None
+
     return metadata

--- a/fiona/_meta.pyx
+++ b/fiona/_meta.pyx
@@ -1,0 +1,43 @@
+
+include "gdal.pxi"
+
+from fiona._err cimport  exc_wrap_pointer
+from fiona.compat import strencode
+from fiona._shim cimport gdal_open_vector
+from fiona.env import require_gdal_version
+import logging
+
+# This is required otherwise GDALGetDriverByName returns NULL for GDAL 1.x
+from fiona._shim cimport *
+
+
+log = logging.getLogger(__name__)
+
+
+@require_gdal_version('2.0')
+def _get_metadata_item(driver, metadata_item):
+    """Query metadata items
+
+    Parameters
+    ----------
+    driver : str
+        Driver to query
+    metadata_item : str
+        Metadata item to query
+
+    Returns
+    -------
+    str
+        XML of metadata item or empty string
+
+    """
+    cdef char* metadata_c = NULL
+    cdef void *cogr_driver
+
+    metadata = ""
+    cogr_driver = exc_wrap_pointer(GDALGetDriverByName(driver.encode('utf-8')))
+    metadata_c = GDALGetMetadataItem(cogr_driver, strencode(metadata_item), NULL)
+    if metadata_c != NULL:
+        metadata = metadata_c
+        metadata = metadata.decode('utf-8')
+    return metadata

--- a/fiona/gdal.pxi
+++ b/fiona/gdal.pxi
@@ -11,6 +11,7 @@ cdef extern from "cpl_conv.h" nogil:
     void CPLSetConfigOption(const char* key, const char* val)
     const char* CPLGetConfigOption(const char* key, const char* default)
     const char *CPLFindFile(const char *pszClass, const char *pszBasename)
+    int CPLCheckForFile(char *pszFilename, char **papszSiblingList)
 
 
 cdef extern from "cpl_error.h" nogil:
@@ -47,6 +48,7 @@ cdef extern from "cpl_string.h" nogil:
     char **CSLSetNameValue(char **list, char *name, char *val)
     void CSLDestroy(char **list)
     char **CSLMerge(char **first, char **second)
+    const char* CSLGetField (char **papszStrList, int)
 
 
 cdef extern from "cpl_vsi.h" nogil:
@@ -224,6 +226,7 @@ cdef extern from "gdal.h" nogil:
                                 GDALDatasetH hds, int strict, char **options,
                                 void *progress_func, void *progress_data)
     char** GDALGetMetadata(GDALMajorObjectH obj, const char *pszDomain)
+    char** GDALGetMetadataDomainList(GDALMajorObjectH obj)
     int GDALSetMetadata(GDALMajorObjectH obj, char **papszMD,
                         const char *pszDomain)
     const char* GDALGetMetadataItem(GDALMajorObjectH obj, const char *pszName,

--- a/fiona/meta.py
+++ b/fiona/meta.py
@@ -5,6 +5,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 class MetadataItem:
     # since GDAL 2.0
     CREATION_FIELD_DATA_TYPES = "DMD_CREATIONFIELDDATATYPES"
@@ -81,36 +82,43 @@ def dataset_creation_options(driver):
         return None
 
     # Fix GDALs XML
+    # Same changes as in https://github.com/OSGeo/gdal/commit/f447a31822e26ddf0cabcee0ce673a028550a2a0
     if driver == 'GML':
         xml = xml.replace("<gml:boundedBy>", "&lt;gml:boundedBy&gt;")
+        xml = xml.replace(">Space separated list of filenames of XML schemas that apply to the data file'/>", ">")
     elif driver == 'GPX':
         xml = xml.replace("<extensions>", "&lt;extensions&gt;")
-    elif driver == 'KML':
-        xml = xml.replace("<extensions>", "&lt;extensions&gt;")
-        xml = xml.replace("<name>", "&lt;name&gt;")
-        xml = xml.replace("<description>", "&lt;description&gt;")
-        xml = xml.replace("<AltitudeMode>", "&lt;AltitudeMode&gt;")
-    elif driver == 'GeoRSS':
-        for tag in ['item', 'entry', 'channel', 'title', 'description', 'link', 'updated', 'author', 'name', 'id']:
-            xml = xml.replace("<{}>".format(tag),
-                              "&lt;{}&gt;".format(tag))
-    elif driver == 'LIBKML':
-        for tag in ['BallonStyle', 'ItemIcon', 'NetworkLinkControl', 'Update', 'atom:Author', 'atom:link', 'cookie',
-                    'description', 'expires', 'linkDescription', 'linkName', 'linkSnippet', 'listItemType',
-                    'maxSessionLength', 'message', 'minRefreshPeriod', 'name', 'open', 'phoneNumber', 'snippet',
-                    'visibility']:
-            xml = xml.replace("<{}>".format(tag),
-                              "&lt;{}&gt;".format(tag))
     elif driver == "FileGDB":
         xml = xml.replace("<esri:DataElement>", "&lt;esri:DataElement&gt;")
-    elif driver == 'ISIS3':
-        xml = xml.replace("'boolean'", "'boolean' ")
-        xml = xml.replace("'string'", "'string' ")
-    elif driver == 'GRIB':
-        xml = xml.replace("max='100'", "max='100' ")
-    elif driver == 'Rasterlite':
-        xml = xml.replace("default='(GTiff", "description='(GTiff")
-        xml = xml.replace("type='string' default='GTiff'", "type='string'")
+    # elif driver == 'KML':
+    #     xml = xml.replace("<extensions>", "&lt;extensions&gt;")
+    #     xml = xml.replace("<name>", "&lt;name&gt;")
+    #     xml = xml.replace("<description>", "&lt;description&gt;")
+    #     xml = xml.replace("<AltitudeMode>", "&lt;AltitudeMode&gt;")
+    # elif driver == 'GeoRSS':
+    #     for tag in ['item', 'entry', 'channel', 'title', 'description', 'link', 'updated', 'author', 'name', 'id']:
+    #         xml = xml.replace("<{}>".format(tag),
+    #                           "&lt;{}&gt;".format(tag))
+    # elif driver == 'LIBKML':
+    #     for tag in ['BallonStyle', 'ItemIcon', 'NetworkLinkControl', 'Update', 'atom:Author', 'atom:link', 'cookie',
+    #                 'description', 'expires', 'linkDescription', 'linkName', 'linkSnippet', 'listItemType',
+    #                 'maxSessionLength', 'message', 'minRefreshPeriod', 'name', 'open', 'phoneNumber', 'snippet',
+    #                 'visibility']:
+    #         xml = xml.replace("<{}>".format(tag),
+    #                           "&lt;{}&gt;".format(tag))
+    #     xml = xml.replace("root_doc'/>'", "root_doc'/>")
+    # elif driver == 'KML':
+    #     xml = xml.replace("'root_doc'/>'", "'root_doc'/>")
+    # elif driver == 'ISIS3':
+    #     xml = xml.replace("'boolean'", "'boolean' ")
+    #     xml = xml.replace("'string'", "'string' ")
+    # elif driver == 'GRIB':
+    #     xml = xml.replace("max='100'", "max='100' ")
+    # elif driver == 'Rasterlite':
+    #     xml = xml.replace("default='(GTiff", "description='(GTiff")
+    #     xml = xml.replace("type='string' default='GTiff'", "type='string'")
+    # elif driver == 'PDF':
+    #     xml = xml.replace("alt_config_option=", " alt_config_option=")
 
     return _parse_options(xml)
 
@@ -138,14 +146,19 @@ def layer_creation_options(driver):
         return None
 
     # Fix GDALs XML
-    if driver == "LIBKML":
-        for tag in ['BallonStyle', 'Camera', 'Document', 'Folder', 'ItemIcon', 'LookAt', 'NetworkLinkControl', 'Region',
-                    'ScreenOverlay', 'Update', 'altitude', 'altitudeMode', 'atom:Author', 'atom:link', 'description',
-                    'expires', 'heading', 'latitude', 'linkDescription', 'linkSnippet', 'listItemType', 'longitude',
-                    'maxSessionLengthcookie', 'message', 'minRefreshPeriod', 'name', 'open', 'overlayXY', 'phoneNumber',
-                    'range', 'roll', 'screenXY', 'sizeXY', 'snippet', 'tilt', 'visibility']:
-            xml = xml.replace("<{}>".format(tag),
-                              "&lt;{}&gt;".format(tag))
+    # Same changes as in https://github.com/OSGeo/gdal/commit/f447a31822e26ddf0cabcee0ce673a028550a2a0
+    # if driver == "LIBKML":
+    #     for tag in ['BallonStyle', 'Camera', 'Document', 'Folder', 'ItemIcon', 'LookAt', 'NetworkLinkControl', 'Region',
+    #                 'ScreenOverlay', 'Update', 'altitude', 'altitudeMode', 'atom:Author', 'atom:link', 'description',
+    #                 'expires', 'heading', 'latitude', 'linkDescription', 'linkSnippet', 'listItemType', 'longitude',
+    #                 'maxSessionLengthcookie', 'message', 'minRefreshPeriod', 'name', 'open', 'overlayXY', 'phoneNumber',
+    #                 'range', 'roll', 'screenXY', 'sizeXY', 'snippet', 'tilt', 'visibility']:
+    #         xml = xml.replace("<{}>".format(tag),
+    #                           "&lt;{}&gt;".format(tag))
+    # elif driver == 'ElasticSearch':
+    #     xml = xml.replace("FeatureCollection'/>.", "FeatureCollection'/>")
+    # elif driver in {'CouchDB', 'Cloudant'}:
+    #     xml = xml.replace("'GEOJSON '", "'GEOJSON'")
 
     return _parse_options(xml)
 
@@ -201,10 +214,19 @@ def print_driver_options(driver):
                     print("\t\tDescription: {description}".format(description=options[option_name]['description']))
                 if 'type' in options[option_name]:
                     print("\t\tType: {type}".format(type=options[option_name]['type']))
-                if 'default' in options[option_name]:
-                    print("\t\tDefault value: {default}".format(default=options[option_name]['default']))
                 if 'values' in options[option_name] and len(options[option_name]['values']) > 0:
                     print("\t\tAccepted values: {values}".format(values=",".join(options[option_name]['values'])))
+                for attr_text, attribute in [('Default value', 'default'),
+                                             ('Required', 'required'),
+                                             ('Alias', 'aliasOf'),
+                                             ('Min', 'min'),
+                                             ('Max', 'max'),
+                                             ('Max size', 'maxsize'),
+                                             ('Scope', 'scope'),
+                                             ('Alternative configuration option', 'alt_config_option')]:
+                    if attribute in options[option_name]:
+                        print("\t\t{attr_text}: {attribute}".format(attr_text=attr_text,
+                                                                    attribute=options[option_name][attribute]))
         print("")
 
 

--- a/fiona/meta.py
+++ b/fiona/meta.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from fiona._meta import _get_metadata_item
-from fiona.env import require_gdal_version, GDALVersion
+from fiona.env import require_gdal_version
 import logging
 
 log = logging.getLogger(__name__)
@@ -80,11 +80,10 @@ def dataset_creation_options(driver):
     if len(xml) == 0:
         return None
 
-    # Fix XML
+    # Fix GDALs XML
     if driver == 'GML':
         xml = xml.replace("<gml:boundedBy>", "&lt;gml:boundedBy&gt;")
     elif driver == 'GPX':
-        print("replace")
         xml = xml.replace("<extensions>", "&lt;extensions&gt;")
     elif driver == 'KML':
         xml = xml.replace("<extensions>", "&lt;extensions&gt;")
@@ -92,16 +91,18 @@ def dataset_creation_options(driver):
         xml = xml.replace("<description>", "&lt;description&gt;")
         xml = xml.replace("<AltitudeMode>", "&lt;AltitudeMode&gt;")
     elif driver == 'GeoRSS':
-        xml = xml.replace("<item>", "&lt;item&gt;")
-        xml = xml.replace("<entry>", "&lt;entry&gt;")
-        xml = xml.replace("<channel>", "&lt;channel&gt;")
-        xml = xml.replace("<title>", "&lt;title&gt;")
-        xml = xml.replace("<description>", "&lt;description&gt;")
-        xml = xml.replace("<link>", "&lt;link&gt;")
-        xml = xml.replace("<updated>", "&lt;updated&gt;")
-        xml = xml.replace("<author>", "&lt;author&gt;")
-        xml = xml.replace("<name>", "&lt;name&gt;")
-        xml = xml.replace("<id>", "&lt;id&gt;")
+        for tag in ['item', 'entry', 'channel', 'title', 'description', 'link', 'updated', 'author', 'name', 'id']:
+            xml = xml.replace("<{}>".format(tag),
+                              "&lt;{}&gt;".format(tag))
+    elif driver == 'LIBKML':
+        for tag in ['BallonStyle', 'ItemIcon', 'NetworkLinkControl', 'Update', 'atom:Author', 'atom:link', 'cookie',
+                    'description', 'expires', 'linkDescription', 'linkName', 'linkSnippet', 'listItemType',
+                    'maxSessionLength', 'message', 'minRefreshPeriod', 'name', 'open', 'phoneNumber', 'snippet',
+                    'visibility']:
+            xml = xml.replace("<{}>".format(tag),
+                              "&lt;{}&gt;".format(tag))
+    elif driver == "FileGDB":
+        xml = xml.replace("<esri:DataElement>", "&lt;esri:DataElement&gt;")
     elif driver == 'ISIS3':
         xml = xml.replace("'boolean'", "'boolean' ")
         xml = xml.replace("'string'", "'string' ")
@@ -135,6 +136,16 @@ def layer_creation_options(driver):
 
     if len(xml) == 0:
         return None
+
+    # Fix GDALs XML
+    if driver == "LIBKML":
+        for tag in ['BallonStyle', 'Camera', 'Document', 'Folder', 'ItemIcon', 'LookAt', 'NetworkLinkControl', 'Region',
+                    'ScreenOverlay', 'Update', 'altitude', 'altitudeMode', 'atom:Author', 'atom:link', 'description',
+                    'expires', 'heading', 'latitude', 'linkDescription', 'linkSnippet', 'listItemType', 'longitude',
+                    'maxSessionLengthcookie', 'message', 'minRefreshPeriod', 'name', 'open', 'overlayXY', 'phoneNumber',
+                    'range', 'roll', 'screenXY', 'sizeXY', 'snippet', 'tilt', 'visibility']:
+            xml = xml.replace("<{}>".format(tag),
+                              "&lt;{}&gt;".format(tag))
 
     return _parse_options(xml)
 

--- a/fiona/meta.py
+++ b/fiona/meta.py
@@ -1,0 +1,214 @@
+import xml.etree.ElementTree as ET
+from fiona._meta import _get_metadata_item
+from fiona.env import require_gdal_version, GDALVersion
+
+
+class MetadataItem:
+    # since GDAL 2.0
+    CREATION_FIELD_DATA_TYPES = "DMD_CREATIONFIELDDATATYPES"
+    # since GDAL 2.3
+    CREATION_FIELD_DATA_SUB_TYPES = "DMD_CREATIONFIELDDATASUBTYPES"
+    CREATION_OPTION_LIST = "DMD_CREATIONOPTIONLIST"
+    LAYER_CREATION_OPTION_LIST = "DS_LAYER_CREATIONOPTIONLIST"
+    # since GDAL 2.0
+    DATASET_OPEN_OPTIONS = "DMD_OPENOPTIONLIST"
+    # since GDAL 2.0
+    EXTENSIONS = "DMD_EXTENSIONS"
+    EXTENSION = "DMD_EXTENSION"
+    VIRTUAL_IO = "DCAP_VIRTUALIO"
+    # since GDAL 2.0
+    NOT_NULL_FIELDS = "DCAP_NOTNULL_FIELDS"
+    # since gdal 2.3
+    NOT_NULL_GEOMETRY_FIELDS = "DCAP_NOTNULL_GEOMFIELDS"
+    # since GDAL 3.2
+    UNIQUE_FIELDS = "DCAP_UNIQUE_FIELDS"
+    # since GDAL 2.0
+    DEFAULT_FIELDS = "DCAP_DEFAULT_FIELDS"
+    OPEN = "DCAP_OPEN"
+    CREATE = "DCAP_CREATE"
+
+
+def _parse_options(xml):
+    """Convert metadata xml to dict"""
+    options = {}
+    if len(xml) > 0:
+
+        root = ET.fromstring(xml)
+        for option in root.iter('Option'):
+
+            option_name = option.attrib['name']
+            opt = {}
+            opt.update((k, v) for k, v in option.attrib.items() if not k == 'name')
+
+            values = []
+            for value in option.iter('Value'):
+                values.append(value.text)
+            if len(values) > 0:
+                opt['values'] = values
+
+            options[option_name] = opt
+
+    return options
+
+
+@require_gdal_version('2.0')
+def dataset_creation_options(driver):
+    """ Returns dataset creation options for driver
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    dict
+        Dataset creation options
+
+    """
+
+    xml = _get_metadata_item(driver, MetadataItem.CREATION_OPTION_LIST)
+
+    # Fix XML
+    if driver == 'GML':
+        xml = xml.replace("<gml:boundedBy>", "&lt;gml:boundedBy&gt;")
+    elif driver == 'GPX':
+        xml = xml.replace("<extensions>", "&lt;extensions&gt;")
+
+    options = _parse_options(xml)
+    return options
+
+
+@require_gdal_version('2.0')
+def layer_creation_options(driver):
+    """ Returns layer creation options for driver
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    dict
+        Layer creation options
+
+    """
+    xml = _get_metadata_item(driver, MetadataItem.LAYER_CREATION_OPTION_LIST)
+    options = _parse_options(xml)
+    return options
+
+
+@require_gdal_version('2.0')
+def dataset_open_options(driver):
+    """ Returns dataset open options for driver
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    dict
+        Dataset open options
+
+    """
+    xml = _get_metadata_item(driver, MetadataItem.DATASET_OPEN_OPTIONS)
+    options = _parse_options(xml)
+    return options
+
+
+@require_gdal_version('2.0')
+def print_driver_options(driver):
+    """ Print driver options for dataset open, dataset creation, and layer creation.
+
+    Parameters
+    ----------
+    driver : str
+
+    """
+
+    for option_type, options in [("Dataset Open Options", dataset_open_options(driver)),
+                                 ("Dataset Creation Options", dataset_creation_options(driver)),
+                                 ("Layer Creation Options", layer_creation_options(driver))]:
+
+        print("{option_type}:".format(option_type=option_type))
+        if len(options) == 0:
+            print("\tNo options available.")
+
+        else:
+            for option_name in options:
+                print("\t{option_name}:".format(option_name=option_name))
+                if 'description' in options[option_name]:
+                    print("\t\tDescription: {description}".format(description=options[option_name]['description']))
+                if 'type' in options[option_name]:
+                    print("\t\tType: {type}".format(type=options[option_name]['type']))
+                if 'default' in options[option_name]:
+                    print("\t\tDefault value: {default}".format(default=options[option_name]['default']))
+                if 'values' in options[option_name] and len(options[option_name]['values']) > 0:
+                    print("\t\tAccepted values: {values}".format(values=",".join(options[option_name]['values'])))
+        print("")
+
+
+@require_gdal_version('2.0')
+def extensions(driver):
+    """ Returns file extensions supported by driver
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    list
+        List with file extensions
+
+    """
+    driver_extensions = set()
+    if GDALVersion().runtime().at_least((2, 0)):
+        for ext in _get_metadata_item(driver, MetadataItem.EXTENSIONS).split(" "):
+            if len(ext) > 0:
+                driver_extensions.add(ext)
+    for ext in _get_metadata_item(driver, MetadataItem.EXTENSION).split(" "):
+        if len(ext) > 0:
+            driver_extensions.add(ext)
+    return list(driver_extensions)
+
+
+@require_gdal_version('2.0')
+def supports_vsi(driver):
+    """ Returns True if driver supports GDAL's VSI*L API
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    bool
+
+    """
+    return _get_metadata_item(driver, MetadataItem.VIRTUAL_IO).upper() == "YES"
+
+
+@require_gdal_version('2.0')
+def supported_field_types(driver):
+    """ Returns supported field and sub field types
+
+    Parameters
+    ----------
+    driver : str
+
+    Returns
+    -------
+    list
+        List with supported field types
+
+    """
+    field_types = set()
+    for field_type in _get_metadata_item(driver, MetadataItem.CREATION_FIELD_DATA_TYPES).split(" "):
+        field_types.add(field_type)
+
+    if GDALVersion().runtime().at_least((2, 3)):
+        for field_type in _get_metadata_item(driver, MetadataItem.CREATION_FIELD_DATA_SUB_TYPES).split(" "):
+            field_types.add(field_type)
+
+    return list(field_types)

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ if source_is_repo and "clean" not in sys.argv:
         Extension('fiona._crs', ['fiona/_crs.pyx'], **ext_options),
         Extension('fiona._env', ['fiona/_env.pyx'], **ext_options),
         Extension('fiona._err', ['fiona/_err.pyx'], **ext_options),
+        Extension('fiona._meta', ['fiona/_meta.pyx'], **ext_options),
         Extension('fiona._shim', ['fiona/_shim.pyx'], **ext_options),
         Extension('fiona.ogrext', ['fiona/ogrext.pyx'], **ext_options)
         ],
@@ -252,6 +253,7 @@ elif "clean" not in sys.argv:
         Extension('fiona._crs', ['fiona/_crs.c'], **ext_options),
         Extension('fiona._env', ['fiona/_env.c'], **ext_options),
         Extension('fiona._err', ['fiona/_err.c'], **ext_options),
+        Extension('fiona._meta', ['fiona/_meta.c'], **ext_options),
         Extension('fiona.ogrext', ['fiona/ogrext.c'], **ext_options),
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,10 @@ requires_gdal22 = pytest.mark.skipif(
     not gdal_version.at_least('2.2'),
     reason="Requires GDAL 2.2.x")
 
+requires_gdal23 = pytest.mark.skipif(
+    not gdal_version.at_least('2.3'),
+    reason="Requires GDAL 2.3.x")
+
 requires_gdal24 = pytest.mark.skipif(
     not gdal_version.at_least('2.4'),
     reason="Requires GDAL 2.4.x")

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -46,8 +46,7 @@ def test_bounds(tmpdir, driver):
     with fiona.open(path, 'w',
                     driver=driver,
                     schema={'geometry': 'Point',
-                            'properties': [('title', 'str')]},
-                    fiona_force_driver=True) as c:
+                            'properties': [('title', 'str')]}) as c:
 
         c.writerecords([{'geometry': {'type': 'Point', 'coordinates': (1.0, 10.0)},
                             'properties': {'title': 'One'}}])

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -883,22 +883,34 @@ def test_open_kwargs(tmpdir, path_coutwildrnp_shp):
 
 @pytest.mark.network
 def test_collection_http():
-    ds = fiona.Collection('http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp', vsi='http')
-    assert ds.path == '/vsicurl/http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.shp'
-    assert len(ds) == 10
+    ds = fiona.Collection(
+        "https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.shp",
+        vsi="https",
+    )
+    assert (
+        ds.path
+        == "/vsicurl/https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.shp"
+    )
+    assert len(ds) == 67
 
 
 @pytest.mark.network
 def test_collection_zip_http():
-    ds = fiona.Collection('http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.zip', vsi='zip+http')
-    assert ds.path == '/vsizip/vsicurl/http://raw.githubusercontent.com/OSGeo/gdal/master/autotest/ogr/data/poly.zip'
-    assert len(ds) == 10
+    ds = fiona.Collection(
+        "https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.zip",
+        vsi="zip+https",
+    )
+    assert (
+        ds.path
+        == "/vsizip/vsicurl/https://raw.githubusercontent.com/Toblerity/Fiona/master/tests/data/coutwildrnp.zip"
+    )
+    assert len(ds) == 67
 
 
-def test_encoding_option_warning(tmpdir, caplog):
+def test_no_encoding_option_warning(tmpdir, caplog):
     """There is no ENCODING creation option log warning for GeoJSON"""
     fiona.Collection(str(tmpdir.join("test.geojson")), "w", driver="GeoJSON", crs="epsg:4326",
-            schema={"geometry": "Point", "properties": {"foo": "int"}})
+                     schema={"geometry": "Point", "properties": {"foo": "int"}})
     assert not caplog.text
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -18,10 +18,11 @@ def test_print_driver_options(driver):
 def test_extension(driver):
     # do not fail
     extension = fiona.meta.extension(driver)
+    print(extension, type(extension))
     assert extension is None or isinstance(extension, str)
 
 
-@requires_gdal23
+@requires_gdal2
 @pytest.mark.parametrize("driver", supported_drivers)
 def test_extensions(driver):
     # do not fail
@@ -44,9 +45,9 @@ def test_supported_field_types(driver):
     assert field_types is None or isinstance(field_types, list)
 
 
-@requires_gdal2
+@requires_gdal23
 @pytest.mark.parametrize("driver", supported_drivers)
-def test_supported_field_types(driver):
+def test_supported_sub_field_types(driver):
     # do not fail
     sub_field_types = fiona.meta.supported_sub_field_types(driver)
     assert sub_field_types is None or isinstance(sub_field_types, list)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,34 @@
+import pytest
+import fiona
+import fiona.drvsupport
+import fiona.meta
+from fiona.drvsupport import supported_drivers
+from .conftest import requires_gdal2
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
+def test_print_driver_options(driver):
+    # do not fail
+    fiona.meta.print_driver_options(driver)
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
+def test_extensions(driver):
+    # do not fail
+    isinstance(fiona.meta.extensions(driver), list)
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
+def test_supports_vsi(driver):
+    # do not fail
+    assert fiona.meta.supports_vsi(driver) in (True, False)
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
+def test_supported_field_types(driver):
+    # do not fail
+    isinstance(fiona.meta.extensions(driver), list)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,7 +3,7 @@ import fiona
 import fiona.drvsupport
 import fiona.meta
 from fiona.drvsupport import supported_drivers
-from .conftest import requires_gdal2
+from .conftest import requires_gdal2, requires_gdal23
 
 
 @requires_gdal2
@@ -21,7 +21,7 @@ def test_extension(driver):
     assert extension is None or isinstance(extension, str)
 
 
-@requires_gdal2
+@requires_gdal23
 @pytest.mark.parametrize("driver", supported_drivers)
 def test_extensions(driver):
     # do not fail

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -15,9 +15,18 @@ def test_print_driver_options(driver):
 
 @requires_gdal2
 @pytest.mark.parametrize("driver", supported_drivers)
+def test_extension(driver):
+    # do not fail
+    extension = fiona.meta.extension(driver)
+    assert extension is None or isinstance(extension, str)
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
 def test_extensions(driver):
     # do not fail
-    isinstance(fiona.meta.extensions(driver), list)
+    extensions = fiona.meta.extensions(driver)
+    assert extensions is None or isinstance(extensions, list)
 
 
 @requires_gdal2
@@ -31,4 +40,13 @@ def test_supports_vsi(driver):
 @pytest.mark.parametrize("driver", supported_drivers)
 def test_supported_field_types(driver):
     # do not fail
-    isinstance(fiona.meta.extensions(driver), list)
+    field_types = fiona.meta.supported_field_types(driver)
+    assert field_types is None or isinstance(field_types, list)
+
+
+@requires_gdal2
+@pytest.mark.parametrize("driver", supported_drivers)
+def test_supported_field_types(driver):
+    # do not fail
+    sub_field_types = fiona.meta.supported_sub_field_types(driver)
+    assert sub_field_types is None or isinstance(sub_field_types, list)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -19,7 +19,6 @@ def test_print_driver_options(driver):
 def test_extension(driver):
     # do not fail
     extension = fiona.meta.extension(driver)
-    print(extension, type(extension))
     assert extension is None or isinstance(extension, string_types)
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -4,6 +4,7 @@ import fiona.drvsupport
 import fiona.meta
 from fiona.drvsupport import supported_drivers
 from .conftest import requires_gdal2, requires_gdal23
+from six import string_types
 
 
 @requires_gdal2
@@ -19,7 +20,7 @@ def test_extension(driver):
     # do not fail
     extension = fiona.meta.extension(driver)
     print(extension, type(extension))
-    assert extension is None or isinstance(extension, str)
+    assert extension is None or isinstance(extension, string_types)
 
 
 @requires_gdal2


### PR DESCRIPTION
Since GDAL 2.0, OGR drivers include more metadata. Currently, there is no way to access this metadata (e.g. to query supported dataset open options, dataset creation options, layer creation options, file extensions etc.) through Fiona. This PR adds a new meta module that allows to query metadata. I decided to create a new module as ogrext seems to grow quite large. If you think that this functionality should belong in Fiona we should think about the best architecture (which might be sharable with rasterio). 

File extensions could be used to create in memory datasets, as some drivers have troubles with files without the proper extension (https://github.com/Toblerity/Fiona/pull/901).   With the current implementation,  `fiona.meta.print_driver_options('GeoJSON')`
outputs the following information:  
```
Dataset Open Options:
    FLATTEN_NESTED_ATTRIBUTES:
        Description: Whether to recursively explore nested objects and produce flatten OGR attributes
        Type: boolean
        Default value: NO
    NESTED_ATTRIBUTE_SEPARATOR:
        Description: Separator between components of nested attributes
        Type: string
        Default value: _
    FEATURE_SERVER_PAGING:
        Description: Whether to automatically scroll through results with a ArcGIS Feature Service endpoint
        Type: boolean
    NATIVE_DATA:
        Description: Whether to store the native JSon representation at FeatureCollection and Feature level
        Type: boolean
        Default value: NO
    ARRAY_AS_STRING:
        Description: Whether to expose JSon arrays of strings, integers or reals as a OGR String
        Type: boolean
        Default value: NO
    DATE_AS_STRING:
        Description: Whether to expose date/time/date-time content using dedicated OGR date/time/date-time types or as a OGR String
        Type: boolean
        Default value: NO

Dataset Creation Options:
    No options available.

Layer Creation Options:
    WRITE_BBOX:
        Description: whether to write a bbox property with the bounding box of the geometries at the feature and feature collection level
        Type: boolean
        Default value: NO
    COORDINATE_PRECISION:
        Description: Number of decimal for coordinates. Default is 15 for GJ2008 and 7 for RFC7946
        Type: int
    SIGNIFICANT_FIGURES:
        Description: Number of significant figures for floating-point values
        Type: int
        Default value: 17
    NATIVE_DATA:
        Description: FeatureCollection level elements.
        Type: string
    NATIVE_MEDIA_TYPE:
        Description: Format of NATIVE_DATA. Must be "application/vnd.geo+json", otherwise NATIVE_DATA will be ignored.
        Type: string
    RFC7946:
        Description: Whether to use RFC 7946 standard. Otherwise GeoJSON 2008 initial version will be used
        Type: boolean
        Default value: NO
    WRITE_NAME:
        Description: Whether to write a "name" property at feature collection level with layer name
        Type: boolean
        Default value: YES
    DESCRIPTION:
        Description: (Long) description to write in a "description" property at feature collection level
        Type: string
    ID_FIELD:
        Description: Name of the source field that must be used as the id member of Feature features
        Type: string
    ID_TYPE:
        Description: Type of the id member of Feature features
        Type: string-select
        Accepted values: AUTO,String,Integer
    WRITE_NON_FINITE_VALUES:
        Description: Whether to write NaN / Infinity values
        Type: boolean
        Default value: NO 
```

Knowing the available options allows to filter them in ogrext WritingSession before being passed to gdal_open_vector, gdal_create, respectively GDALDatasetCreateLayer to avoid warnings. (Currently only for write mode, as only there a driver is known). Adding filtering for read and append mode could be added by first querying the driver, such as in _remove() using gdal_open_vector and GDALGetDatasetDriver.
This is related to  https://github.com/Toblerity/Fiona/issues/504 . However, I'm unsure how much of this issue is already solved with https://github.com/Toblerity/Fiona/commit/5e687a06e55d1c634da7792b950deb4b6ea169b3

Adding options filtering to these functions meant to refactor the creation of dataset in the WritingSession.  Especially this part needs a careful review. The biggest change involves using _remove() instead of os.unlink() for all drivers instead of just GeoJSON.  This allows in the following example that all auxiliary files of a Shapefile are deleted when it is overwritten by a GeoJSON dataset. However, as deleting files is potentially very dangerous, I'm unsure if the default of Fiona should be to overwrite files or to fail. What about adding an overwrite=True/False argument to Collection?  The refactoring also fixes https://github.com/Toblerity/Fiona/issues/771 and https://github.com/Toblerity/Fiona/issues/568

```
with fiona.open('foo.shp', "w", driver="ESRI Shapefile", schema=schema1) as dst:
    dst.writerecords(features1)

assert set(os.listdir(tmpdir.strpath)) == {'foo.cpg', 'foo.dbf', 'foo.shx', 'foo.shp'}


with fiona.open('foo.shx', "w", driver="GeoJSON", schema=schema1) as dst:
    dst.writerecords(features1)

assert os.listdir(tmpdir.strpath) == ['foo.shx']
```

If you think this PR is too big or you would like only a subset of the features, I'm happy to refactor this PR or create a new one. 
Documentation of the new features is currently missing, as it is probably best to wait until the implementation is stable before writing it.


