### PR TITLE
Expose OGR error messages (Backport from maint-1.9)

### DIFF
--- a/fiona/_err.pxd
+++ b/fiona/_err.pxd
@@ -9,6 +9,7 @@ cdef extern from "ogr_core.h":
     ctypedef int OGRErr
 
 
+cdef get_last_error_msg()
 cdef int exc_wrap_int(int retval) except -1
 cdef OGRErr exc_wrap_ogrerr(OGRErr retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL

--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -235,6 +235,27 @@ cdef inline object exc_check():
         return
 
 
+cdef get_last_error_msg():
+    """Checks GDAL error stack for the latest error message
+    Returns
+    -------
+    An error message or empty string
+    """
+
+    err_msg = CPLGetLastErrorMsg()
+
+    if err_msg != NULL:
+        # Reformat messages.
+        msg_b = err_msg
+        msg = msg_b.decode('utf-8')
+        msg = msg.replace("`", "'")
+        msg = msg.replace("\n", " ")
+    else:
+        msg = ""
+
+    return msg
+
+
 cdef int exc_wrap_int(int err) except -1:
     """Wrap a GDAL/OGR function that returns CPLErr or OGRErr (int)
 

--- a/fiona/_geometry.pxd
+++ b/fiona/_geometry.pxd
@@ -103,7 +103,7 @@ cdef extern from "ogr_api.h":
     double  OGR_G_GetX (void *geometry, int n)
     double  OGR_G_GetY (void *geometry, int n)
     double  OGR_G_GetZ (void *geometry, int n)
-    void    OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
+    OGRErr  OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
     int     OGR_G_WkbSize (void *geometry)
 
 

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import logging
 
 from fiona.errors import UnsupportedGeometryTypeError
+from fiona._err cimport exc_wrap_int
 
 
 class NullHandler(logging.Handler):
@@ -100,7 +101,7 @@ cdef void * _createOgrGeomFromWKB(object wkb) except NULL:
     cdef unsigned char *buffer = wkb
     cdef void *cogr_geometry = OGR_G_CreateGeometry(<OGRwkbGeometryType>wkbtype)
     if cogr_geometry is not NULL:
-        OGR_G_ImportFromWkb(cogr_geometry, buffer, len(wkb))
+        exc_wrap_int(OGR_G_ImportFromWkb(cogr_geometry, buffer, len(wkb)))
     return cogr_geometry
 
 
@@ -234,7 +235,7 @@ cdef class OGRGeomBuilder:
         cdef void *cogr_geometry = self._createOgrGeometry(GEOJSON2OGR_GEOMETRY_TYPES['Polygon'])
         for ring in coordinates:
             cogr_ring = self._buildLinearRing(ring)
-            OGR_G_AddGeometryDirectly(cogr_geometry, cogr_ring)
+            exc_wrap_int(OGR_G_AddGeometryDirectly(cogr_geometry, cogr_ring))
         return cogr_geometry
 
     cdef void * _buildMultiPoint(self, object coordinates) except NULL:
@@ -242,7 +243,7 @@ cdef class OGRGeomBuilder:
         cdef void *cogr_geometry = self._createOgrGeometry(GEOJSON2OGR_GEOMETRY_TYPES['MultiPoint'])
         for coordinate in coordinates:
             cogr_part = self._buildPoint(coordinate)
-            OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part)
+            exc_wrap_int(OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part))
         return cogr_geometry
 
     cdef void * _buildMultiLineString(self, object coordinates) except NULL:
@@ -250,7 +251,7 @@ cdef class OGRGeomBuilder:
         cdef void *cogr_geometry = self._createOgrGeometry(GEOJSON2OGR_GEOMETRY_TYPES['MultiLineString'])
         for line in coordinates:
             cogr_part = self._buildLineString(line)
-            OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part)
+            exc_wrap_int(OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part))
         return cogr_geometry
 
     cdef void * _buildMultiPolygon(self, object coordinates) except NULL:
@@ -258,7 +259,7 @@ cdef class OGRGeomBuilder:
         cdef void *cogr_geometry = self._createOgrGeometry(GEOJSON2OGR_GEOMETRY_TYPES['MultiPolygon'])
         for part in coordinates:
             cogr_part = self._buildPolygon(part)
-            OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part)
+            exc_wrap_int(OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part))
         return cogr_geometry
 
     cdef void * _buildGeometryCollection(self, object coordinates) except NULL:
@@ -266,7 +267,7 @@ cdef class OGRGeomBuilder:
         cdef void *cogr_geometry = self._createOgrGeometry(GEOJSON2OGR_GEOMETRY_TYPES['GeometryCollection'])
         for part in coordinates:
             cogr_part = OGRGeomBuilder().build(part)
-            OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part)
+            exc_wrap_int(OGR_G_AddGeometryDirectly(cogr_geometry, cogr_part))
         return cogr_geometry
 
     cdef void * build(self, object geometry) except NULL:

--- a/fiona/_shim1.pyx
+++ b/fiona/_shim1.pyx
@@ -3,7 +3,7 @@
 import os
 
 from fiona.ogrext1 cimport *
-from fiona._err cimport exc_wrap_pointer
+from fiona._err cimport exc_wrap_pointer, exc_wrap_int
 from fiona._err import cpl_errs, CPLE_BaseError, FionaNullPointerError
 from fiona.errors import DriverError
 
@@ -23,7 +23,7 @@ cdef void set_field_null(void *feature, int n):
 
 
 cdef void gdal_flush_cache(void *cogr_ds):
-    retval = OGR_DS_SyncToDisk(cogr_ds)
+    retval = exc_wrap_int(OGR_DS_SyncToDisk(cogr_ds))
     if retval != OGRERR_NONE:
         raise RuntimeError("Failed to sync to disk")
 

--- a/fiona/gdal.pxi
+++ b/fiona/gdal.pxi
@@ -347,7 +347,7 @@ cdef extern from "ogr_api.h" nogil:
     OGRGeometryH OGR_G_CreateGeometryFromJson(const char *json)
     void OGR_G_DestroyGeometry(OGRGeometryH geometry)
     char *OGR_G_ExportToJson(OGRGeometryH geometry)
-    void OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, char *buffer)
+    OGRErr OGR_G_ExportToWkb(OGRGeometryH geometry, int endianness, char *buffer)
     int OGR_G_GetCoordinateDimension(OGRGeometryH geometry)
     int OGR_G_GetGeometryCount(OGRGeometryH geometry)
     const char *OGR_G_GetGeometryName(OGRGeometryH geometry)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -19,7 +19,7 @@ from fiona._shim cimport *
 from fiona._geometry cimport (
     GeomBuilder, OGRGeomBuilder, geometry_type_code,
     normalize_geometry_type_code, base_geometry_type_code)
-from fiona._err cimport exc_wrap_int, exc_wrap_pointer, exc_wrap_vsilfile
+from fiona._err cimport exc_wrap_int, exc_wrap_pointer, exc_wrap_vsilfile, get_last_error_msg
 
 import fiona
 from fiona._env import get_gdal_version_num, calc_gdal_version_num, get_gdal_version_tuple
@@ -80,6 +80,7 @@ cdef const char * OLC_ALTERFIELDDEFN = "AlterFieldDefn"
 cdef const char * OLC_DELETEFEATURE = "DeleteFeature"
 cdef const char * OLC_STRINGSASUTF8 = "StringsAsUTF8"
 cdef const char * OLC_TRANSACTIONS = "Transactions"
+cdef const char * OLC_IGNOREFIELDS =  "IgnoreFields"
 
 # OGR integer error types.
 
@@ -348,7 +349,7 @@ cdef class OGRFeatureBuilder:
         if feature['geometry'] is not None:
             cogr_geometry = OGRGeomBuilder().build(
                                 feature['geometry'])
-        OGR_F_SetGeometryDirectly(cogr_feature, cogr_geometry)
+            exc_wrap_int(OGR_F_SetGeometryDirectly(cogr_feature, cogr_geometry))
 
         # OGR_F_SetFieldString takes encoded strings ('bytes' in Python 3).
         encoding = session._get_internal_encoding()
@@ -550,6 +551,8 @@ cdef class Session:
         encoding = self._get_internal_encoding()
 
         if collection.ignore_fields:
+            if not OGR_L_TestCapability(self.cogr_layer, OLC_IGNOREFIELDS):
+                raise DriverError("Driver does not support ignore_fields")
             try:
                 for name in collection.ignore_fields:
                     try:
@@ -1272,7 +1275,9 @@ cdef class WritingSession(Session):
             cogr_feature = OGRFeatureBuilder().build(record, collection)
             result = OGR_L_CreateFeature(cogr_layer, cogr_feature)
             if result != OGRERR_NONE:
-                raise RuntimeError("Failed to write record: %s" % record)
+                msg = get_last_error_msg()
+                raise RuntimeError("GDAL Error: {msg} \n \n Failed to write record: "
+                                   "{record}".format(msg=msg, record=record))
             _deleteOgrFeature(cogr_feature)
 
             if transactions_supported:
@@ -1413,7 +1418,10 @@ cdef class Iterator:
 
         self.next_index = start
         log.debug("Next index: %d", self.next_index)
-        OGR_L_SetNextByIndex(session.cogr_layer, self.next_index)
+        
+        # Set OGR_L_SetNextByIndex only if within range
+        if start >= 0 and (self.ftcount == -1 or self.start < self.ftcount):
+            exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))
 
     def __iter__(self):
         return self
@@ -1423,6 +1431,7 @@ cdef class Iterator:
 
         cdef Session session
         session = self.collection.session
+
 
         # Check if next_index is valid
         if self.next_index < 0:
@@ -1442,7 +1451,7 @@ cdef class Iterator:
 
         # Set read cursor to next_item position
         if self.step > 1 and self.fastindex:
-            OGR_L_SetNextByIndex(session.cogr_layer, self.next_index)
+            exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))
         elif self.step > 1 and not self.fastindex and not self.next_index == self.start:
             # GDALs default implementation of SetNextByIndex is calling ResetReading() and then
             # calling GetNextFeature n times. We can shortcut that if we know the previous index.
@@ -1452,9 +1461,9 @@ cdef class Iterator:
                 if cogr_feature == NULL:
                     raise StopIteration
         elif self.step > 1 and not self.fastindex and self.next_index == self.start:
-            OGR_L_SetNextByIndex(session.cogr_layer, self.next_index)
+            exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))
         elif self.step < 0:
-            OGR_L_SetNextByIndex(session.cogr_layer, self.next_index)
+            exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))
 
         # set the next index
         self.next_index += self.step

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -254,7 +254,7 @@ cdef extern from "ogr_api.h":
     double  OGR_G_GetX (void *geometry, int n)
     double  OGR_G_GetY (void *geometry, int n)
     double  OGR_G_GetZ (void *geometry, int n)
-    void    OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
+    OGRErr  OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
     int     OGR_G_WkbSize (void *geometry)
     void *  OGR_G_ForceToMultiPolygon (void *geometry)
     void *  OGR_G_ForceToPolygon (void *geometry)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -304,7 +304,7 @@ cdef extern from "ogr_api.h":
     double  OGR_G_GetX (void *geometry, int n)
     double  OGR_G_GetY (void *geometry, int n)
     double  OGR_G_GetZ (void *geometry, int n)
-    void    OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
+    OGRErr  OGR_G_ImportFromWkb (void *geometry, unsigned char *bytes, int nbytes)
     int     OGR_G_WkbSize (void *geometry)
     void *  OGR_G_ForceToMultiPolygon (void *geometry)
     void *  OGR_G_ForceToPolygon (void *geometry)

--- a/fiona/ogrext3.pxd
+++ b/fiona/ogrext3.pxd
@@ -298,7 +298,7 @@ cdef extern from "ogr_api.h":
     void *  OGR_G_CreateGeometry (int wkbtypecode)
     void    OGR_G_DestroyGeometry (void *geometry)
     unsigned char *  OGR_G_ExportToJson (void *geometry)
-    void    OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
+    OGRErr  OGR_G_ExportToWkb (void *geometry, int endianness, char *buffer)
     int     OGR_G_GetGeometryCount (void *geometry)
     unsigned char *  OGR_G_GetGeometryName (void *geometry)
     int     OGR_G_GetGeometryType (void *geometry)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -29,7 +29,8 @@ def get_schema(driver, field_type):
         return {
             'properties': OrderedDict([('name', 'str'), ('comment', 'str'), ('icon', 'int'), ('time', field_type)]),
             'geometry': 'Point'}
-
+    if driver == 'CSV':
+        return {"properties": {"datefield": field_type}}
     return {"geometry": "Point",
             "properties": {"datefield": field_type}}
 
@@ -42,6 +43,8 @@ def get_records(driver, values):
         return [{"geometry": {"type": "Point", "coordinates": [1, 2]},
                  "properties": OrderedDict([('name', ''), ('comment', ''), ('icon', 48), ('time', val)])} for
                 val in values]
+    if driver == 'CSV':
+        return [{"properties": {"datefield": val}} for val in values]
 
     return [{"geometry": {"type": "Point", "coordinates": [1, 2]},
              "properties": {"datefield": val}} for val in values]

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -3,12 +3,13 @@
 import tempfile
 import shutil
 import os
+from collections import OrderedDict
 import pytest
 from fiona.env import GDALVersion
 import fiona
 from fiona.errors import FionaDeprecationWarning
 from .conftest import get_temp_filename
-from fiona.drvsupport import supported_drivers, driver_mode_mingdal, _driver_supports_mode
+from fiona.drvsupport import supported_drivers, _driver_supports_mode
 
 gdal_version = GDALVersion.runtime()
 
@@ -45,17 +46,29 @@ def test_collection_iterator_next(path_coutwildrnp_shp):
 
 @pytest.fixture(scope="module", params=[driver for driver in supported_drivers if
                                         _driver_supports_mode(driver, 'w')
-                                        and driver not in {'DGN', 'MapInfo File', 'GPSTrackMaker', 'GPX', 'BNA', 'DXF',
-                                                           'GML'}])
+                                        and driver not in {'DGN', 'MapInfo File', 'GPSTrackMaker', 'GPX', 'BNA', 'DXF'}])
 def slice_dataset_path(request):
     """ Create temporary datasets for test_collection_iterator_items_slice()"""
 
     driver = request.param
     min_id = 0
     max_id = 9
-    schema = {'geometry': 'Point', 'properties': [('position', 'int')]}
-    records = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i
-               in range(min_id, max_id + 1)]
+
+    def get_schema(driver):
+        special_schemas = {'CSV': {'geometry': None, 'properties': OrderedDict([('position', 'int')])}}
+        return special_schemas.get(driver, {'geometry': 'Point', 'properties': OrderedDict([('position', 'int')])})
+
+    def get_records(driver, range):
+        special_records1 = {'CSV': [{'geometry': None, 'properties': {'position': i}} for i in range],
+                            'PCIDSK': [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i), 0.0)},
+                                        'properties': {'position': i}} for i in range]
+                            }
+        return special_records1.get(driver, [
+            {'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i in
+            range])
+
+    schema = get_schema(driver)
+    records = get_records(driver, range(min_id, max_id + 1))
 
     tmpdir = tempfile.mkdtemp()
     path = os.path.join(tmpdir, get_temp_filename(driver))
@@ -74,6 +87,9 @@ def slice_dataset_path(request):
                                   (-5, -1, None),
                                   (0, None, None),
                                   (5, None, None),
+                                  (8, None, None),
+                                  (9, None, None),
+                                  (10, None, None),
                                   (0, 5, 2),
                                   (0, 5, 2),
                                   (1, 5, 2),


### PR DESCRIPTION
Today I tried to merge maint-1.8 into maint-1.9 and stumbled on a few failing tests (new to maint-1.8) related to wrapping GDAL function in exc_wrap* functions (See PR https://github.com/Toblerity/Fiona/pull/866 merged into maint-1.8)

This PR applies the changes of https://github.com/Toblerity/Fiona/pull/866 to maint-1.8 and resolves the found issues. 

The discovered issues are:

https://github.com/rbuffat/Fiona/blob/1ba8162137a5f6f2f9efc7997237c339c13f24a8/fiona/ogrext.pyx#L352
OGR_F_SetGeometryDirectly returns an error code when a geometry should be written for the CSV driver (the driver only supports geometries when an open parameter is set). The tests are adapted to not write features with geometries for this driver.

https://github.com/rbuffat/Fiona/blob/1ba8162137a5f6f2f9efc7997237c339c13f24a8/fiona/ogrext.pyx#L1422-L1424
OGR_L_SetNextByIndex returns an error code when the index is negative. A negative index is used to signal a StopIteration. The above code should ensure that OGR_L_SetNextByIndex is only called for indexes within the range of the available features.  

