### PR TITLE
Add 'where' SQL clause to set attribute filter

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -104,6 +104,14 @@ concatenated datasets.
 
 New in 1.4.0.
 
+The cat command provides optional methods to filter data, which are
+different to the ``fio filter`` tool.
+A bounding box ``--bbox w,s,e,n`` tests for a spatial intersection with
+the geometries. An attribute filter ``--where TEXT`` can use
+an `SQL WHERE clause <https://gdal.org/user/ogr_sql_dialect.html#where>`__.
+If more than one datasets is passed to ``fio cat``, the attributes used
+in the WHERE clause must be valid for each dataset.
+
 collect
 -------
 
@@ -285,6 +293,9 @@ Otherwise, the feature is excluded from the output.
 
 Would create a geojson file with only those features from `data.shp` where the
 area was over a given threshold.
+
+Note this tool is different than ``fio cat --where TEXT ...``, which provides
+SQL WHERE clause filtering of feature attributes.
 
 rm
 --

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -246,15 +246,17 @@ class Collection(object):
         mask = kwds.get('mask')
         if bbox and mask:
             raise ValueError("mask and bbox can not be set together")
+        where = kwds.get('where')
         self.iterator = Iterator(
-            self, start, stop, step, bbox, mask)
+            self, start, stop, step, bbox, mask, where)
         return self.iterator
 
     def items(self, *args, **kwds):
         """Returns an iterator over FID, record pairs, optionally
         filtered by a test for spatial intersection with the provided
         ``bbox``, a (minx, miny, maxx, maxy) tuple or a geometry
-        ``mask``.
+        ``mask``. Additionally, an attribute filter can be set
+        using an SQL ``where`` clause.
 
         Positional arguments ``stop`` or ``start, stop[, step]`` allows
         iteration to skip over items or stop at a specific item.
@@ -274,8 +276,9 @@ class Collection(object):
         mask = kwds.get('mask')
         if bbox and mask:
             raise ValueError("mask and bbox can not be set together")
+        where = kwds.get('where')
         self.iterator = ItemsIterator(
-            self, start, stop, step, bbox, mask)
+            self, start, stop, step, bbox, mask, where)
         return self.iterator
 
     def keys(self, *args, **kwds):

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -226,7 +226,9 @@ class Collection(object):
     def filter(self, *args, **kwds):
         """Returns an iterator over records, but filtered by a test for
         spatial intersection with the provided ``bbox``, a (minx, miny,
-        maxx, maxy) tuple or a geometry ``mask``.
+        maxx, maxy) tuple or a geometry ``mask``. An attribute filter can
+        be set using an SQL ``where`` clause, which uses the `OGR SQL dialect
+        <https://gdal.org/user/ogr_sql_dialect.html#where>`__.
 
         Positional arguments ``stop`` or ``start, stop[, step]`` allows
         iteration to skip over items or stop at a specific item.
@@ -255,8 +257,9 @@ class Collection(object):
         """Returns an iterator over FID, record pairs, optionally
         filtered by a test for spatial intersection with the provided
         ``bbox``, a (minx, miny, maxx, maxy) tuple or a geometry
-        ``mask``. Additionally, an attribute filter can be set
-        using an SQL ``where`` clause.
+        ``mask``. An attribute filter can be set using an SQL ``where``
+        clause, which uses the `OGR SQL dialect
+        <https://gdal.org/user/ogr_sql_dialect.html#where>`__.
 
         Positional arguments ``stop`` or ``start, stop[, step]`` allows
         iteration to skip over items or stop at a specific item.
@@ -285,7 +288,9 @@ class Collection(object):
         """Returns an iterator over FIDs, optionally
         filtered by a test for spatial intersection with the provided
         ``bbox``, a (minx, miny, maxx, maxy) tuple or a geometry
-        ``mask``.
+        ``mask``. An attribute filter can be set using an SQL ``where``
+        clause, which uses the `OGR SQL dialect
+        <https://gdal.org/user/ogr_sql_dialect.html#where>`__.
 
         Positional arguments ``stop`` or ``start, stop[, step]`` allows
         iteration to skip over items or stop at a specific item.
@@ -305,8 +310,9 @@ class Collection(object):
         mask = kwds.get('mask')
         if bbox and mask:
             raise ValueError("mask and bbox can not be set together")
+        where = kwds.get('where')
         self.iterator = KeysIterator(
-            self, start, stop, step, bbox, mask)
+            self, start, stop, step, bbox, mask, where)
         return self.iterator
 
     def __contains__(self, fid):

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -9,6 +9,10 @@ class FionaValueError(ValueError):
     """Fiona-specific value errors"""
 
 
+class AttributeFilterError(FionaValueError):
+    """Error processing SQL WHERE clause with the dataset."""
+
+
 class DriverError(FionaValueError):
     """Encapsulates unsupported driver and driver mode errors."""
 

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -11,6 +11,7 @@ import cligj
 import fiona
 from fiona.transform import transform_geom
 from fiona.fio import options, with_context_env
+from fiona.errors import AttributeFilterError
 
 
 warnings.simplefilter('default')
@@ -86,6 +87,8 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
                             click.echo(u'\u001e', nl=False)
                         click.echo(json.dumps(feat, **dump_kwds))
 
+    except AttributeFilterError as e:
+        raise click.BadParameter("'where' clause is invalid: " + str(e))
     except Exception:
         logger.exception("Exception caught during processing")
         raise click.Abort()

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -33,10 +33,12 @@ warnings.simplefilter('default')
 @cligj.use_rs_opt
 @click.option('--bbox', default=None, metavar="w,s,e,n",
               help="filter for features intersecting a bounding box")
+@click.option('--where', default=None,
+              help="attribute filter using SQL where clause")
 @click.pass_context
 @with_context_env
 def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
-        use_rs, bbox, layer):
+        use_rs, bbox, where, layer):
     """
     Concatenate and print the features of input datasets as a sequence of
     GeoJSON features.
@@ -72,7 +74,7 @@ def cat(ctx, files, precision, indent, compact, ignore_errors, dst_crs,
         for i, path in enumerate(files, 1):
             for lyr in layer[str(i)]:
                 with fiona.open(path, layer=lyr) as src:
-                    for i, feat in src.items(bbox=bbox):
+                    for i, feat in src.items(bbox=bbox, where=where):
                         if dst_crs or precision >= 0:
                             g = transform_geom(
                                 src.crs, dst_crs, feat['geometry'],

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1212,7 +1212,7 @@ cdef class Iterator:
     cdef stepsign
 
     def __cinit__(self, collection, start=None, stop=None, step=None,
-                  bbox=None, mask=None):
+                  bbox=None, mask=None, where=None):
         if collection.session is None:
             raise ValueError("I/O operation on closed collection")
         self.collection = collection
@@ -1237,6 +1237,14 @@ cdef class Iterator:
 
         else:
             OGR_L_SetSpatialFilter(cogr_layer, NULL)
+
+        if where:
+            where_b = where.encode('utf-8')
+            where_c = where_b
+            OGR_L_SetAttributeFilter(cogr_layer, <const char*>where_c)
+
+        else:
+            OGR_L_SetAttributeFilter(cogr_layer, NULL)
 
         self.encoding = session._get_internal_encoding()
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1241,7 +1241,8 @@ cdef class Iterator:
         if where:
             where_b = where.encode('utf-8')
             where_c = where_b
-            OGR_L_SetAttributeFilter(cogr_layer, <const char*>where_c)
+            exc_wrap_int(
+                OGR_L_SetAttributeFilter(cogr_layer, <const char*>where_c))
 
         else:
             OGR_L_SetAttributeFilter(cogr_layer, NULL)

--- a/fiona/ogrext1.pxd
+++ b/fiona/ogrext1.pxd
@@ -260,4 +260,5 @@ cdef extern from "ogr_api.h":
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
+    OGRErr  OGR_L_SetAttributeFilter(void *layer, const char*)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)

--- a/fiona/ogrext2.pxd
+++ b/fiona/ogrext2.pxd
@@ -323,6 +323,7 @@ cdef extern from "ogr_api.h":
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
+    OGRErr  OGR_L_SetAttributeFilter(void *layer, const char*)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
     long long OGR_F_GetFieldAsInteger64 (void *feature, int n)
     void    OGR_F_SetFieldInteger64 (void *feature, int n, long long value)

--- a/fiona/ogrext3.pxd
+++ b/fiona/ogrext3.pxd
@@ -322,6 +322,7 @@ cdef extern from "ogr_api.h":
     void *  OGROpenShared (char *path, int mode, void *x)
     int     OGRReleaseDataSource (void *datasource)
     OGRErr  OGR_L_SetIgnoredFields (void *layer, const char **papszFields)
+    OGRErr  OGR_L_SetAttributeFilter(void *layer, const char*)
     OGRErr  OGR_L_SetNextByIndex (void *layer, long nIndex)
     long long OGR_F_GetFieldAsInteger64 (void *feature, int n)
     void    OGR_F_SetFieldInteger64 (void *feature, int n, long long value)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,8 +9,9 @@ import pytest
 import fiona
 from fiona.collection import Collection, supported_drivers
 from fiona.env import getenv
-from fiona.errors import FionaValueError, DriverError, FionaDeprecationWarning
-from fiona._err import CPLE_AppDefinedError
+from fiona.errors import (
+    AttributeFilterError, FionaValueError, DriverError, FionaDeprecationWarning
+)
 
 from .conftest import WGS84PATTERN
 
@@ -368,7 +369,7 @@ class TestFilterReading(object):
 
     def test_filter_where_error(self):
         for w in ["bad stuff", "NAME=3", "NNAME LIKE 'Mount%'"]:
-            with pytest.raises(CPLE_AppDefinedError):
+            with pytest.raises(AttributeFilterError):
                 self.c.filter(where=w)
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -360,10 +360,10 @@ class TestFilterReading(object):
 
     def test_filter_bbox_where(self):
         # combined filter criteria
-        results = list(self.c.filter(
+        results = set(self.c.keys(
             bbox=(-120.0, 40.0, -100.0, 50.0), where="NAME LIKE 'Mount%'"))
-        assert set([x['id'] for x in results]) == set(['0', '2', '5', '13'])
-        results = list(self.c.filter())
+        assert results == set([0, 2, 5, 13])
+        results = set(self.c.keys())
         assert len(results) == 67
 
     def test_filter_where_error(self):

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -63,6 +63,55 @@ def test_bbox_json_yes(path_coutwildrnp_shp):
     assert result.output.count('"Feature"') == 19
 
 
+def test_bbox_where(path_coutwildrnp_shp):
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['cat', path_coutwildrnp_shp, '--bbox', '-120,40,-100,50',
+         '--where', "NAME LIKE 'Mount%'"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 4
+
+
+def test_where_no(path_coutwildrnp_shp):
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['cat', path_coutwildrnp_shp, '--where', "STATE LIKE '%foo%'"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_where_yes(path_coutwildrnp_shp):
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['cat', path_coutwildrnp_shp, '--where', "NAME LIKE 'Mount%'"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 9
+
+
+def test_where_yes_two_files(path_coutwildrnp_shp):
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['cat', path_coutwildrnp_shp, path_coutwildrnp_shp,
+         '--where', "NAME LIKE 'Mount%'"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 18
+
+
+def test_where_fail(data_dir):
+    runner = CliRunner()
+    result = runner.invoke(main_group, ['cat', '--where', "NAME=3",
+                           data_dir])
+    assert result.exit_code != 0
+
+
 def test_multi_layer(data_dir):
     layerdef = "1:coutwildrnp,1:coutwildrnp"
     runner = CliRunner()


### PR DESCRIPTION
This PR implements a `where` argument to set an attribute filter ([where docs](https://gdal.org/user/ogr_sql_dialect.html#where), [API docs](https://gdal.org/api/vector_c_api.html#_CPPv424OGR_L_SetAttributeFilter9OGRLayerHPKc)), which could work alongside existing `bbox` and `mask` spatial filter parameters.

Basic usage is:

```python
import fiona

c = fiona.open('tests/data/coutwildrnp.shp', 'r')

print(len(list(c.items(where="WILDRNP020 BETWEEN 450 AND 480"))))  # 14
print(len(list(c.items(where="WILDRNP020 BETWEEN 450 AND 480 AND STATE='UT'"))))  # 3
print(len(list(c.items(where="STATE='UT'"))))  # 13
```
TODO/Questions:

- [x] How to capture/handle error messages? E.g. `c.items(where="id=2")` logs "ERROR 1: "id" not recognised as an available field." to the console.
- [x] Should this also integrate with `fio cat`? (I think so, as this is effectivley ogr2ogr's [-where](https://gdal.org/programs/ogr2ogr.html#cmdoption-ogr2ogr-where) option)
- [x] <s>Should arguments like this be available to be passed from the `kwargs` from `fiona.open`? This would allow, e.g. `geopandas.from_file(..., where='id > 5000')` from 3rd party interfaces. This question applies to `bbox` too, so could be deferred to a later issue.</s> (See [geopandas/io/file.py](https://github.com/geopandas/geopandas/blob/63de9bd1820080eedc443c09df7686e1022304a0/geopandas/io/file.py#L48-L158) where `bbox` and `mask` are handled separately from `kwargs` -- this would need to be followed up on geopandas directly)
- [x] Does the API header need to be repeated in all `ogrext*.pxd` files? This isn't clear.
- [x] Add doc (where is the main docstrings?), and add example.
- [x] Add tests.