### PR TITLE
Fix maint-1.8 appveyor

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+filterwarnings =
+    ignore:.*Sequential read of iterator was interrupted*:RuntimeWarning
+    ignore:.*negative slices or start values other than zero may be slow*:RuntimeWarning
+    ignore:.*negative step size may be slow*:RuntimeWarning
+    ignore:.*is buggy and will be removed in Fiona 2.0.*
+
+markers = 
+    iconv: marks tests that require gdal to be compiled with iconv
+    network: marks tests that require a network connection
+    wheel: marks test that only works when installed from wheel
+
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cligj==0.5.0
 munch==2.3.2
 six==1.11.0
 enum34==1.1.6 ; python_version < '3.4'
+certifi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[tool:pytest]
-testpaths = tests
-markers =
-    slow
-    network
-    iconv
-    wheel

--- a/tests/test_fio_load.py
+++ b/tests/test_fio_load.py
@@ -5,6 +5,8 @@ import json
 import os
 import shutil
 
+import pytest
+
 import fiona
 from fiona.fio.main import main_group
 
@@ -121,7 +123,8 @@ def test_fio_load_layer(tmpdir, runner):
         shutil.rmtree(outdir)
 
 
-def test_creation_optiona(tmpdir, runner, feature_seq):
+@pytest.mark.iconv
+def test_creation_options(tmpdir, runner, feature_seq):
     tmpfile = str(tmpdir.mkdir("tests").join("test.shp"))
     result = runner.invoke(
         main_group,


### PR DESCRIPTION
- Add certifi to requirements
- Mark test_fio_load.py/test_creation_options with @pytest.mark.iconv
- Ignore certain warnings in the pytest warning summary