### PR TITLE
this_schema not used for fp_writer

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -227,7 +227,7 @@ def open(fp, mode='r', driver=None, schema=None, crs=None, encoding=None,
         def fp_writer(fp):
             memfile = MemoryFile()
             dataset = memfile.open(
-                driver=driver, crs=crs, schema=schema, layer=layer,
+                driver=driver, crs=crs, schema=this_schema, layer=layer,
                 encoding=encoding, enabled_drivers=enabled_drivers,
                 crs_wkt=crs_wkt, **kwargs)
             try:


### PR DESCRIPTION
`this_schema` and the conversion to OrderedDict is not used. Unsure though if it is needed at all, as there seemed to be no issue without it.

https://github.com/Toblerity/Fiona/blob/c2cbbab04ff7d3eaf1a11ab767d7f86e918a5edf/fiona/__init__.py#L219-L232