### PR TITLE
Only warn iterator reset when iteration has started

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1467,7 +1467,7 @@ cdef class Iterator:
 
         # Set read cursor to next_item position
         if session.cursor_interrupted:
-            if not self.fastindex:
+            if not self.fastindex and not self.next_index == self.start:
                 warnings.warn("Sequential read of iterator was interrupted. Resetting iterator. "
                               "This can negatively impact the performance.", RuntimeWarning)
             exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1438,6 +1438,7 @@ cdef class Iterator:
         # Set OGR_L_SetNextByIndex only if within range
         if start >= 0 and (self.ftcount == -1 or self.start < self.ftcount):
             exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))
+        session.cursor_interrupted = False
 
     def __iter__(self):
         return self

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1467,7 +1467,7 @@ cdef class Iterator:
 
         # Set read cursor to next_item position
         if session.cursor_interrupted:
-            if not self.fastindex and not self.next_index == self.start:
+            if not self.fastindex and not self.next_index == 0:
                 warnings.warn("Sequential read of iterator was interrupted. Resetting iterator. "
                               "This can negatively impact the performance.", RuntimeWarning)
             exc_wrap_int(OGR_L_SetNextByIndex(session.cogr_layer, self.next_index))


### PR DESCRIPTION
This PR fixes that a warning is raised in cases where a collection is converted to a list (https://github.com/Toblerity/Fiona/issues/986), such as:

```
    with fiona.open('sample.gpkg') as src:
        sample = list(src)  # issues a RuntimeWarning in fiona 1.8.18
```

However, it does not prevent that OGR_L_SetNextByIndex(start_index) is executed twice. When the start_index is 0, this is probably not a costly operation, but if the start_index is large, and the driver does not support random access, this could be costly. 

This could be solved by moving https://github.com/Toblerity/Fiona/blob/maint-1.9/fiona/ogrext.pyx#L1554-L1556 into _next() However, _next() is potentially executed many times for large datasets, thus this could generate some overhead for large datasets. 