### PR TITLE
[WIP] Replace deprecated GDAL methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ install:
   - fio --version
   - fio --gdal-version
   - python -c "import fiona; fiona.show_versions()"
+  - python scripts/check_deprecated.py
 
 script:
   - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing

--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -36,4 +36,3 @@ from fiona._shim cimport OGR_DS_GetLayerCount as GDALDatasetGetLayerCount
 from fiona._shim cimport OGR_DS_DeleteLayer as GDALDatasetDeleteLayer
 from fiona._shim cimport OGR_DS_CreateLayer as GDALDatasetCreateLayer
 from fiona._shim cimport OGR_Dr_DeleteDataSource as GDALDeleteDataset
-from fiona._shim cimport OGRReleaseDataSource as GDALClose

--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -36,3 +36,4 @@ from fiona._shim cimport OGR_DS_GetLayerCount as GDALDatasetGetLayerCount
 from fiona._shim cimport OGR_DS_DeleteLayer as GDALDatasetDeleteLayer
 from fiona._shim cimport OGR_DS_CreateLayer as GDALDatasetCreateLayer
 from fiona._shim cimport OGR_Dr_DeleteDataSource as GDALDeleteDataset
+from fiona._shim cimport OGRReleaseDataSource as GDALClose

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -914,7 +914,7 @@ cdef class WritingSession(Session):
                     self.cogr_layer = exc_wrap_pointer(GDALDatasetGetLayer(self.cogr_ds, collection.name))
 
             except CPLE_BaseError as exc:
-                OGRReleaseDataSource(self.cogr_ds)
+                GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
                 self.cogr_layer = NULL
                 raise DriverError(u"{}".format(exc))
@@ -982,7 +982,7 @@ cdef class WritingSession(Session):
                     OSRSetFromUserInput(cogr_srs, proj_c)
                     osr_set_traditional_axis_mapping_strategy(cogr_srs)
             except CPLE_BaseError as exc:
-                OGRReleaseDataSource(self.cogr_ds)
+                GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
                 self.cogr_layer = NULL
                 raise CRSError(u"{}".format(exc))
@@ -1061,7 +1061,7 @@ cdef class WritingSession(Session):
                         <OGRwkbGeometryType>geometry_code, options))
 
             except Exception as exc:
-                OGRReleaseDataSource(self.cogr_ds)
+                GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
                 raise DriverIOError(u"{}".format(exc))
 
@@ -1133,7 +1133,7 @@ cdef class WritingSession(Session):
                     exc_wrap_int(OGR_L_CreateField(self.cogr_layer, cogr_fielddefn, 1))
 
                 except (UnicodeEncodeError, CPLE_BaseError) as exc:
-                    OGRReleaseDataSource(self.cogr_ds)
+                    GDALClose(self.cogr_ds)
                     self.cogr_ds = NULL
                     self.cogr_layer = NULL
                     raise SchemaError(u"{}".format(exc))

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1490,7 +1490,7 @@ def _remove(path, driver=None):
         cogr_driver = GDALGetDatasetDriver(cogr_ds)
         GDALClose(cogr_ds)
     else:
-        cogr_driver = OGRGetDriverByName(driver.encode("utf-8"))
+        cogr_driver = GDALGetDriverByName(driver.encode("utf-8"))
 
     if cogr_driver == NULL:
         raise DatasetDeleteError("Null driver when attempting to delete {}".format(path))
@@ -1527,7 +1527,7 @@ def _remove_layer(path, layer, driver=None):
     except (DriverError, FionaNullPointerError):
         raise DatasetDeleteError("Failed to remove data source {}".format(path))
 
-    result = OGR_DS_DeleteLayer(cogr_ds, layer_index)
+    result = GDALDatasetDeleteLayer(cogr_ds, layer_index)
     GDALClose(cogr_ds)
     if result == OGRERR_UNSUPPORTED_OPERATION:
         raise DatasetDeleteError("Removal of layer {} not supported by driver".format(layer_str))

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -237,11 +237,7 @@ cdef extern from "ogr_srs_api.h":
 cdef extern from "ogr_api.h":
 
     const char * OGR_Dr_GetName (void *driver)
-    void *  OGR_Dr_CreateDataSource (void *driver, const char *path, char **options)
-    int     OGR_Dr_DeleteDataSource (void *driver, char *)
-    void *  OGR_Dr_Open (void *driver, const char *path, int bupdate)
     int     OGR_Dr_TestCapability (void *driver, const char *)
-    int     OGR_DS_DeleteLayer (void *datasource, int n)
     void *  OGR_F_Create (void *featuredefn)
     void    OGR_F_Destroy (void *feature)
     long    OGR_F_GetFID (void *feature)
@@ -287,7 +283,6 @@ cdef extern from "ogr_api.h":
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
     void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
-    int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)
     int     OGR_G_GetGeometryType (void *geometry)
@@ -318,10 +313,6 @@ cdef extern from "ogr_api.h":
                 void *layer, double minx, double miny, double maxx, double maxy
                 )
     int     OGR_L_TestCapability (void *layer, char *name)
-    void *  OGRGetDriverByName (char *)
-    void *  OGROpen (char *path, int mode, void *x)
-    void *  OGROpenShared (char *path, int mode, void *x)
-    int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
     long long OGR_F_GetFieldAsInteger64 (void *feature, int n)

--- a/fiona/ogrext3.pxd
+++ b/fiona/ogrext3.pxd
@@ -238,11 +238,7 @@ cdef extern from "ogr_srs_api.h":
 cdef extern from "ogr_api.h":
 
     const char * OGR_Dr_GetName (void *driver)
-    void *  OGR_Dr_CreateDataSource (void *driver, const char *path, char **options)
-    int     OGR_Dr_DeleteDataSource (void *driver, char *)
-    void *  OGR_Dr_Open (void *driver, const char *path, int bupdate)
     int     OGR_Dr_TestCapability (void *driver, const char *)
-    int     OGR_DS_DeleteLayer (void *datasource, int n)
     void *  OGR_F_Create (void *featuredefn)
     void    OGR_F_Destroy (void *feature)
     long    OGR_F_GetFID (void *feature)
@@ -288,7 +284,6 @@ cdef extern from "ogr_api.h":
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
     void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
-    int     OGR_G_GetCoordinateDimension (void *geometry)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)
     int     OGR_G_GetGeometryType (void *geometry)
@@ -319,10 +314,6 @@ cdef extern from "ogr_api.h":
                 void *layer, double minx, double miny, double maxx, double maxy
                 )
     int     OGR_L_TestCapability (void *layer, char *name)
-    void *  OGRGetDriverByName (char *)
-    void *  OGROpen (char *path, int mode, void *x)
-    void *  OGROpenShared (char *path, int mode, void *x)
-    int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
     long long OGR_F_GetFieldAsInteger64 (void *feature, int n)

--- a/scripts/check_deprecated.py
+++ b/scripts/check_deprecated.py
@@ -5,7 +5,7 @@ import re
 
 ignored_files = {'_shim.pyx', '_shim1.pyx', '_shim1.pxd', 'ogrext1.pxd'}
 
-# Listofdeprecatedmethodsfromhttps://gdal.org/doxygen/deprecated.html#_deprecated000028
+# List of deprecated methods from https://gdal.org/doxygen/deprecated.html#_deprecated000028
 deprecated = {
     'CPL_LSBINT16PTR',
     'CPL_LSBINT32PTR(x)',
@@ -53,4 +53,5 @@ for path in files:
 for path in sorted(found_lines):
     print(path)
     for line_nr, line, method in found_lines[path]:
-        print("\t", line_nr, line)
+        print("\t{}\t{}".format(line_nr, line))
+    print("")

--- a/scripts/check_deprecated.py
+++ b/scripts/check_deprecated.py
@@ -1,0 +1,55 @@
+import glob
+import os
+from collections import defaultdict
+
+ignored_files = {'_shim.pyx', '_shim1.pyx', '_shim1.pxd', 'ogrext1.pxd'}
+
+# Listofdeprecatedmethodsfromhttps://gdal.org/doxygen/deprecated.html#_deprecated000028
+deprecated = {
+    'CPL_LSBINT16PTR',
+    'CPL_LSBINT32PTR(x)',
+    'OGR_Dr_CopyDataSource',
+    'OGR_Dr_CreateDataSource',
+    'OGR_Dr_DeleteDataSource',
+    'OGR_Dr_Open',
+    'OGR_Dr_TestCapability',
+    'OGR_DS_CopyLayer',
+    'OGR_DS_CreateLayer',
+    'OGR_DS_DeleteLayer',
+    'OGR_DS_Destroy',
+    'OGR_DS_ExecuteSQL',
+    'OGR_DS_GetDriver',
+    'OGR_DS_GetLayer',
+    'OGR_DS_GetLayerByName',
+    'OGR_DS_GetLayerCount',
+    'OGR_DS_GetName',
+    'OGR_DS_ReleaseResultSet',
+    'OGR_DS_TestCapability',
+    'OGR_G_GetCoordinateDimension',
+    'OGR_G_SetCoordinateDimension',
+    'OGRGetDriver',
+    'OGRGetDriverByName',
+    'OGRGetDriverCount',
+    'OGROpen',
+    'OGROpenShared',
+    'OGRRegisterAll',
+    'OGRReleaseDataSource',
+}
+
+
+found_lines = defaultdict(list)
+files = glob.glob('fiona/*.pyx') + glob.glob('fiona/*.pxd')
+for path in files:
+    if os.path.basename(path) in ignored_files:
+        continue
+
+    with open(path, 'r') as f:
+        for i, line in enumerate(f):
+            for deprecated_method in deprecated:
+                if deprecated_method + "(" in line or deprecated_method + " (" in line:
+                    found_lines[path].append((i+1, line.strip(), deprecated_method))
+
+for path in sorted(found_lines):
+    print(path)
+    for line_nr, line, method in found_lines[path]:
+        print("\t", line_nr, line)

--- a/scripts/check_deprecated.py
+++ b/scripts/check_deprecated.py
@@ -1,6 +1,7 @@
 import glob
 import os
 from collections import defaultdict
+import re
 
 ignored_files = {'_shim.pyx', '_shim1.pyx', '_shim1.pxd', 'ogrext1.pxd'}
 
@@ -36,7 +37,6 @@ deprecated = {
     'OGRReleaseDataSource',
 }
 
-
 found_lines = defaultdict(list)
 files = glob.glob('fiona/*.pyx') + glob.glob('fiona/*.pxd')
 for path in files:
@@ -46,7 +46,8 @@ for path in files:
     with open(path, 'r') as f:
         for i, line in enumerate(f):
             for deprecated_method in deprecated:
-                if deprecated_method + "(" in line or deprecated_method + " (" in line:
+                match = re.search('{}\s*\('.format(deprecated_method), line)
+                if match:
                     found_lines[path].append((i+1, line.strip(), deprecated_method))
 
 for path in sorted(found_lines):


### PR DESCRIPTION
In https://github.com/Toblerity/Fiona/pull/909 I noticed that some deprecated GDAL methods are only partially replaced. 

I created a small helper script to identify these methods. In this PR I already replaced the trivial cases. The current output of the script is as follows:
```
fiona/_env.pyx
	151	return GDALGetDriverCount() + OGRGetDriverCount()
	397	OGRRegisterAll()
	457	for i in range(OGRGetDriverCount()):
	458	drv = OGRGetDriver(i)
fiona/_geometry.pxd
	97	int     OGR_G_GetCoordinateDimension (void *geometry)
fiona/_geometry.pyx
	184	self.ndims = OGR_G_GetCoordinateDimension(geom)
fiona/ogrext.pyx
	1498	if not OGR_Dr_TestCapability(cogr_driver, ODrCDeleteDataSource):
fiona/ogrext2.pxd
	240	int     OGR_Dr_TestCapability (void *driver, const char *)
fiona/ogrext3.pxd
	241	int     OGR_Dr_TestCapability (void *driver, const char *)
```
**_env.pyx and _geometry.pyx**
For the cases of _env.pyx and _geometry.pyx I'm not sure how to handle them. At least OGR_G_GetCoordinateDimension and OGRGetDriverCount have drop-in replacements.  In _shim1.pxd a pattern of renaming imports such as `from fiona._shim cimport OGRGetDriverByName as GDALGetDriverByName` is used. But I'm unsure what the best way would be to apply this pattern here.

**OGR_Dr_TestCapability**
In `ogrext.pyx` OGR_Dr_TestCapability is used to test if a data source can be deleted:
```
    if not OGR_Dr_TestCapability(cogr_driver, ODrCDeleteDataSource):
        raise DatasetDeleteError("Driver does not support dataset removal operation")
```

But GDALs documentation mentions only a "create" as a replacement:
```
Deprecated:
Use GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATE) in GDAL 2.0
```
There seems to be no GDAL_DCAP_DELETE as far as I can see. Also, it seems as in current GDAL there are not many references to [ODrCDeleteDataSource](https://github.com/OSGeo/gdal/search?q=ODrCDeleteDataSource&unscoped_q=ODrCDeleteDataSource)

I would suggest to just remove the `OGR_Dr_TestCapability(cogr_driver, ODrCDeleteDataSource)` test and wrap GDALDeleteDataset with exc_wrap_ogrerr.

**GDALClose**
Both OGR_DS_Destroy and OGRReleaseDataSource are deprecated and are replaced with GDALClose. It looks as until now only OGR_DS_Destroy was replaced with GDALClose.
I think the difference is, that OGR_DS_Destroy destroys a data source directly, while OGRReleaseDataSource only destroys a data source if the reference counter is zero. As far as I saw I don't think that a data source is shared somewhere, so it should be safe to just use OGR_DS_Destroy for GDALClose.

