### PR TITLE
Pass dataset creation options to gdal_create when creating new file

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1007,7 +1007,7 @@ cdef class WritingSession(Session):
 
             if not CPLCheckForFile(path_c, NULL):
                 log.debug("File doesn't exist. Creating a new one...")
-                cogr_ds = gdal_create(cogr_driver, path_c, {})
+                cogr_ds = gdal_create(cogr_driver, path_c, kwargs)
 
             else:
                 if collection.driver == "GeoJSON":

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1007,7 +1007,8 @@ cdef class WritingSession(Session):
 
             if not CPLCheckForFile(path_c, NULL):
                 log.debug("File doesn't exist. Creating a new one...")
-                cogr_ds = gdal_create(cogr_driver, path_c, kwargs)
+                with Env(GDAL_VALIDATE_CREATION_OPTIONS="NO"):
+                    cogr_ds = gdal_create(cogr_driver, path_c, kwargs)
 
             else:
                 if collection.driver == "GeoJSON":

--- a/tests/test_driver_options.py
+++ b/tests/test_driver_options.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+from collections import OrderedDict
+import glob
+
+import fiona
+from tests.conftest import get_temp_filename
+
+
+def test_gml_format_option():
+    """ Test GML dataset creation option FORMAT (see https://github.com/Toblerity/Fiona/issues/968)"""
+
+    schema = {'geometry': 'Point', 'properties': OrderedDict([('position', 'int')])}
+    records = [{'geometry': {'type': 'Point', 'coordinates': (0.0, float(i))}, 'properties': {'position': i}} for i in
+               range(10)]
+
+    tmpdir = tempfile.mkdtemp()
+    fpath = os.path.join(tmpdir, get_temp_filename('GML'))
+
+    with fiona.open(fpath,
+                    'w',
+                    driver="GML",
+                    schema=schema,
+                    FORMAT="GML3") as out:
+        out.writerecords(records)
+
+    xsd_path = glob.glob(os.path.join(tmpdir, "*.xsd"))[0]
+    with open(xsd_path) as f:
+        xsd = f.read()
+        assert "http://schemas.opengis.net/gml/3.1.1" in xsd

--- a/tests/test_driver_options.py
+++ b/tests/test_driver_options.py
@@ -2,11 +2,11 @@ import os
 import tempfile
 from collections import OrderedDict
 import glob
-
 import fiona
-from tests.conftest import get_temp_filename
+from tests.conftest import get_temp_filename, requires_gdal2
 
 
+@requires_gdal2
 def test_gml_format_option():
     """ Test GML dataset creation option FORMAT (see https://github.com/Toblerity/Fiona/issues/968)"""
 


### PR DESCRIPTION
Currently, Fiona does only pass options when a new layer is created, but not when a dataset is created. 
This PR passes options to gdal_create when a new dataset is created.

I'm not sure if in this case gdal_create should be wrapped with `with Env(GDAL_VALIDATE_CREATION_OPTIONS="NO")`.

This fixes https://github.com/Toblerity/Fiona/issues/968