### PR TITLE
Replace IOError alias with OSError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Fiona
 
 Fiona reads and writes geographic data files and thereby helps Python programmers
 integrate geographic information systems with other computer systems. Fiona
-contains extension modules that link the Geospatial Data Abstraction Library (GDAL).
+contains extension modules that link the Geospatial Data Abstraction Library (`GDAL`_).
 
 .. image:: https://github.com/Toblerity/Fiona/workflows/Linux%20CI/badge.svg?branch=maint-1.8
    :target: https://github.com/Toblerity/Fiona/actions?query=branch%3Amaint-1.8

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -159,7 +159,7 @@ the Fiona repository for use in this and other examples.
 
                   sink.write(f)
 
-              except Exception, e:
+              except Exception as e:
                   logging.exception("Error processing feature %s:", f["id"])
 
           # The sink file is written to disk and closed when its block ends.

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -199,7 +199,7 @@ class Collection(object):
             elif self.mode in ('a', 'w'):
                 self.session = WritingSession()
                 self.session.start(self, **kwargs)
-        except IOError:
+        except OSError:
             self.session = None
             raise
 
@@ -385,7 +385,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -420,7 +420,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -454,7 +454,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -502,7 +502,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         if self.mode not in ('a', 'w'):
-            raise IOError("collection not open for writing")
+            raise OSError("collection not open for writing")
         self.session.writerecs(records, self)
         self._len = self.session.get_length()
         self._bounds = None

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -29,11 +29,11 @@ class UnsupportedOperation(FionaError):
     """Raised when reading from a file opened in 'w' mode"""
 
 
-class DataIOError(IOError):
+class DataIOError(OSError):
     """IO errors involving driver registration or availability."""
 
 
-class DriverIOError(IOError):
+class DriverIOError(OSError):
     """A format specific driver error."""
 
 
@@ -41,7 +41,7 @@ class DriverSupportError(DriverIOError):
     """Driver does not support schema"""
 
 
-class DatasetDeleteError(IOError):
+class DatasetDeleteError(OSError):
     """Failure to delete a dataset"""
 
 

--- a/fiona/io.py
+++ b/fiona/io.py
@@ -50,7 +50,7 @@ class MemoryFile(MemoryFileBase):
         parameters of `fiona.open()`.
         """
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
 
         if not self.exists():
             self._ensure_extension(driver)
@@ -118,7 +118,7 @@ class ZipMemoryFile(MemoryFile):
             vsi_path = '/vsizip{0}'.format(self.name)
 
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
         if path:
             vsi_path = '/vsizip{0}/{1}'.format(self.name, path.lstrip('/'))
         else:

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -155,7 +155,7 @@ class TestReading(object):
         assert f['properties']['STATE'] == 'UT'
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -246,7 +246,7 @@ class TestReading(object):
         assert f['id'] == "2"
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):
@@ -426,11 +426,11 @@ class TestGenericWritingTest(object):
         assert self.c.encoding == 'Windows-1252'
 
     def test_no_iter(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             iter(self.c)
 
     def test_no_filter(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.filter()
 
 

--- a/tests/test_collection_legacy.py
+++ b/tests/test_collection_legacy.py
@@ -167,7 +167,7 @@ class ReadingTest(unittest.TestCase):
         assert f['id'] == "2"
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -69,7 +69,7 @@ def test_open_closed():
     memfile = MemoryFile()
     memfile.close()
     assert memfile.closed
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         memfile.open()
 
 
@@ -78,7 +78,7 @@ def test_open_closed_zip():
     memfile = ZipMemoryFile()
     memfile.close()
     assert memfile.closed
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         memfile.open()
 
 

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -58,10 +58,10 @@ def test_remove(tmpdir, kind, driver, specify_driver):
 
 
 def test_remove_nonexistent(tmpdir):
-    """Attempting to remove a file that does not exist results in an IOError"""
+    """Attempting to remove a file that does not exist results in an OSError"""
     filename = str(tmpdir.join("does_not_exist.shp"))
     assert not os.path.exists(filename)
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         fiona.remove(filename)
 
 @requires_gpkg
@@ -106,12 +106,12 @@ def test_remove_layer_geojson(tmpdir):
     """Removal of layers is not supported by GeoJSON driver
 
     The reason for failure is slightly different between GDAL 2.2+ and < 2.2.
-    With < 2.2 the datasource will fail to open in write mode (IOError), while
+    With < 2.2 the datasource will fail to open in write mode (OSError), while
     with 2.2+ the datasource will open but the removal operation will fail (not
     supported).
     """
     filename = str(tmpdir.join("a_filename.geojson"))
     create_sample_data(filename, "GeoJSON")
-    with pytest.raises((RuntimeError, IOError)):
+    with pytest.raises((RuntimeError, OSError)):
         fiona.remove(filename, layer=0)
     assert os.path.exists(filename)


### PR DESCRIPTION
Since Python 3.3,  IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including IOError (i.e. `assert IOError is OSError`).

This PR changes the old IOError alias to OSError.