### PR TITLE
Remove _driver_supports_unknown_timezones() from drvsupport

### DIFF
--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -344,25 +344,3 @@ def _driver_supports_milliseconds(driver):
 
     return True
 
-
-# None: field type never supports unknown timezones, (2, 0, 0): field type supports unknown timezones with GDAL 2.0.0
-_drivers_not_supporting_unknown_timezone = {
-    'datetime':
-        {'GPKG': None,
-         'GPX': (2, 4, 0)
-         }
-}
-
-
-def _driver_supports_unknown_timezones(driver, field_type):
-    """ Returns True if the driver supports timezones for field_type, False otherwise
-
-        Note: this function is not part of Fiona's public API.
-    """
-    if (field_type in _drivers_not_supporting_unknown_timezone and
-            driver in _drivers_not_supporting_unknown_timezone[field_type]):
-        if _drivers_not_supporting_unknown_timezone[field_type][driver] is None:
-            return False
-        elif get_gdal_version_num() < calc_gdal_version_num(*_drivers_not_supporting_unknown_timezone[field_type][driver]):
-            return False
-    return True


### PR DESCRIPTION
The GPKG driver now supports unknown timezones (https://github.com/OSGeo/gdal/issues/2898) and the test_datetime.py/test_no_unknown_timezone fails because of this for gdal 3.1.3 and master. But _driver_supports_unknown_timezones() is never used except in this test. Thus it is best to remove it as it tests only gdals behavior.