### PR TITLE
BUG: Remove unreachable return in ogrext

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -2061,8 +2061,6 @@ cdef class MemoryFileBase:
         finally:
             CPLFree(buffer)
 
-        return result
-
     def write(self, data):
         """Write data bytes to MemoryFile"""
         cdef const unsigned char *view = <bytes>data


### PR DESCRIPTION
Saw a warning when compiling about this being unreachable.