### PR TITLE
MAINT: use super() as described by PEP 3135

### DIFF
--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -388,7 +388,7 @@ cdef class GDALEnv(ConfigEnv):
     """Configuration and driver management"""
 
     def __init__(self, **options):
-        super(GDALEnv, self).__init__(**options)
+        super().__init__(**options)
         self._have_registered_drivers = False
 
     def start(self):

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -723,12 +723,12 @@ class BytesCollection(Collection):
         self.virtual_file = buffer_to_virtual_file(self.bytesbuf, ext=ext)
 
         # Instantiate the parent class.
-        super(BytesCollection, self).__init__(self.virtual_file, vsi=filetype,
-                                              encoding='utf-8', **kwds)
+        super().__init__(
+            self.virtual_file, vsi=filetype, encoding='utf-8', **kwds)
 
     def close(self):
         """Removes the virtual file associated with the class."""
-        super(BytesCollection, self).close()
+        super().close()
         if self.virtual_file:
             remove_virtual_file(self.virtual_file)
             self.virtual_file = None

--- a/fiona/io.py
+++ b/fiona/io.py
@@ -29,7 +29,7 @@ class MemoryFile(MemoryFileBase):
     def __init__(self, file_or_bytes=None, filename=None, ext=""):
         if ext and not ext.startswith("."):
             ext = "." + ext
-        super(MemoryFile, self).__init__(
+        super().__init__(
             file_or_bytes=file_or_bytes, filename=filename, ext=ext)
 
     def open(self, driver=None, schema=None, crs=None, encoding=None,
@@ -95,7 +95,7 @@ class ZipMemoryFile(MemoryFile):
     """
 
     def __init__(self, file_or_bytes=None):
-        super(ZipMemoryFile, self).__init__(file_or_bytes, ext=".zip")
+        super().__init__(file_or_bytes, ext=".zip")
 
     def open(self, path=None, driver=None, encoding=None, layer=None,
              enabled_drivers=None, **kwargs):

--- a/fiona/logutils.py
+++ b/fiona/logutils.py
@@ -10,7 +10,7 @@ class FieldSkipLogFilter(logging.Filter):
     """
 
     def __init__(self, name=''):
-        super(FieldSkipLogFilter, self).__init__(name)
+        super().__init__(name)
         self.seen_msgs = set()
 
     def filter(self, record):


### PR DESCRIPTION
This PR refactors `super()` to be simpler, as described by [PEP 3135](https://www.python.org/dev/peps/pep-3135/) and approved in 2007 for Python 3.0.

The "old" convention (e.g. `super(C, self)`) was only required to support Python 2.