### PR TITLE
CI: upgrade GDAL 3.1.0 -> 3.1.3

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -50,7 +50,7 @@ jobs:
             }
           - {
               python: 3.6,
-              GDALVERSION: "3.1.0",
+              GDALVERSION: "3.1.3",
               PROJVERSION: "6.3.2",
               allow_failure: "false",
             }


### PR DESCRIPTION
This upgrade fixes CI failures in `tests/test_meta.py::test_print_driver_options` with a condensed traceback:
```
fiona/meta.py:146: in print_driver_options
    ("Dataset Creation Options", dataset_creation_options(driver)),
fiona/env.py:591: in wrapper
    return f(*args, **kwds)
fiona/meta.py:82: in dataset_creation_options
    return _parse_options(xml)
fiona/meta.py:41: in _parse_options
    root = ET.fromstring(xml)
...
arser.feed(text)
E         File "<string>", line None
E       xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 278
```
while not investigated, it seems that one of the GDAL 3.1 patch releases fixed the bug in the XML.