### PR TITLE
Move rstcheck to a github action

### DIFF
--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -1,0 +1,26 @@
+name: rstcheck
+
+# Run this workflow every time a new commit pushed to your repository
+on: [push, pull_request]
+
+jobs:
+  rstcheck:
+    name: rstcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install sphinx==3.2.1 rstcheck==3.3.1
+
+      - name: Run rstcheck
+        run: |
+          rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,9 +117,6 @@ install:
 script:
   - python -m pytest -m "not wheel" --cov fiona --cov-report term-missing
 
-  # Check documentation
-  - rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .
-
 after_script:
   - python setup.py clean
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,1 @@
 coveralls
-# sphinx 3.x does not support python 2.7
-sphinx==3.0.2 ; python_version > '3.0'
-sphinx==1.8.5 ; python_version < '3.0'
-rstcheck==3.3.1
-


### PR DESCRIPTION
Travis only caches after a successful build. I found it a bit annoying when gdal had to be compiled from source, pytest was successful but then rstcheck failed and gdal was not cached.

This PR moves the rstcheck from travis to a dedicated github action. 
