### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -80,12 +80,18 @@ jobs:
               PROJVERSION: "7.2.1",
               allow_failure: "false",
             }
+          - {
+              python: "3.10",
+              GDALVERSION: "3.3.3",
+              PROJVERSION: "8.2.0",
+              allow_failure: "false",
+            }
 
           # Test GDAL master
           - {
-              python: 3.6,
+              python: 3.9,
               GDALVERSION: "master",
-              PROJVERSION: "7.2.1",
+              PROJVERSION: "8.2.0",
               allow_failure: "true",
             }
 

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -101,7 +101,7 @@ supported_drivers = dict([
     # multi-layer
     #   ("OpenAir", "r"),
     # PCI Geomatics Database File 	PCIDSK 	No 	No 	Yes, using internal PCIDSK SDK (from GDAL 1.7.0)
-    ("PCIDSK", "rw"),
+    ("PCIDSK", "raw"),
     # PDS 	PDS 	No 	Yes 	Yes
     ("PDS", "r"),
     # PDS renamed to OGR_PDS for GDAL 2.x
@@ -162,6 +162,7 @@ driver_mode_mingdal = {
           'FlatGeobuf': (3, 1, 3)},
 
     'a': {'GPKG': (1, 11, 0),
+          'PCIDSK': (3, 3, 0),
           'GeoJSON': (2, 1, 0),
           'MapInfo File': (2, 0, 0)}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]
+requires = [
+    "cython==0.29.24",
+    "oldest-supported-numpy",
+    "setuptools",
+    "wheel",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 -r requirements.txt
-pytest==5.0.1
-setuptools==41.6.0
-boto3==1.9.19
-coverage==4.5.4
-cython==0.29.21
-pytest-cov==2.8.1
-pytz==2020.1
-setuptools==41.6.0
-wheel==0.33.6
+pytest==6.2.5
+boto3==1.20.10
+coverage==6.1.2
+cython==0.29.24
+pytest-cov==3.0.0
+pytz==2021.3
+setuptools==58.5.3
+wheel==0.37.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-attrs==18.2.0
+attrs==21.2.0
 click-plugins==1.0.4
 cligj==0.5.0
 munch==2.3.2
-six==1.11.0
+six==1.16.0
 certifi

--- a/setup.py
+++ b/setup.py
@@ -340,6 +340,8 @@ setup_args = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: GIS'])
 
 if os.environ.get('PACKAGE_DATA'):


### PR DESCRIPTION
The main fix is to upgrade cython to a version that supports Python 3.10. Package classifier metadata is also updated.

Also add recent versions of GDAL and PROJ in the CI matrix.

Appyveyor (Windows) is not updated here, as it appears to have generally lagged without Python 3.9 support yet.

Closes #1043