### PR TITLE
Remove 'six' module use; reduce footprint of 'fiona.compat'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Changes:
   fiona.model.Properties.
 - GDAL 3.1.0 is the minimum GDAL version.
 - Drop Python 2, and establish Python 3.7 as the minimum version (#1079).
+- Remove six and reduce footprint of fiona.compat (#985).
 
 Deprecations:
 

--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ gdal``).
 Python Requirements
 -------------------
 
-Fiona depends on the modules ``six``, ``cligj``,  and ``munch``.
+Fiona depends on the modules ``cligj`` and ``munch``.
 Pip will fetch these requirements for you, but users installing Fiona from a
 Windows installer must get them separately.
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -68,7 +68,6 @@ import os
 import sys
 import warnings
 import platform
-from six import string_types
 from collections import OrderedDict
 
 try:
@@ -348,7 +347,7 @@ def listdir(path):
     """
     if isinstance(path, Path):
         path = str(path)
-    if not isinstance(path, string_types):
+    if not isinstance(path, str):
         raise TypeError("invalid path: %r" % path)
     pobj = parse_path(path)
     return _listdir(vsi_path(pobj))
@@ -382,9 +381,9 @@ def listlayers(fp, vfs=None):
         if isinstance(fp, Path):
             fp = str(fp)
 
-        if not isinstance(fp, string_types):
+        if not isinstance(fp, str):
             raise TypeError("invalid path: %r" % fp)
-        if vfs and not isinstance(vfs, string_types):
+        if vfs and not isinstance(vfs, str):
             raise TypeError("invalid vfs: %r" % vfs)
 
         if vfs:

--- a/fiona/_crs.pyx
+++ b/fiona/_crs.pyx
@@ -7,8 +7,6 @@ from __future__ import absolute_import
 
 import logging
 
-from six import string_types
-
 from fiona cimport _cpl
 from fiona._err cimport exc_wrap_pointer
 from fiona._err import CPLE_BaseError
@@ -38,7 +36,7 @@ def crs_to_wkt(crs):
         crs = crs.to_wkt()
 
     # First, check for CRS strings like "EPSG:3857".
-    if isinstance(crs, string_types):
+    if isinstance(crs, str):
         proj_b = crs.encode('utf-8')
         proj_c = proj_b
         OSRSetFromUserInput(cogr_srs, proj_c)

--- a/fiona/_transform.pyx
+++ b/fiona/_transform.pyx
@@ -6,13 +6,13 @@ from __future__ import absolute_import
 
 import logging
 import warnings
+from collections import UserDict
 
 from fiona cimport _cpl, _crs, _csl, _geometry
 from fiona._crs cimport OGRSpatialReferenceH
 from fiona._shim cimport osr_set_traditional_axis_mapping_strategy
 
-from fiona.compat import UserDict, DICT_TYPES
-from fiona.compat import UserDict
+from fiona.compat import DICT_TYPES
 from fiona.model import Geometry
 
 

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -32,7 +32,6 @@ with fiona._loading.add_gdal_dll_directories():
         _driver_supports_field,
     )
     from fiona.path import Path, vsi_path, parse_path
-    from six import string_types, binary_type
 
 
 _GDAL_VERSION_TUPLE = get_gdal_version_tuple()
@@ -71,26 +70,26 @@ class Collection(object):
         options.
         """
 
-        if not isinstance(path, (string_types, Path)):
+        if not isinstance(path, (str, Path)):
             raise TypeError("invalid path: %r" % path)
-        if not isinstance(mode, string_types) or mode not in ('r', 'w', 'a'):
+        if not isinstance(mode, str) or mode not in ('r', 'w', 'a'):
             raise TypeError("invalid mode: %r" % mode)
-        if driver and not isinstance(driver, string_types):
+        if driver and not isinstance(driver, str):
             raise TypeError("invalid driver: %r" % driver)
         if schema and not hasattr(schema, 'get'):
             raise TypeError("invalid schema: %r" % schema)
-        if crs and not isinstance(crs, compat.DICT_TYPES + string_types):
+        if crs and not isinstance(crs, compat.DICT_TYPES + (str,)):
             raise TypeError("invalid crs: %r" % crs)
-        if crs_wkt and not isinstance(crs_wkt, string_types):
+        if crs_wkt and not isinstance(crs_wkt, str):
             raise TypeError("invalid crs_wkt: %r" % crs_wkt)
-        if encoding and not isinstance(encoding, string_types):
+        if encoding and not isinstance(encoding, str):
             raise TypeError("invalid encoding: %r" % encoding)
-        if layer and not isinstance(layer, tuple(list(string_types) + [int])):
+        if layer and not isinstance(layer, (str, int)):
             raise TypeError("invalid name: %r" % layer)
         if vsi:
-            if not isinstance(vsi, string_types) or not vfs.valid_vsi(vsi):
+            if not isinstance(vsi, str) or not vfs.valid_vsi(vsi):
                 raise TypeError("invalid vsi: %r" % vsi)
-        if archive and not isinstance(archive, string_types):
+        if archive and not isinstance(archive, str):
             raise TypeError("invalid archive: %r" % archive)
         if ignore_fields is not None and include_fields is not None:
             raise ValueError("Cannot specify both 'ignore_fields' and 'include_fields'")
@@ -146,7 +145,7 @@ class Collection(object):
             self.path = vsi_path(path)
 
         if mode == 'w':
-            if layer and not isinstance(layer, string_types):
+            if layer and not isinstance(layer, str):
                 raise ValueError("in 'w' mode, layer names must be strings")
             if driver == 'GeoJSON':
                 if layer is not None:
@@ -651,7 +650,7 @@ ALL_GEOMETRY_TYPES.add("None")
 def _get_valid_geom_types(schema, driver):
     """Returns a set of geometry types the schema will accept"""
     schema_geom_type = schema["geometry"]
-    if isinstance(schema_geom_type, string_types) or schema_geom_type is None:
+    if isinstance(schema_geom_type, str) or schema_geom_type is None:
         schema_geom_type = (schema_geom_type,)
     valid_types = set()
     for geom_type in schema_geom_type:
@@ -690,7 +689,7 @@ class BytesCollection(Collection):
         """Takes buffer of bytes whose contents is something we'd like
         to open with Fiona and maps it to a virtual file.
         """
-        if not isinstance(bytesbuf, binary_type):
+        if not isinstance(bytesbuf, bytes):
             raise ValueError("input buffer must be bytes")
 
         # Hold a reference to the buffer, as bad things will happen if

--- a/fiona/compat.py
+++ b/fiona/compat.py
@@ -1,23 +1,8 @@
-import collections
-import sys
-
-if sys.version_info[0] >= 3:
-    from urllib.parse import urlparse
-    from collections import UserDict
-    from inspect import getfullargspec as getargspec
-else:
-    from urlparse import urlparse
-    from UserDict import UserDict
-    from inspect import getargspec
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping, MutableMapping
-else:
-    from collections import Mapping, MutableMapping
+from collections import UserDict
+from collections.abc import Mapping
 
 # Users can pass in objects that subclass a few different objects
 # More specifically, rasterio has a CRS() class that subclasses UserDict()
-# In Python 2 UserDict() is in its own module and does not subclass Mapping()
 DICT_TYPES = (dict, Mapping, UserDict)
 
 

--- a/fiona/crs.py
+++ b/fiona/crs.py
@@ -10,8 +10,6 @@ here we use mappings:
     {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
 """
 
-from six import string_types
-
 
 def to_string(crs):
     """Turn a parameter mapping into a more conventional PROJ.4 string.
@@ -24,8 +22,7 @@ def to_string(crs):
     items = []
     for k, v in sorted(filter(
             lambda x: x[0] in all_proj_keys and x[1] is not False and (
-                isinstance(x[1], (bool, int, float)) or
-                isinstance(x[1], string_types)),
+                isinstance(x[1], (bool, int, float, str))),
             crs.items())):
         items.append(
             "+" + "=".join(

--- a/fiona/env.py
+++ b/fiona/env.py
@@ -1,6 +1,7 @@
 """Fiona's GDAL/AWS environment"""
 
 from functools import wraps, total_ordering
+from inspect import getfullargspec
 import logging
 import os
 import re
@@ -8,7 +9,6 @@ import threading
 import warnings
 
 import attr
-from six import string_types
 
 import fiona._loading
 
@@ -24,7 +24,6 @@ with fiona._loading.add_gdal_dll_directories():
         set_gdal_config,
         set_proj_data_search_path,
     )
-    from fiona.compat import getargspec
     from fiona.errors import EnvError, FionaDeprecationWarning, GDALVersionError
     from fiona.session import Session, DummySession
 
@@ -514,7 +513,7 @@ class GDALVersion(object):
             return input
         if isinstance(input, tuple):
             return cls(*input)
-        elif isinstance(input, string_types):
+        elif isinstance(input, str):
             # Extract major and minor version components.
             # alpha, beta, rc suffixes ignored
             match = re.search(r"^\d+\.\d+", input)
@@ -619,7 +618,7 @@ def require_gdal_version(
                     )
 
                 # normalize args and kwds to dict
-                argspec = getargspec(f)
+                argspec = getfullargspec(f)
                 full_kwds = kwds.copy()
 
                 if argspec.args:

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 import itertools
 from json import JSONEncoder
 from warnings import warn
+from collections.abc import MutableMapping
 
 from fiona.errors import FionaDeprecationWarning
-from fiona.compat import MutableMapping
 
 
 # Mapping of OGR integer geometry types to GeoJSON type names.

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -13,8 +13,6 @@ import math
 from collections import namedtuple, OrderedDict
 from uuid import uuid4
 
-from six import integer_types, string_types, text_type
-
 from fiona._shim cimport *
 
 from fiona._geometry cimport (
@@ -231,7 +229,7 @@ cdef class FeatureBuilder:
             elif fieldtype is float:
                 props[key] = OGR_F_GetFieldAsDouble(feature, i)
 
-            elif fieldtype is text_type:
+            elif fieldtype is str:
                 val = OGR_F_GetFieldAsString(feature, i)
                 try:
                     val = val.decode(encoding)
@@ -364,7 +362,7 @@ cdef class OGRFeatureBuilder:
                 value = json.dumps(value)
 
             # Continue over the standard OGR types.
-            if isinstance(value, integer_types):
+            if isinstance(value, int):
                 if schema_type == 'int32':
                     OGR_F_SetFieldInteger(cogr_feature, i, value)
                 else:
@@ -373,7 +371,7 @@ cdef class OGRFeatureBuilder:
             elif isinstance(value, float):
                 OGR_F_SetFieldDouble(cogr_feature, i, value)
             elif schema_type in ['date', 'time', 'datetime'] and value is not None:
-                if isinstance(value, string_types):
+                if isinstance(value, str):
                     if schema_type == 'date':
                         y, m, d, hh, mm, ss, ms, tz = parse_date(value)
                     elif schema_type == 'time':
@@ -432,7 +430,7 @@ cdef class OGRFeatureBuilder:
                 string_c = value
                 OGR_F_SetFieldBinary(cogr_feature, i, len(value),
                     <unsigned char*>string_c)
-            elif isinstance(value, string_types):
+            elif isinstance(value, str):
                 value_bytes = strencode(value, encoding)
                 string_c = value_bytes
                 OGR_F_SetFieldString(cogr_feature, i, string_c)
@@ -514,7 +512,7 @@ cdef class Session:
 
         self.cogr_ds = gdal_open_vector(path_c, 0, drivers, kwargs)
 
-        if isinstance(collection.name, string_types):
+        if isinstance(collection.name, str):
             name_b = collection.name.encode('utf-8')
             name_c = name_b
             self.cogr_layer = GDALDatasetGetLayerByName(self.cogr_ds, name_c)
@@ -1016,7 +1014,7 @@ cdef class WritingSession(Session):
             try:
                 self.cogr_ds = gdal_open_vector(path_c, 1, None, kwargs)
 
-                if isinstance(collection.name, string_types):
+                if isinstance(collection.name, str):
                     name_b = collection.name.encode('utf-8')
                     name_c = name_b
                     self.cogr_layer = exc_wrap_pointer(GDALDatasetGetLayerByName(self.cogr_ds, name_c))
@@ -1123,7 +1121,7 @@ cdef class WritingSession(Session):
                 layer_names.append(name_b.decode('utf-8'))
 
             idx = -1
-            if isinstance(collection.name, string_types):
+            if isinstance(collection.name, str):
                 if collection.name in layer_names:
                     idx = layer_names.index(collection.name)
             elif isinstance(collection.name, int):
@@ -1157,7 +1155,7 @@ cdef class WritingSession(Session):
                 options = CSLAddNameValue(options, <const char *>k, <const char *>v)
 
             geometry_type = collection.schema.get("geometry", "Unknown")
-            if not isinstance(geometry_type, string_types) and geometry_type is not None:
+            if not isinstance(geometry_type, str) and geometry_type is not None:
                 geometry_types = set(geometry_type)
                 if len(geometry_types) > 1:
                     geometry_type = "Unknown"
@@ -1742,7 +1740,7 @@ def _remove_layer(path, layer, driver=None):
     cdef void *cogr_ds
     cdef int layer_index
 
-    if isinstance(layer, integer_types):
+    if isinstance(layer, int):
         layer_index = layer
         layer_str = str(layer_index)
     else:
@@ -1836,7 +1834,7 @@ def buffer_to_virtual_file(bytesbuf, ext=''):
     """
 
     vsi_filename = '/vsimem/{}'.format(uuid4().hex + ext)
-    vsi_cfilename = vsi_filename if not isinstance(vsi_filename, string_types) else vsi_filename.encode('utf-8')
+    vsi_cfilename = vsi_filename if not isinstance(vsi_filename, str) else vsi_filename.encode('utf-8')
 
     vsi_handle = VSIFileFromMemBuffer(vsi_cfilename, <unsigned char *>bytesbuf, len(bytesbuf), 0)
 
@@ -1849,7 +1847,7 @@ def buffer_to_virtual_file(bytesbuf, ext=''):
 
 
 def remove_virtual_file(vsi_filename):
-    vsi_cfilename = vsi_filename if not isinstance(vsi_filename, string_types) else vsi_filename.encode('utf-8')
+    vsi_cfilename = vsi_filename if not isinstance(vsi_filename, str) else vsi_filename.encode('utf-8')
     return VSIUnlink(vsi_cfilename)
 
 

--- a/fiona/path.py
+++ b/fiona/path.py
@@ -5,7 +5,7 @@ import sys
 
 import attr
 
-from fiona.compat import urlparse
+from urllib.parse import urlparse
 
 # Supported URI schemes and their mapping to GDAL's VSI suffix.
 # TODO: extend for other cloud plaforms.

--- a/fiona/schema.pyx
+++ b/fiona/schema.pyx
@@ -1,5 +1,3 @@
-from six import text_type
-
 from fiona.errors import SchemaError
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
 
@@ -39,7 +37,7 @@ FIELD_TYPES = [
 FIELD_TYPES_MAP = {
     'int32': int,
     'float': float,
-    'str': text_type,
+    'str': str,
     'date': FionaDateType,
     'time': FionaTimeType,
     'datetime': FionaDateTimeType,

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import re
-from fiona.compat import urlparse
+from urllib.parse import urlparse
 
 
 # Supported URI schemes and their mapping to GDAL's VSI suffix.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ click-plugins
 cligj>=0.5.0
 munch==2.3.2
 setuptools>=49.0
-six==1.16.0
 certifi

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,6 @@ requirements = [
     'click>=4.0',
     'cligj>=0.5',
     'click-plugins>=1.0',
-    'six>=1.7',
     'munch',
     "setuptools",
 ]

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -2,7 +2,6 @@
 
 
 import pytest
-import six
 
 import fiona
 
@@ -16,7 +15,6 @@ class TestReading(object):
         yield
         self.c.close()
 
-    @pytest.mark.skipif(six.PY2, reason='string are bytes in Python 2')
     def test_construct_with_str(self, path_coutwildrnp_json):
         with open(path_coutwildrnp_json) as src:
             strbuf = src.read()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
 """Unittests to verify Fiona is functioning properly with other software."""
 
 
-import six
+from collections import UserDict
 
 import fiona
 
@@ -14,7 +14,7 @@ def test_dict_subclass(tmpdir):
     not a subclass of `collections.Mapping()`, so it provides an edge case.
     """
 
-    class CRS(six.moves.UserDict):
+    class CRS(UserDict):
         pass
 
     outfile = str(tmpdir.join('test_UserDict.geojson'))

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -5,7 +5,6 @@ import fiona.meta
 from fiona.drvsupport import supported_drivers
 from fiona.errors import FionaValueError
 from .conftest import requires_gdal2, requires_gdal23, requires_gdal31
-from six import string_types
 
 
 @requires_gdal31
@@ -29,7 +28,7 @@ def test_extension(driver):
     """ Test fiona.meta.extension(driver)  """
     # do not fail
     extension = fiona.meta.extension(driver)
-    assert extension is None or isinstance(extension, string_types)
+    assert extension is None or isinstance(extension, str)
 
 
 @requires_gdal2

--- a/tests/test_props.py
+++ b/tests/test_props.py
@@ -1,6 +1,5 @@
 import json
 import os.path
-from six import text_type
 import tempfile
 
 import fiona
@@ -20,8 +19,8 @@ def test_width_other():
 
 
 def test_types():
-    assert prop_type('str:254') == text_type
-    assert prop_type('str') == text_type
+    assert prop_type('str:254') == str
+    assert prop_type('str') == str
     assert isinstance(0, prop_type('int'))
     assert isinstance(0.0, prop_type('float'))
     assert prop_type('date') == FionaDateType
@@ -189,7 +188,7 @@ def test_json_prop_decode_non_geojson_driver():
     with fiona.open(filename) as src:
         actual = next(iter(src))
 
-    assert isinstance(actual['properties']['ulc'], text_type)
+    assert isinstance(actual['properties']['ulc'], str)
     a = json.loads(actual['properties']['ulc'])
     e = json.loads(actual['properties']['ulc'])
     assert e == a

--- a/tests/test_subtypes.py
+++ b/tests/test_subtypes.py
@@ -1,5 +1,4 @@
 import fiona
-import six
 
 def test_read_bool_subtype(tmpdir):
     test_data = """{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"bool": true, "not_bool": 1, "float": 42.5}, "geometry": null}]}"""
@@ -14,7 +13,7 @@ def test_read_bool_subtype(tmpdir):
         assert type(feature["properties"]["bool"]) is bool
     else:
         assert type(feature["properties"]["bool"]) is int
-    assert isinstance(feature["properties"]["not_bool"], six.integer_types)
+    assert isinstance(feature["properties"]["not_bool"], int)
     assert type(feature["properties"]["float"]) is float
 
 def test_write_bool_subtype(tmpdir):


### PR DESCRIPTION
While `six` was handy transitioning thru the Python 2 to 3 conversion, now that Fiona is fully Python 3, it is no longer needed.

Also, there are fewer instances where `fiona.compat` is needed.