### PR TITLE
Include FileGDB in travis and fix related issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - GDALBUILD=$HOME/gdalbuild
     - PROJINST=$HOME/gdalinstall
     - PROJBUILD=$HOME/projbuild
+    - FILEGDB=$HOME/gdalinstall/filegdb
     - CYTHON_COVERAGE="true"
     - MAKEFLAGS="-j 2"
     - CXXFLAGS="-O0"
@@ -55,19 +56,19 @@ matrix:
     # Test all supported python versions with latest stable gdal release
     - python: "2.7"
       env:
-        GDALVERSION="3.1.0"
+        GDALVERSION="3.1.2"
         PROJVERSION="6.3.2"
     - python: "3.6"
       env:
-        GDALVERSION="3.1.0"
+        GDALVERSION="3.1.2"
         PROJVERSION="6.3.2"
     - python: "3.7"
       env:
-        GDALVERSION="3.1.0"
+        GDALVERSION="3.1.2"
         PROJVERSION="6.3.2"
     - python: "3.8"
       env:
-        GDALVERSION="3.1.0"
+        GDALVERSION="3.1.2"
         PROJVERSION="6.3.2"
 
     # Test master
@@ -100,6 +101,7 @@ before_install:
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
   - . ./scripts/travis_proj_install.sh
+  - . ./scripts/travis_filegdb_install.sh
   - . ./scripts/travis_gdal_install.sh
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,10 @@ Changes
 
 All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
+TBD (TBD)
+---------
+- Fix "Failed to commit transaction" TransactionError for FileGDB driver
+
 1.8.13.post1 (2020-02-21)
 -------------------------
 

--- a/fiona/_shim1.pxd
+++ b/fiona/_shim1.pxd
@@ -12,6 +12,7 @@ cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(const char* path_c, int mode, drivers, options) except NULL
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NULL
+cdef bint check_capability_transaction(void *cogr_ds)
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim1.pyx
+++ b/fiona/_shim1.pyx
@@ -93,6 +93,12 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NU
 
 
 # transactions are not supported in GDAL 1.x
+
+
+cdef bint check_capability_transaction(void *cogr_ds):
+    return False
+
+
 cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
     return OGRERR_NONE
 

--- a/fiona/_shim2.pxd
+++ b/fiona/_shim2.pxd
@@ -5,6 +5,7 @@ cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(const char* path_c, int mode, drivers, options) except NULL
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NULL
+cdef bint check_capability_transaction(void *cogr_ds)
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim2.pyx
+++ b/fiona/_shim2.pyx
@@ -98,6 +98,10 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NU
         CSLDestroy(creation_opts)
 
 
+cdef bint check_capability_transaction(void *cogr_ds):
+    return GDALDatasetTestCapability(cogr_ds, ODsCTransactions)
+
+
 cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
     return GDALDatasetStartTransaction(cogr_ds, force)
 

--- a/fiona/_shim22.pxd
+++ b/fiona/_shim22.pxd
@@ -5,6 +5,7 @@ cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(const char *path_c, int mode, drivers, options) except NULL
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NULL
+cdef bint check_capability_transaction(void *cogr_ds)
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim22.pyx
+++ b/fiona/_shim22.pyx
@@ -107,6 +107,10 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NU
         CSLDestroy(creation_opts)
 
 
+cdef bint check_capability_transaction(void *cogr_ds):
+    return GDALDatasetTestCapability(cogr_ds, ODsCTransactions)
+
+
 cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
     return GDALDatasetStartTransaction(cogr_ds, force)
 

--- a/fiona/_shim3.pxd
+++ b/fiona/_shim3.pxd
@@ -5,6 +5,7 @@ cdef void set_field_null(void *feature, int n)
 cdef void gdal_flush_cache(void *cogr_ds)
 cdef void* gdal_open_vector(const char *path_c, int mode, drivers, options) except NULL
 cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NULL
+cdef bint check_capability_transaction(void *cogr_ds)
 cdef OGRErr gdal_start_transaction(void *cogr_ds, int force)
 cdef OGRErr gdal_commit_transaction(void *cogr_ds)
 cdef OGRErr gdal_rollback_transaction(void *cogr_ds)

--- a/fiona/_shim3.pyx
+++ b/fiona/_shim3.pyx
@@ -116,6 +116,10 @@ cdef void* gdal_create(void* cogr_driver, const char *path_c, options) except NU
         CSLDestroy(creation_opts)
 
 
+cdef bint check_capability_transaction(void *cogr_ds):
+    return GDALDatasetTestCapability(cogr_ds, ODsCTransactions)
+
+
 cdef OGRErr gdal_start_transaction(void* cogr_ds, int force):
     return GDALDatasetStartTransaction(cogr_ds, force)
 

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -247,7 +247,8 @@ _driver_field_type_unsupported = {
         'DGN': None,
         'BNA': None,
         'DXF': None,
-        'PCIDSK': (2, 1, 0)
+        'PCIDSK': (2, 1, 0),
+        'FileGDB': None
     },
     'datetime': {
         'ESRI Shapefile': None,
@@ -263,7 +264,8 @@ _driver_field_type_unsupported = {
         'DGN': None,
         'BNA': None,
         'DXF': None,
-        'PCIDSK': (2, 1, 0)
+        'PCIDSK': (2, 1, 0),
+        'FileGDB': None
     }
 }
 
@@ -287,7 +289,8 @@ _drivers_not_supporting_timezones = {
     'datetime': {
         'MapInfo File': None,
         'GPKG': (3, 1, 0),
-        'GPSTrackMaker': (3, 1, 1)
+        'GPSTrackMaker': (3, 1, 1),
+        'FileGDB': None
     },
     'time': {
         'MapInfo File': None,
@@ -318,7 +321,8 @@ def _driver_supports_timezones(driver, field_type):
 
 # None: driver never supports timezones, (2, 0, 0): driver supports timezones with GDAL 2.0.0
 _drivers_not_supporting_milliseconds = {
-    'GPSTrackMaker': None
+    'GPSTrackMaker': None,
+    'FileGDB': None
 }
 
 

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -117,6 +117,7 @@ cdef extern from "ogr_core.h":
 
     char * ODsCCreateLayer = "CreateLayer"
     char * ODsCDeleteLayer = "DeleteLayer"
+    char * ODsCTransactions = "Transactions"
 
 
 cdef extern from "gdal.h":

--- a/fiona/ogrext3.pxd
+++ b/fiona/ogrext3.pxd
@@ -117,6 +117,7 @@ cdef extern from "ogr_core.h":
 
     char * ODsCCreateLayer = "CreateLayer"
     char * ODsCDeleteLayer = "DeleteLayer"
+    char * ODsCTransactions = "Transactions"
 
 
 cdef extern from "gdal.h":

--- a/scripts/travis_filegdb_install.sh
+++ b/scripts/travis_filegdb_install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install filegdb if not already installed
+if [ ! -d "$FILEGDB" ]; then
+  mkdir -p $FILEGDB
+  cd $FILEGDB
+  wget -q https://github.com/Esri/file-geodatabase-api/raw/master/FileGDB_API_1.5.1/FileGDB_API_1_5_1-64gcc51.tar.gz
+  tar -xzf FileGDB_API_1_5_1-64gcc51.tar.gz --strip=1 FileGDB_API-64gcc51
+  rm FileGDB_API_1_5_1-64gcc51.tar.gz
+  rm -rf samples
+  rm -rf doc
+fi
+
+export LD_LIBRARY_PATH=$FILEGDB/lib:$LD_LIBRARY_PATH
+
+# change back to travis build dir
+cd $TRAVIS_BUILD_DIR
+

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -47,6 +47,9 @@ GDALOPTS="  --with-ogr \
             --without-mrf \
             --with-webp=no"
 
+if [ -d "$FILEGDB" ]; then
+  GDALOPTS="$GDALOPTS --with-fgdb=$FILEGDB"
+fi
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from fiona.env import GDALVersion
 driver_extensions = {'DXF': 'dxf',
                      'CSV': 'csv',
                      'ESRI Shapefile': 'shp',
+                     'FileGDB': 'gdb',
                      'GML': 'gml',
                      'GPX': 'gpx',
                      'GPSTrackMaker': 'gtm',
@@ -399,7 +400,10 @@ def testdata_generator():
         is_good = is_good and val_in['geometry'] == val_out['geometry']
         for key in val_in['properties']:
             if key in val_out['properties']:
-                is_good = is_good and str(val_in['properties'][key]) == str(val_out['properties'][key])
+                if driver == 'FileGDB' and isinstance(val_in['properties'][key], int):
+                    is_good = is_good and str(val_in['properties'][key]) == str(int(val_out['properties'][key]))
+                else:
+                    is_good = is_good and str(val_in['properties'][key]) == str(val_out['properties'][key])
             else:
                 is_good = False
         return is_good

--- a/tests/test_drvsupport.py
+++ b/tests/test_drvsupport.py
@@ -50,7 +50,11 @@ def test_write_or_driver_error(tmpdir, driver, testdata_generator):
 
             c.writerecords(records1)
 
-        with fiona.open(path) as c:
+        if driver in {'FileGDB', 'OpenFileGDB'}:
+            open_driver = driver
+        else:
+            open_driver = None
+        with fiona.open(path, driver=open_driver) as c:
             assert c.driver == driver
             items = list(c)
             assert len(items) == len(records1)
@@ -130,7 +134,11 @@ def test_append_or_driver_error(tmpdir, testdata_generator, driver):
                         driver=driver) as c:
             c.writerecords(records2)
 
-        with fiona.open(path) as c:
+        if driver in {'FileGDB', 'OpenFileGDB'}:
+            open_driver = driver
+        else:
+            open_driver = None
+        with fiona.open(path, driver=open_driver) as c:
             assert c.driver == driver
             items = list(c)
             assert len(items) == len(records1) + len(records2)
@@ -179,7 +187,11 @@ def test_append_does_not_work_when_gdal_smaller_mingdal(tmpdir, driver, testdata
                             driver=driver) as c:
                 c.writerecords(records2)
 
-            with fiona.open(path) as c:
+            if driver in {'FileGDB', 'OpenFileGDB'}:
+                open_driver = driver
+            else:
+                open_driver = None
+            with fiona.open(path, driver=open_driver) as c:
                 assert c.driver == driver
                 items = list(c)
                 assert len(items) == len(records1) + len(records2)
@@ -250,7 +262,11 @@ def test_no_append_driver_cannot_append(tmpdir, driver, testdata_generator, monk
                         driver=driver) as c:
             c.writerecords(records2)
 
-        with fiona.open(path) as c:
+        if driver in {'FileGDB', 'OpenFileGDB'}:
+            open_driver = driver
+        else:
+            open_driver = None
+        with fiona.open(path, driver=open_driver) as c:
             assert c.driver == driver
             items = list(c)
             is_good = is_good and len(items) == len(records1) + len(records2)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -5,8 +5,10 @@ import logging
 from random import uniform, randint
 from collections import defaultdict
 import pytest
+from tests.conftest import requires_gdal2
 
 has_gpkg = "GPKG" in fiona.supported_drivers.keys()
+
 
 def create_records(count):
     for n in range(count):
@@ -15,6 +17,7 @@ def create_records(count):
             "properties": {"value": randint(0, 1000)}
         }
         yield record
+
 
 class DebugHandler(logging.Handler):
     def __init__(self, pattern):
@@ -30,6 +33,7 @@ class DebugHandler(logging.Handler):
 log = logging.getLogger()
 
 
+@requires_gdal2
 @pytest.mark.skipif(not has_gpkg, reason="Requires geopackage driver")
 class TestTransaction:
     def setup_method(self):


### PR DESCRIPTION
FileGDB is included in supported_drivers, but currently not tested. 

This PR:
- Adds FileGDB support to travis using https://github.com/Esri/file-geodatabase-api
- Updates drvsupport for  FileGDB
- Fixes an issue when a driver does not support transitions (such as FileGDB), writing records results in `fiona.errors.TransactionError: Failed to commit transaction` (https://travis-ci.org/github/rbuffat/Fiona/jobs/718900437)

It seems that ints written with the FileGDB driver are read as floats back. Not sure why.

I'm not that much of a fan of using the FileGDB API, but as long as we include FileGDB in drvsupport, I prefer if we test the driver. If it causes problems, the support can be removed again.