### PR TITLE
Fix schema mapping if driver includes default fields

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import fiona
 from fiona.errors import SchemaError, UnsupportedGeometryTypeError, \
     DriverSupportError
@@ -368,3 +370,17 @@ def test_property_only_schema_update(tmpdir, driver):
             assert 'geometry' not in f or f['geometry'] is None
         assert 'prop1' in data[0]['properties'] and data[0]['properties']['prop1'] == 'one'
         assert 'prop1' in data[1]['properties'] and data[1]['properties']['prop1'] == 'two'
+
+
+def test_schema_default_fields_wrong_type(tmpdir):
+    """ Test for SchemaError if a default field is specified with a different type"""
+
+    name = str(tmpdir.join('test.gpx'))
+    schema = {'properties': OrderedDict([('ele', 'str'), ('time', 'datetime')]),
+              'geometry': 'Point'}
+
+    with pytest.raises(SchemaError):
+        with fiona.open(name, 'w',
+                        driver="GPX",
+                        schema=schema) as c:
+            pass


### PR DESCRIPTION
Problem:
Some drivers create fields by default. Fiona is currently not aware of these fields. Additionally, some drivers modify the field names (e.g. Shapefile has a length restriction for field names). Fiona maintains a schema mapping between field names in the schema provided to Fiona, and the resulting field names. However, as the default fields are not considered, the resulting mapping is wrong (see https://github.com/Toblerity/Fiona/issues/916).

This PR fixes the schema mapping if a driver contains default fields. This is kind of a minimal solution, as the existence of default fields also influence the schema validation, which is not touched with this PR. This PR does not modify that only the fields in the schema provided to Fiona are validated.

Currently, schema validation requires that records include all fields of the schema. However, drivers include also "optional" default fields, that do not need to be present. E.g. the default fields for the GPX driver are:
```
        'GPX': {'properties': OrderedDict([('ele', 'float'),
                                           ('time', 'datetime'),
                                           ('magvar', 'float'),
                                           ('geoidheight', 'float'),
                                           ('name', 'str'),
                                           ('cmt', 'str'),
                                           ('desc', 'str'),
                                           ('src', 'str'),
                                           ('link1_href', 'str'),
                                           ('link1_text', 'str'),
                                           ('link1_type', 'str'),
                                           ('link2_href', 'str'),
                                           ('link2_text', 'str'),
                                           ('link2_type', 'str'),
                                           ('sym', 'str'),
                                           ('type', 'str'),
                                           ('fix', 'str'),
                                           ('sat', 'int'),
                                           ('hdop', 'float'),
                                           ('vdop', 'float'),
                                           ('pdop', 'float'),
                                           ('ageofdgpsdata', 'float'),
                                           ('dgpsid', 'int')]),
```

E.g. the`geoidheight` element is defined with `minOccurs="0"` in https://www.topografix.com/GPX/1/1/gpx.xsd
