### PR TITLE
Support precision for GeometryCollection geometries in fiona.transform

### DIFF
--- a/fiona/_transform.pyx
+++ b/fiona/_transform.pyx
@@ -163,7 +163,7 @@ def _transform_geom(
 
     if precision >= 0:
     
-        def process_point(g):
+        def round_point(g):
             coords = list(g['coordinates'])
             x, y = coords[:2]
             x = round(x, precision)
@@ -175,7 +175,7 @@ def _transform_geom(
             return new_coords
         
         
-        def process_linestring(g):
+        def round_linestring(g):
             coords = list(zip(*g['coordinates']))
             xp, yp = coords[:2]
             xp = [round(v, precision) for v in xp]
@@ -189,7 +189,7 @@ def _transform_geom(
             return new_coords
 
 
-        def process_polygon(g):
+        def round_polygon(g):
             new_coords = []
             for piece in g['coordinates']:
                 coords = list(zip(*piece))
@@ -204,7 +204,7 @@ def _transform_geom(
                     new_coords.append(list(zip(xp, yp)))
             return new_coords
 
-        def process_multipolygon(g):
+        def round_multipolygon(g):
             parts = g['coordinates']
             new_coords = []
             for part in parts:
@@ -223,22 +223,22 @@ def _transform_geom(
                 new_coords.append(inner_coords)
             return new_coords
 
-        def process_geometry(g):        
+        def round_geometry(g):        
             if g['type'] == 'Point':
-                g['coordinates'] = process_point(g)
+                g['coordinates'] = round_point(g)
             elif g['type'] in ['LineString', 'MultiPoint']:
-                g['coordinates'] = process_linestring(g)
+                g['coordinates'] = round_linestring(g)
             elif g['type'] in ['Polygon', 'MultiLineString']:
-                g['coordinates'] = process_polygon(g)
+                g['coordinates'] = round_polygon(g)
             elif g['type'] == 'MultiPolygon':
-                g['coordinates'] = process_multipolygon(g)
+                g['coordinates'] = round_multipolygon(g)
             else:
                 raise RuntimeError("Unsupported geometry type: {}".format(g['type']))
         
         if g['type'] == 'GeometryCollection':
             for _g in g['geometries']:
-                process_geometry(_g)
+                round_geometry(_g)
         else:
-            process_geometry(g)
+            round_geometry(g)
 
     return g

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -70,3 +70,15 @@ def test_axis_ordering(crs):
     geom = {"type": "Point", "coordinates": [-8427998.647958742, 4587905.27136252]}
     g2 = transform.transform_geom("epsg:3857", crs, geom, precision=3)
     assert g2["coordinates"] == pytest.approx(rev_expected)
+
+
+def test_transform_issue971():
+    """ See https://github.com/Toblerity/Fiona/issues/971 """
+    source_crs = "epsg:25832"
+    dest_src = "epsg:4326"
+    geom = {'type': 'GeometryCollection', 'geometries': [{'type': 'LineString',
+                                                          'coordinates': [(512381.8870945257, 5866313.311218272),
+                                                                          (512371.23869999964, 5866322.282500001),
+                                                                          (512364.6014999999, 5866328.260199999)]}]}
+    geom_transformed = transform.transform_geom(source_crs, dest_src, geom, precision=3)
+

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -81,4 +81,4 @@ def test_transform_issue971():
                                                                           (512371.23869999964, 5866322.282500001),
                                                                           (512364.6014999999, 5866328.260199999)]}]}
     geom_transformed = transform.transform_geom(source_crs, dest_src, geom, precision=3)
-
+    assert geom_transformed['geometries'][0]['coordinates'][0] == pytest.approx((9.184, 52.946))


### PR DESCRIPTION
Currently, fiona.transform does not support GeometryCollection geometries when the precision argument is set (see https://github.com/Toblerity/Fiona/issues/971). 

This PR refactors the way geometries are rounded after the transformation and supports GeometryCollection.
@sgillies I'm not sure if this is the best way to solve this issue. The code looks a bit complicated. 