### PR TITLE
Travis install setuptools version from requirements-dev.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ addons:
 
 before_install:
   - pip install -U pip
-  - pip install setuptools==36.0.1
+  - pip install `cat requirements-dev.txt | grep setuptools==`
   - pip install wheel
   - "python -m pip install -r requirements-ci.txt"
   - python -m pip wheel -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,8 @@ addons:
     - sqlite3
 
 before_install:
-  - pip install -U pip
-  - pip install `cat requirements-dev.txt | grep setuptools==`
-  - pip install wheel
-  - "python -m pip install -r requirements-ci.txt"
+  - python -m pip install -U pip
+  - python -m pip install -r requirements-ci.txt
   - python -m pip wheel -r requirements-dev.txt
   - python -m pip install -r requirements-dev.txt
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH


### PR DESCRIPTION
Travis install  setuptools==36.0.1 in .travis.yml and then again setuptools==41.6.0 from requirements-dev.txt.

This PR changes travis.yml to use the version of setuptools from  requirements-dev.txt.

But I'm not sure if it would be better to just use: 

```
  - pip install -U pip
  - python -m pip install -r requirements-ci.txt
  - python -m pip install -r requirements-dev.txt
```

instead of 

```
  - pip install -U pip
  - pip install setuptools==36.0.1
  - pip install wheel
  - "python -m pip install -r requirements-ci.txt"
  - python -m pip wheel -r requirements-dev.txt
  - python -m pip install -r requirements-dev.txt
```