### PR TITLE
Increase coverage for MemoryFile test

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1797,6 +1797,8 @@ cdef class MemoryFileBase:
         int
 
         """
+        if not self.getbuffer():
+            return 0        
         return self.getbuffer().size
 
     def getbuffer(self):
@@ -1809,10 +1811,10 @@ cdef class MemoryFileBase:
         buffer = VSIGetMemFileBuffer(name_b, &buffer_len, 0)
 
         if buffer == NULL or buffer_len == 0:
-            buff_view = memoryview(b"")
+            return None
         else:
             buff_view = <unsigned char [:buffer_len]>buffer
-        return buff_view
+            return buff_view
 
     def close(self):
         """Close and tear down VSI file and directory."""

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -107,6 +107,14 @@ def test_memoryfile_write_extension(profile_first_coutwildrnp_shp):
         assert memfile.name.endswith(".shp")
 
 
+def test_memoryfile_open_file_or_bytes_read(path_coutwildrnp_json):
+    """Test MemoryFile.open when file_or_bytes has a read attribute """
+    with open(path_coutwildrnp_json, 'rb') as f:
+        with MemoryFile(f) as memfile:
+            with memfile.open() as collection:
+                assert len(collection) == 67
+
+
 def test_memoryfile_bytesio(data_coutwildrnp_json):
     """GeoJSON file stored in BytesIO can be read"""
     with fiona.open(BytesIO(data_coutwildrnp_json)) as collection:
@@ -118,6 +126,22 @@ def test_memoryfile_fileobj(path_coutwildrnp_json):
     with open(path_coutwildrnp_json, 'rb') as f:
         with fiona.open(f) as collection:
             assert len(collection) == 67
+
+
+def test_memoryfile_len(data_coutwildrnp_json):
+    """Test MemoryFile.__len__ """
+    with MemoryFile() as memfile:
+        assert len(memfile) == 0
+        memfile.write(data_coutwildrnp_json)
+        assert len(memfile) == len(data_coutwildrnp_json)
+
+
+def test_memoryfile_tell(data_coutwildrnp_json):
+    """Test MemoryFile.tell() """
+    with MemoryFile() as memfile:
+        assert memfile.tell() == 0
+        memfile.write(data_coutwildrnp_json)
+        assert memfile.tell() == len(data_coutwildrnp_json)
 
 
 def test_write_bytesio(profile_first_coutwildrnp_shp):


### PR DESCRIPTION
This PR increases the coverage for MemoryFile.

Thereby I noticed the following code resulted in `BufferError: memoryview: underlying buffer is not writable`
 exception. 

```
from fiona.io import MemoryFile
with MemoryFile() as memfile:
    len(memfile) == 0
```

To solve this, getbuffer() is changed to return None if buffer == NULL or buffer_len == 0