### PR TITLE
CI: run "apt-get update" before "apt-get install ..."

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -134,6 +134,7 @@ jobs:
 
       - name: Install apt packages
         run: |
+          sudo apt-get update
           sudo apt-get install libatlas-base-dev libcurl4-openssl-dev libgeos-dev libfreexl-dev libzstd-dev libspatialite-dev
 
           # Unlike travis, packages from non default repositories are installed.


### PR DESCRIPTION
Fixes recent GitHub Actions error with Ubuntu:
```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.15_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```