### PR TITLE
TST: require GDAL>=2.1 for test_open.py::test_write_memfile_crs_wkt

### DIFF
--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -9,6 +9,8 @@ import fiona
 from fiona._crs import crs_to_wkt
 from fiona.errors import DriverError
 
+from .conftest import requires_gdal21
+
 
 def test_open_shp(path_coutwildrnp_shp):
     """Open a shapefile"""
@@ -21,6 +23,7 @@ def test_open_filename_with_exclamation(data_dir):
     assert fiona.open(path), "Failed to open !test.geojson"
 
 
+@requires_gdal21
 @pytest.mark.xfail(raises=DriverError)
 def test_write_memfile_crs_wkt():
     example_schema = {


### PR DESCRIPTION
This is a "fix" for one of the CI test failures with GDAL 2.0 from #1002, with credits to @caspervdw for the [idea](https://github.com/Toblerity/Fiona/pull/1002#issuecomment-783188101).

Investigating this locally, it seems that the format is detected as "SQLite" if read from a BytesIO buffer, but the same bytes written as a file is accurately detected as "GPKG". This behavior goes away with GDAL 2.1, when both memory and file versions are detected as GPKG.

The actual issue may remain unknown, but bare in mind these are 5+ year old versions of GDAL.