### PR TITLE
Fix* travis for "Test merge maint 1.8 master" branch

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -67,7 +67,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
-          python -m pip install coveralls>=1.1 --upgrade
 
       - name: Build PROJ
         run: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,0 +1,94 @@
+name: MacOS CI
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # Test all supported gdal minor versions (except latest stable) with one python version
+          - { python-version: 3.6, GDALVERSION: "3.0.4",   PROJVERSION: "6.2.1" }
+          # Test all supported python versions with latest stable gdal release
+          - { python-version: 3.6, GDALVERSION: "3.1.3",   PROJVERSION: "6.3.2" }
+          - { python-version: 3.7, GDALVERSION: "3.1.3",   PROJVERSION: "6.3.2" }
+          - { python-version: 3.8, GDALVERSION: "3.1.3",   PROJVERSION: "6.3.2" }
+          - { python-version: 3.9, GDALVERSION: "3.1.3",   PROJVERSION: "6.3.2" }
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.config.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.config.python-version }}
+
+      # Environment variables need to be set in each step. Create $GITHUB_WORKSPACE/env_variables to
+      # facilitate setting of env variables
+      - name: Set env variables
+        run: |
+          touch $GITHUB_WORKSPACE/env_variables
+          echo "export MAKEFLAGS=\"-j 4 -s\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export CXXFLAGS=\"-O0\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export CFLAGS=\"-O0\"" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALINST=$GITHUB_WORKSPACE/gdalinstall" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALBUILD=$GITHUB_WORKSPACE/gdalbuild" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJINST=$GITHUB_WORKSPACE/gdalinstall" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJBUILD=$GITHUB_WORKSPACE/projbuild" >> $GITHUB_WORKSPACE/env_variables
+          echo "export GDALVERSION=${{matrix.config.GDALVERSION}}" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJVERSION=${{matrix.config.PROJVERSION}}" >> $GITHUB_WORKSPACE/env_variables
+          echo "export TRAVIS_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_WORKSPACE/env_variables
+          echo "export TRAVIS_OS_NAME=osx" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH="/usr/local/opt/expat/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH="/usr/local/opt/libxml2/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          source $GITHUB_WORKSPACE/env_variables
+          echo "export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj" >> $GITHUB_WORKSPACE/env_variables
+          echo "export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:\$PATH" >> $GITHUB_WORKSPACE/env_variables
+          echo "export DYLD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:\$DYLD_LIBRARY_PATH" >> $GITHUB_WORKSPACE/env_variables
+          cat $GITHUB_WORKSPACE/env_variables
+
+      # The hash of $GITHUB_WORKSPACE/brew_list is used to invalidate the gdal cache if a dependency has changed
+      - name: Install brew packages
+        run: |
+          brew install pkg-config expat libspatialite sqlite geos
+          brew list --versions | grep 'expat\|libspatialite\|sqlite\|geos\|curl\|libxml2\|freexl\|zstd' > $GITHUB_WORKSPACE/brew_list
+          cat $GITHUB_WORKSPACE/brew_list
+
+      - name: Dependency Cache
+        uses: actions/cache@v2
+        with:
+          path: gdalinstall
+          key: ${{ runner.os }}-gdal-${{ matrix.config.GDALVERSION }}-proj-${{ matrix.config.PROJVERSION }}-${{ hashFiles('**/brew_list')}}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          python -m pip install coveralls>=1.1 --upgrade
+
+      - name: Build PROJ
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          chmod +x scripts/travis_proj_install.sh && ./scripts/travis_proj_install.sh
+
+      - name: Build GDAL
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          chmod +x scripts/travis_gdal_install.sh && ./scripts/travis_gdal_install.sh
+          gdal-config --version
+
+      - name: Build Fiona
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $($GDALINST/gdal-$GDALVERSION/bin/gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+          GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install -v -v -v --no-deps --force-reinstall --no-use-pep517 -e .
+          fio --version
+          fio --gdal-version
+
+      - name: Test with pytest
+        run: |
+          source $GITHUB_WORKSPACE/env_variables
+          python -m pytest -m "not wheel" --cov fiona --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       ox: linux
       arch: ppc64le
       env:
-        GDALVERSION="3.1.3"
+        GDALVERSION="3.0.4"
         PROJVERSION="6.3.2"
   
     # Test master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,16 @@ env:
 
 jobs:
   include:
-    - python: "3.6"
+    # Test all supported gdal minor versions (except latest stable) with one python version
+    - python: "3.8"
       env:
         GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+
+    # Test all supported python versions with latest stable gdal release
+    - python: "3.6"
+      env:
+        GDALVERSION="3.1.3"
         PROJVERSION="6.3.2"
     - python: "3.7"
       env:
@@ -33,117 +40,74 @@ jobs:
       env:
         GDALVERSION="3.1.3"
         PROJVERSION="6.3.2"
-    - python: "3.8"
+    - python: "3.9"
       env:
-        GDALVERSION="master"
-        PROJVERSION="7.1.1"
+        GDALVERSION="3.1.3"
+        PROJVERSION="6.3.2"
+
+    # Test other architectures
     - python: "3.8"
       ox: linux
       arch: ppc64le
       env:
         GDALVERSION="3.1.3"
         PROJVERSION="6.3.2"
-    - os: osx
-      osx_image: xcode11.2
-      python: "3.8"
+  
+    # Test master
+    - python: "3.8"
       env:
-        GDALVERSION="3.1.3"
-        PROJVERSION="6.3.2"
+        GDALVERSION="master"
+        PROJVERSION="7.0.1"
+
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="7.1.1"
+        PROJVERSION="7.0.1"
 
 addons:
   apt:
     packages:
-      - libatlas-dev
-      - libatlas-base-dev
-      - gfortran
-      - libsqlite3-dev
-      - sqlite3
-  homebrew:
-    packages:
-      - expat
-      - libspatialite
-      - sqlite
-      - geos
-
-matrix:
-  fast_finish: true
-  include:
-    - os: linux
-      python: "3.6"
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
- 
-    - os: linux
-      python: "3.7"
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
-
-    - os: linux
-      python: "3.8"
-      env:
-        GDALVERSION="3.0.4"
-        PROJVERSION="6.2.1"
-
-    - os: linux
-      python: "3.8"
-      env:
-        GDALVERSION="master"
-        PROJVERSION="6.3.0"
-
-    - os: osx
-      osx_image: xcode11.2
-      language: shell
-      env:
-        GDALVERSION="3.0.3"
-        PROJVERSION="6.2.1"
-
-  allow_failures:
-    - env:
-        GDALVERSION="master"
-        PROJVERSION="6.3.0"
+    - libatlas-dev
+    - libatlas-base-dev
+    - gfortran
+    - libsqlite3-dev
+    - sqlite3
 
 
 before_install:
-  - python3 -m pip install -U pip
+  - python -m pip install -U pip
+  - python -m pip install -r requirements-ci.txt
+  - python -m pip wheel -r requirements-dev.txt
+  - python -m pip install -r requirements-dev.txt
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$GDALINST/proj-$PROJVERSION/bin:$PATH
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export DYLD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$DYLD_LIBRARY_PATH; fi
-  - chmod +x scripts/travis_proj_install.sh && ./scripts/travis_proj_install.sh
-  - chmod +x scripts/travis_gdal_install.sh && ./scripts/travis_gdal_install.sh
+  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$GDALINST/proj-$PROJVERSION/lib:$LD_LIBRARY_PATH
+  - . ./scripts/travis_proj_install.sh
+  - if [ "$TRAVIS_CPU_ARCH" = "amd64" ]; then . ./scripts/travis_filegdb_install.sh; fi
+  - . ./scripts/travis_gdal_install.sh
   - export GDAL_DATA=$GDALINST/gdal-$GDALVERSION/share/gdal
   - export PROJ_LIB=$GDALINST/gdal-$GDALVERSION/share/proj
   - gdal-config --version
-  - $GDALINST/gdal-$GDALVERSION/bin/gdal-config --version
-  - python3 -m pip wheel -r requirements-dev.txt
-  - python3 -m pip install -r requirements-dev.txt
-  - python3 -m pip install coveralls>=1.1 --upgrade
 
 install:
-  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $($GDALINST/gdal-$GDALVERSION/bin/gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
-  - GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python3 -m pip install -v -v -v --no-deps --force-reinstall --no-use-pep517 -e .
-  - python3 -m pip freeze
+  - if [ "$GDALVERSION" = "master" ]; then echo "Using gdal master"; elif [ $(gdal-config --version) == $(sed 's/[a-zA-Z].*//g' <<< $GDALVERSION) ]; then echo "Using gdal $GDALVERSION"; else echo "NOT using gdal $GDALVERSION as expected; aborting"; exit 1; fi
+  - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --no-deps --force-reinstall --no-use-pep517 -e ."
+  - python -m pip freeze
   - fio --version
   - fio --gdal-version
   - python -c "import fiona; fiona.show_versions()"
   - python scripts/check_deprecated.py
 
 script:
-  - python3 -m pytest -m "not wheel" --cov fiona --cov-report term-missing
-
-after_script:
-  - python3 setup.py clean
+  - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing
 
   # Check documentation
   - rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .
 
 after_script:
-  - python3 setup.py clean
+  - python setup.py clean
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"
+
+before_cache:
+  - if [ "$GDALVERSION" = "master" ]; then rm -rf $GDALINST/gdal-$GDALVERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ addons:
 
 
 before_install:
+  - | 
+    if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then
+        sudo chown -Rv $USER:$GROUP ~/.cache/pip/wheels
+    fi
   - python -m pip install -U pip
   - python -m pip install -r requirements-ci.txt
   - python -m pip wheel -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       env:
         GDALVERSION="3.1.3"
         PROJVERSION="6.3.2"
-    - python: "3.9"
+    - python: "3.9-dev"
       env:
         GDALVERSION="3.1.3"
         PROJVERSION="6.3.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,12 @@ jobs:
     - python: "3.8"
       env:
         GDALVERSION="master"
-        PROJVERSION="7.0.1"
+        PROJVERSION="7.1.1"
 
   allow_failures:
     - env:
         GDALVERSION="master"
-        PROJVERSION="7.0.1"
+        PROJVERSION="7.1.1"
 
 addons:
   apt:

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Fiona
 
 Fiona reads and writes geographic data files and thereby helps Python programmers
 integrate geographic information systems with other computer systems. Fiona
-contains extension modules that link the Geospatial Data Abstraction Library (GDAL).
+contains extension modules that link the Geospatial Data Abstraction Library (GDAL_).
 
 .. image:: https://travis-ci.org/Toblerity/Fiona.png?branch=master
    :target: https://travis-ci.org/Toblerity/Fiona

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -96,17 +96,16 @@ polygons in Google Earth for one. No other library (like :py:mod:`Shapely`) is
 needed here, which keeps it uncomplicated. There's a :file:`test_uk` file in
 the Fiona repository for use in this and other examples.
 
-.. sourcecode:: python
+.. code-block:: python
 
   import datetime
   import logging
   import sys
-
+  
   import fiona
-
+  
   logging.basicConfig(stream=sys.stderr, level=logging.INFO)
-
-
+  
   def signed_area(coords):
       """Return the signed area enclosed by a ring using the linear time
       algorithm at http://www.cgafaq.info/wiki/Polygon_Area. A value >= 0
@@ -114,53 +113,51 @@ the Fiona repository for use in this and other examples.
       """
       xs, ys = map(list, zip(*coords))
       xs.append(xs[1])
-      ys.append(ys[1])
-      return sum(xs[i] * (ys[i + 1] - ys[i - 1]) for i in range(1, len(coords))) / 2.0
-
-
-  with fiona.open("docs/data/test_uk.shp", "r") as source:
-
+      ys.append(ys[1]) 
+      return sum(xs[i]*(ys[i+1]-ys[i-1]) for i in range(1, len(coords)))/2.0
+  
+  with fiona.open('docs/data/test_uk.shp', 'r') as source:
+      
       # Copy the source schema and add two new properties.
       sink_schema = source.schema
-      sink_schema["properties"]["s_area"] = "float"
-      sink_schema["properties"]["timestamp"] = "datetime"
-
-      # Create a sink for processed features with the same format and
+      sink_schema['properties']['s_area'] = 'float'
+      sink_schema['properties']['timestamp'] = 'datetime'
+      
+      # Create a sink for processed features with the same format and 
       # coordinate reference system as the source.
       with fiona.open(
-          "oriented-ccw.shp",
-          "w",
-          crs=source.crs,
-          driver=source.driver,
-          schema=sink_schema,
-      ) as sink:
-
+              'oriented-ccw.shp', 'w',
+              crs=source.crs,
+              driver=source.driver,
+              schema=sink_schema,
+              ) as sink:
+          
           for f in source:
-
+              
               try:
-
+  
                   # If any feature's polygon is facing "down" (has rings
                   # wound clockwise), its rings will be reordered to flip
                   # it "up".
-                  g = f["geometry"]
-                  assert g["type"] == "Polygon"
-                  rings = g["coordinates"]
+                  g = f['geometry']
+                  assert g['type'] == "Polygon"
+                  rings = g['coordinates']
                   sa = sum(signed_area(r) for r in rings)
                   if sa < 0.0:
                       rings = [r[::-1] for r in rings]
-                      g["coordinates"] = rings
-                      f["geometry"] = g
-
+                      g['coordinates'] = rings
+                      f['geometry'] = g
+  
                   # Add the signed area of the polygon and a timestamp
                   # to the feature properties map.
-                  f["properties"].update(
-                      s_area=sa, timestamp=datetime.datetime.now().isoformat()
-                  )
-
+                  f['properties'].update(
+                      s_area=sa,
+                      timestamp=datetime.datetime.now().isoformat() )
+  
                   sink.write(f)
-
-              except Exception, e:
-                  logging.exception("Error processing feature %s:", f["id"])
+              
+              except Exception as e:
+                  logging.exception("Error processing feature %s:", f['id'])
 
           # The sink file is written to disk and closed when its block ends.
 
@@ -1436,7 +1433,7 @@ in an instance of ZipMemoryFile.
 *New in 1.8.0*
 
 Fiona command line interface
-======
+============================
 
 Fiona comes with a command line interface called "fio". See the
 `CLI Documentation <cli.html>`__ for detailed usage instructions.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,4 +3,3 @@ coveralls
 sphinx==3.0.2 ; python_version > '3.0'
 sphinx==1.8.5 ; python_version < '3.0'
 rstcheck==3.3.1
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cligj==0.5.0
 munch==2.3.2
 six==1.11.0
 enum34==1.1.6 ; python_version < '3.4'
+certifi

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -14,7 +14,8 @@ GDALOPTS="  --with-geos \
             --without-libgrass \
             --without-cfitsio \
             --without-pcraster \
-            --with-netcdf \
+            --without-netcdf \
+            --without-openjpeg \
             --with-png=internal \
             --with-jpeg=internal \
             --without-gif \
@@ -37,17 +38,19 @@ GDALOPTS="  --with-geos \
             --without-perl \
             --without-python \
             --with-oci=no \
-            --with-webp=no"
+            --without-mrf \
+            --with-webp=no \
+            --without-lerc"
 
 # OS specific gdal build options
-if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    GDALOPTS="$GDALOPTS \
-                --with-expat \
-                --with-sqlite3"
-elif [ $TRAVIS_OS_NAME = 'osx' ]; then
+if [ $TRAVIS_OS_NAME = 'osx' ]; then
     GDALOPTS="$GDALOPTS \
                 --with-expat=/usr/local/opt/expat \
                 --with-sqlite3=/usr/local/opt/sqlite"
+else
+    GDALOPTS="$GDALOPTS \
+              --with-expat \
+              --with-sqlite3"
 fi
 
 if [ -d "$FILEGDB" ]; then

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -4,7 +4,6 @@
 set -e
 
 GDALOPTS="  --with-geos \
-            --with-expat \
             --without-libtool \
             --with-libz=internal \
             --with-libtiff=internal \
@@ -40,6 +39,17 @@ GDALOPTS="  --with-geos \
             --without-python \
             --with-oci=no \
             --with-webp=no"
+
+# OS specific gdal build options
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    GDALOPTS="$GDALOPTS \
+                --with-expat \
+                --with-sqlite3"
+elif [ $TRAVIS_OS_NAME = 'osx' ]; then
+    GDALOPTS="$GDALOPTS \
+                --with-expat=/usr/local/opt/expat \
+                --with-sqlite3=/usr/local/opt/sqlite"
+fi
 
 if [ -d "$FILEGDB" ]; then
   GDALOPTS="$GDALOPTS --with-fgdb=$FILEGDB"

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -4,6 +4,7 @@
 set -e
 
 GDALOPTS="  --with-geos \
+            --with-expat \
             --without-libtool \
             --with-libz=internal \
             --with-libtiff=internal \
@@ -14,8 +15,9 @@ GDALOPTS="  --with-geos \
             --without-libgrass \
             --without-cfitsio \
             --without-pcraster \
-            --without-netcdf \
-            --without-openjpeg \
+            --with-netcdf \
+            --with-png=internal \
+            --with-jpeg=internal \
             --without-gif \
             --without-ogdi \
             --without-fme \
@@ -31,29 +33,13 @@ GDALOPTS="  --with-geos \
             --without-xerces \
             --without-odbc \
             --with-curl \
+            --with-sqlite3 \
             --without-idb \
             --without-sde \
             --without-perl \
-            --without-php \
             --without-python \
             --with-oci=no \
-            --without-mrf \
-            --with-webp=no \
-            --without-lerc \
-            --with-png=internal \
-            --with-jpeg=internal"
-
-# OS specific gdal build options
-if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    GDALOPTS="$GDALOPTS \
-                --with-expat \
-                --with-sqlite3"
-
-elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    GDALOPTS="$GDALOPTS \
-                --with-expat=/usr/local/opt/expat \
-                --with-sqlite3=/usr/local/opt/sqlite"
-fi
+            --with-webp=no"
 
 if [ -d "$FILEGDB" ]; then
   GDALOPTS="$GDALOPTS --with-fgdb=$FILEGDB"
@@ -61,37 +47,34 @@ fi
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then
-  mkdir "$GDALBUILD";
+  mkdir $GDALBUILD;
 fi
 
 if [ ! -d "$GDALINST" ]; then
-  mkdir "$GDALINST";
+  mkdir $GDALINST;
 fi
 
-ls -l "$GDALINST";
+ls -l $GDALINST
 
 if [ "$GDALVERSION" = "master" ]; then
     PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
-    cd "$GDALBUILD"
-    git clone --depth 1 https://github.com/OSGeo/gdal gdal-"$GDALVERSION"
-    cd gdal-"$GDALVERSION/gdal"
-    echo "$PROJVERSION" > newproj.txt
+    cd $GDALBUILD
+    git clone --depth 1 https://github.com/OSGeo/gdal gdal-$GDALVERSION
+    cd gdal-$GDALVERSION/gdal
+    echo $PROJVERSION > newproj.txt
     git rev-parse HEAD > newrev.txt
     BUILD=no
     # Only build if nothing cached or if the GDAL revision changed
-
-    if test ! -f "$GDALINST/gdal-$GDALVERSION/rev.txt"; then
+    if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
         BUILD=yes
-    elif ( ! diff newrev.txt "$GDALINST/gdal-$GDALVERSION/rev.txt" >/dev/null ) || ( ! diff newproj.txt "$GDALINST/gdal-$GDALVERSION/newproj.txt" >/dev/null ); then
+    elif ( ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null ) || ( ! diff newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt >/dev/null ); then
         BUILD=yes
     fi
-
     if test "$BUILD" = "yes"; then
-        mkdir -p "$GDALINST/gdal-$GDALVERSION"
-        cp newrev.txt "$GDALINST/gdal-$GDALVERSION/rev.txt"
-        cp newproj.txt "$GDALINST/gdal-$GDALVERSION/newproj.txt"
-        echo "./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT"
-        ./configure --prefix="$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT"
+        mkdir -p $GDALINST/gdal-$GDALVERSION
+        cp newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt
+        cp newproj.txt $GDALINST/gdal-$GDALVERSION/newproj.txt
+        ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
         make
         make install
     fi
@@ -101,13 +84,12 @@ else
     PROJOPT="--with-proj=$GDALINST/gdal-$GDALVERSION"
 
     if [ ! -d "$GDALINST/gdal-$GDALVERSION/share/gdal" ]; then
-        cd "$GDALBUILD"
+        cd $GDALBUILD
         gdalver=$(expr "$GDALVERSION" : '\([0-9]*.[0-9]*.[0-9]*\)')
-        wget -q "http://download.osgeo.org/gdal/$gdalver/gdal-$GDALVERSION.tar.gz"
-        tar -xzf "gdal-$GDALVERSION.tar.gz"
-        cd "gdal-$gdalver"
-        echo "./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT"
-        ./configure --prefix="$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT"
+        wget -q http://download.osgeo.org/gdal/$gdalver/gdal-$GDALVERSION.tar.gz
+        tar -xzf gdal-$GDALVERSION.tar.gz
+        cd gdal-$gdalver
+        ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS $PROJOPT
         make
         make install
     fi
@@ -117,4 +99,4 @@ fi
 rm -rf "$GDALBUILD"
 
 # change back to travis build dir
-cd "$TRAVIS_BUILD_DIR"
+cd $TRAVIS_BUILD_DIR

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -32,7 +32,6 @@ GDALOPTS="  --with-geos \
             --without-xerces \
             --without-odbc \
             --with-curl \
-            --with-sqlite3 \
             --without-idb \
             --without-sde \
             --without-perl \

--- a/scripts/travis_proj_install.sh
+++ b/scripts/travis_proj_install.sh
@@ -25,5 +25,8 @@ if [ ! -d "$PROJINST/gdal-$GDALVERSION/share/proj" ]; then
     make install
 fi
 
+# Remove projbuild to emulate travis cache
+rm -rf "$PROJBUILD"
+
 # change back to travis build dir
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
@sgillies I did not spot what exactly caused that gdal install did not find the proj libs. I used the travis setup from maint-1.8 and tried to apply the same changes. I hope I caught everything. I

I moved the OSX builds to a github workflow. If you don't like this feel free to delete the  .github/workflows/ci_macos.yml. The advantage of using the github workflow is that it allows specifying the Python version and more jobs can run in parallel.

There are still some issues:
- An appveyor test is still failing
- Pytest should not display runtime warnings, such as `RuntimeWarning: Sequential read of iterator was interrupted. Resetting iterator. This can negatively impact the performance.`

The build of gdal 3.1.3 fails for ppc64le, but it succeeds with gdal 3.0.4. 