### PR TITLE
Add pytz to test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ requirements = [
 extras_require = {
     'calc': ['shapely'],
     's3': ['boto3>=1.2.4'],
-    'test': ['pytest>=3', 'pytest-cov', 'boto3>=1.2.4']
+    'test': ['pytest>=3', 'pytest-cov', 'boto3>=1.2.4', 'pytz']
 }
 
 extras_require['all'] = list(set(it.chain(*extras_require.values())))


### PR DESCRIPTION
It is used in [`tests/test_datetime.py`](https://github.com/Toblerity/Fiona/blob/master/tests/test_datetime.py#L17).