### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -80,6 +80,12 @@ jobs:
               PROJVERSION: "7.2.1",
               allow_failure: "false",
             }
+          - {
+              python: "3.10",
+              GDALVERSION: "3.3.3",
+              PROJVERSION: "8.2.0",
+              allow_failure: "false",
+            }
 
           # Test GDAL master
           - {

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -99,7 +99,7 @@ supported_drivers = dict([
     # multi-layer
     #   ("OpenAir", "r"),
     # PCI Geomatics Database File 	PCIDSK 	No 	No 	Yes, using internal PCIDSK SDK (from GDAL 1.7.0)
-    ("PCIDSK", "rw"),
+    ("PCIDSK", "raw"),
     # PDS 	PDS 	No 	Yes 	Yes
     ("PDS", "r"),
     # PDS renamed to OGR_PDS for GDAL 2.x
@@ -160,6 +160,7 @@ driver_mode_mingdal = {
           'FlatGeobuf': (3, 1, 3)},
 
     'a': {'GPKG': (1, 11, 0),
+          'PCIDSK': (3, 3, 0),
           'GeoJSON': (2, 1, 0),
           'MapInfo File': (2, 0, 0)}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]
+requires = [
+    "cython==0.29.24",
+    "oldest-supported-numpy",
+    "setuptools",
+    "wheel",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ mock ; python_version < '3.3'
 pytest==6.2.5
 pytest-cov==2.8.1
 setuptools==41.6.0
-boto3==1.9.19
+boto3==1.20.10
 wheel==0.33.6
 pytz==2020.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 coverage==4.5.4
 cython==0.29.24
 mock ; python_version < '3.3'
-pytest==4.6.6
+pytest==6.2.5
 pytest-cov==2.8.1
 setuptools==41.6.0
 boto3==1.9.19

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage==4.5.4
-cython==0.29.21
+cython==0.29.24
 mock ; python_version < '3.3'
 pytest==4.6.6
 pytest-cov==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-attrs==18.2.0
+attrs==21.2.0
 click-plugins==1.0.4
 cligj==0.5.0
 munch==2.3.2
-six==1.11.0
+six==1.16.0
 enum34==1.1.6 ; python_version < '3.4'
 certifi

--- a/setup.py
+++ b/setup.py
@@ -352,7 +352,11 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: GIS'])
 
 if os.environ.get('PACKAGE_DATA'):

--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,9 @@ requirements = [
     'ordereddict; python_version < "2.7"',
     'enum34; python_version < "3.4"'
 ]
+# Python 3.10 workaround as enum34 not available
+if sys.version_info >= (3, 10):
+    requirements.remove('enum34; python_version < "3.4"')
 
 extras_require = {
     'calc': ['shapely'],

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -9,6 +9,8 @@ import fiona
 from fiona._crs import crs_to_wkt
 from fiona.errors import DriverError
 
+from .conftest import requires_gdal21
+
 
 def test_open_shp(path_coutwildrnp_shp):
     """Open a shapefile"""
@@ -21,6 +23,7 @@ def test_open_filename_with_exclamation(data_dir):
     assert fiona.open(path), "Failed to open !test.geojson"
 
 
+@requires_gdal21
 @pytest.mark.xfail(raises=DriverError)
 def test_write_memfile_crs_wkt():
     example_schema = {


### PR DESCRIPTION
An attempt to bring Python 3.10 support to maint-1.8 branch?  I paired back the original commit some out of my blissful ignorance of what may not be necessary.  Please feel free to forcibly reject the PR with fire!

In my fork, the python3.6 build failure matches current [maint-1.8 branch build failure](https://github.com/Toblerity/Fiona/runs/2713722152?check_suite_focus=true)

```
def test_write_memfile_crs_wkt():
E               AssertionError: assert 'SQLite' == 'GPKG'
E                 - SQLite
E                 + GPKG
```

To get python 3.10 green in CI, I needed to additionally:
-  add a setup.py shim since `enum34` was not available.
- bump pytest and boto3 to a version that works on python 3.10

The please-with-a-cherry-on-top, would be to then cut a 1.8.21 release :)