### PR TITLE
Ensable sqlite support

### DIFF
--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -115,6 +115,7 @@ supported_drivers = dict([
     ("SEGY", "r"),
     # Norwegian SOSI Standard 	SOSI 	No 	Yes 	No, needs FYBA library
     # SQLite/SpatiaLite 	SQLite 	Yes 	Yes 	No, needs libsqlite3 or libspatialite
+    ("SQLite", "raw"),
     # SUA 	SUA 	No 	Yes 	Yes
     ("SUA", "r"),
     # SVG 	SVG 	No 	Yes 	No, needs libexpat


### PR DESCRIPTION
This closes https://github.com/Toblerity/Fiona/issues/992. As Geopackage is a standard within the sqlite file format, the corresponding unittests are are copy of `test_geopackage.py`.