### PR TITLE
Establish minimum Python version 3.6 for maint-1.9 branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9dev
 ------
 
+Changes:
+
+- Drop Python 2, and establish Python 3.6 as the minimum version (#1079).
+
 Deprecations:
 
 - The fiona.drivers() function has been deprecated and will be removed in

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@ Fiona
 
 Fiona is GDAL_'s neat and nimble vector API for Python programmers.
 
-.. image:: https://github.com/Toblerity/Fiona/workflows/Linux%20CI/badge.svg?branch=maint-1.8
-   :target: https://github.com/Toblerity/Fiona/actions?query=branch%3Amaint-1.8
+.. image:: https://github.com/Toblerity/Fiona/workflows/Linux%20CI/badge.svg?branch=maint-1.9
+   :target: https://github.com/Toblerity/Fiona/actions?query=branch%3Amaint-1.9
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/Toblerity/Fiona?svg=true
-   :target: https://ci.appveyor.com/project/sgillies/fiona/branch/master
+   :target: https://ci.appveyor.com/project/sgillies/fiona/branch/maint-1.9
 
 .. image:: https://coveralls.io/repos/Toblerity/Fiona/badge.svg
    :target: https://coveralls.io/r/Toblerity/Fiona
@@ -19,7 +19,10 @@ and protocols such as files, dictionaries, mappings, and iterators instead of
 classes specific to OGR. Fiona can read and write real-world data using
 multi-layered GIS formats and zipped virtual file systems and integrates
 readily with other Python GIS packages such as pyproj_, Rtree_, and Shapely_.
-Fiona is supported only on CPython versions 2.7 and 3.4+.
+
+Fiona is supported only on CPython versions 3.6+.
+
+Why the name "Fiona"? Because Fiona Is OGR's Neat and Nimble API for Python programmers. And a Shrek reference made us laugh.
 
 For more details, see:
 
@@ -216,7 +219,7 @@ info`` pretty prints information about a data file.
 Installation
 ============
 
-Fiona requires Python 2.7 or 3.4+ and GDAL/OGR 1.8+. To build from
+Fiona requires Python 3.6+ and GDAL/OGR 1.8+. To build from
 a source distribution you will need a C compiler and GDAL and Python
 development headers and libraries (libgdal1-dev for Debian/Ubuntu, gdal-dev for
 CentOS/Fedora).
@@ -233,10 +236,9 @@ gdal``).
 Python Requirements
 -------------------
 
-Fiona depends on the modules ``enum34``, ``six``, ``cligj``,  ``munch``, ``argparse``, and
-``ordereddict`` (the two latter modules are standard in Python 2.7+). Pip will
-fetch these requirements for you, but users installing Fiona from a Windows
-installer must get them separately.
+Fiona depends on the modules ``six``, ``cligj``,  and ``munch``.
+Pip will fetch these requirements for you, but users installing Fiona from a
+Windows installer must get them separately.
 
 Unix-like systems
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ provides an index ordered list of layer names.
             print(layername, len(src))
 
     # Output:
-    # (u'coutwildrnp', 67)
+    # ('coutwildrnp', 67)
 
 Layer can also be specified by index. In this case, ``layer=0`` and
 ``layer='test_uk'`` specify the same layer in the data file or directory.
@@ -113,7 +113,7 @@ Layer can also be specified by index. In this case, ``layer=0`` and
             print(i, layername, len(src))
 
     # Output:
-    # (0, u'coutwildrnp', 67)
+    # (0, 'coutwildrnp', 67)
 
 Writing Multilayer data
 -----------------------
@@ -139,10 +139,10 @@ writing.
         print(f['properties'])
 
         # Output:
-        # [u'bar']
+        # ['bar']
         # 1
         # Polygon
-        # OrderedDict([(u'PERIMETER', 1.22107), (u'FEATURE2', None), (u'NAME', u'Mount Naomi Wilderness'), (u'FEATURE1', u'Wilderness'), (u'URL', u'http://www.wilderness.net/index.cfm?fuse=NWPS&sec=wildView&wname=Mount%20Naomi'), (u'AGBUR', u'FS'), (u'AREA', 0.0179264), (u'STATE_FIPS', u'49'), (u'WILDRNP020', 332), (u'STATE', u'UT')])
+        # OrderedDict([('PERIMETER', 1.22107), ('FEATURE2', None), ('NAME', 'Mount Naomi Wilderness'), ('FEATURE1', 'Wilderness'), ('URL', 'http://www.wilderness.net/index.cfm?fuse=NWPS&sec=wildView&wname=Mount%20Naomi'), ('AGBUR', 'FS'), ('AREA', 0.0179264), ('STATE_FIPS', '49'), ('WILDRNP020', 332), ('STATE', 'UT')])
 
 A view of the /tmp/foo directory will confirm the creation of the new files.
 
@@ -165,7 +165,7 @@ and write zipped Shapefiles.
             print(i, layername, len(src))
 
     # Output:
-    # (0, u'coutwildrnp', 67)
+    # (0, 'coutwildrnp', 67)
 
 Fiona can also read from more exotic file systems. For instance, a
 zipped shape file in S3 can be accessed like so:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import fiona
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+import fiona
 
 # -- General configuration -----------------------------------------------------
 
@@ -41,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Fiona'
-copyright = u'2011, Sean Gillies'
+project = 'Fiona'
+copyright = '2011, Sean Gillies'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +185,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Fiona.tex', u'Fiona Documentation',
-   u'Sean Gillies', 'manual'),
+  ('index', 'Fiona.tex', 'Fiona Documentation',
+   'Sean Gillies', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +215,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'fiona', u'Fiona Documentation',
-     [u'Sean Gillies'], 1)
+    ('index', 'fiona', 'Fiona Documentation',
+     ['Sean Gillies'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +229,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Fiona', u'Fiona Documentation',
-   u'Sean Gillies', 'Fiona', 'One line description of project.',
+  ('index', 'Fiona', 'Fiona Documentation',
+   'Sean Gillies', 'Fiona', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -247,10 +247,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'Fiona'
-epub_author = u'Sean Gillies'
-epub_publisher = u'Sean Gillies'
-epub_copyright = u'2011, Sean Gillies'
+epub_title = 'Fiona'
+epub_author = 'Sean Gillies'
+epub_publisher = 'Sean Gillies'
+epub_copyright = '2011, Sean Gillies'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -293,7 +293,7 @@ Features of a collection may also be accessed by index.
                                    (-4.663611, 51.158333)]],
                   'type': 'Polygon'},
      'id': '1',
-     'properties': OrderedDict([(u'CAT', 232.0), (u'FIPS_CNTRY', u'UK'), (u'CNTRY_NAME', u'United Kingdom'), (u'AREA', 244820.0), (u'POP_CNTRY', 60270708.0)]),
+     'properties': OrderedDict([('CAT', 232.0), ('FIPS_CNTRY', 'UK'), ('CNTRY_NAME', 'United Kingdom'), ('AREA', 244820.0), ('POP_CNTRY', 60270708.0)]),
      'type': 'Feature'}
 
 Note that these indices are controlled by GDAL, and do not always follow Python conventions. They can start from 0, 1 (e.g. geopackages), or even other values, and have no guarantee of contiguity. Negative indices will only function correctly if indices start from 0 and are contiguous.
@@ -457,9 +457,8 @@ Field Types
 -----------
 
 In a nutshell, the types and their names are as near to what you'd expect in
-Python (or Javascript) as possible. The 'str' vs 'unicode' muddle is a fact of
-life in Python < 3.0. Fiona records have Unicode strings, but their field type
-name is 'str' (looking forward to Python 3).
+Python (or Javascript) as possible. Since Python 3, the 'str' field type
+may contain Unicode characters.
 
 .. code-block:: pycon
 
@@ -497,14 +496,6 @@ Another function gets the proper Python type of a property.
   <type 'float'>
   >>> prop_type('str:25')
   <class 'str'>
-
-The example above is for Python 3. With Python 2, the type of 'str' properties
-is 'unicode'.
-
-.. code-block:: pycon
-
-  >>> prop_type('str:25')
-  <class 'unicode'>
 
 Geometry Types
 --------------

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -22,7 +22,7 @@ attribute table. For example:
 
   {'id': '1',
    'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
-   'properties': {'label': u'Null Island'} }
+   'properties': {'label': 'Null Island'} }
 
 is a Fiona feature with a point geometry and one property.
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -69,6 +69,7 @@ import sys
 import warnings
 import platform
 from six import string_types
+from collections import OrderedDict
 
 try:
     from pathlib import Path
@@ -95,7 +96,6 @@ with fiona._loading.add_gdal_dll_directories():
         get_gdal_release_name,
         get_gdal_version_tuple,
     )
-    from fiona.compat import OrderedDict
     from fiona.io import MemoryFile
     from fiona.ogrext import (
         _bounds,

--- a/fiona/_crs.pyx
+++ b/fiona/_crs.pyx
@@ -31,7 +31,7 @@ def crs_to_wkt(crs):
     try:
         cogr_srs = exc_wrap_pointer(OSRNewSpatialReference(NULL))
     except CPLE_BaseError as exc:
-        raise CRSError(u"{}".format(exc))
+        raise CRSError(str(exc))
 
     # check for other CRS classes
     if hasattr(crs, "to_wkt") and callable(crs.to_wkt):

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -388,7 +388,7 @@ cdef class GDALEnv(ConfigEnv):
     """Configuration and driver management"""
 
     def __init__(self, **options):
-        super(GDALEnv, self).__init__(**options)
+        super().__init__(**options)
         self._have_registered_drivers = False
 
     def start(self):

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -189,9 +189,9 @@ cpdef get_gdal_config(key, normalize=True):
     elif val.isdigit():
         return int(val)
     else:
-        if val == u'ON':
+        if val == 'ON':
             return True
-        elif val == u'OFF':
+        elif val == 'OFF':
             return False
         else:
             return val

--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -63,10 +63,7 @@ class CPLE_BaseError(Exception):
         self.errmsg = errmsg
 
     def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
-        return u"{}".format(self.errmsg)
+        return str(self.errmsg)
 
     @property
     def args(self):

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -199,7 +199,7 @@ class Collection(object):
             elif self.mode in ('a', 'w'):
                 self.session = WritingSession()
                 self.session.start(self, **kwargs)
-        except IOError:
+        except OSError:
             self.session = None
             raise
 
@@ -383,7 +383,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -415,7 +415,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -446,7 +446,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         elif self.mode != 'r':
-            raise IOError("collection not open for reading")
+            raise OSError("collection not open for reading")
         if args:
             s = slice(*args)
             start = s.start
@@ -493,7 +493,7 @@ class Collection(object):
         if self.closed:
             raise ValueError("I/O operation on closed collection")
         if self.mode not in ('a', 'w'):
-            raise IOError("collection not open for writing")
+            raise OSError("collection not open for writing")
         self.session.writerecs(records, self)
         self._len = self.session.get_length()
         self._bounds = None

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -710,11 +710,11 @@ class BytesCollection(Collection):
         self.virtual_file = buffer_to_virtual_file(self.bytesbuf, ext=ext)
 
         # Instantiate the parent class.
-        super(BytesCollection, self).__init__(self.virtual_file, vsi=filetype, **kwds)
+        super().__init__(self.virtual_file, vsi=filetype, **kwds)
 
     def close(self):
         """Removes the virtual file associated with the class."""
-        super(BytesCollection, self).close()
+        super().close()
         if self.virtual_file:
             remove_virtual_file(self.virtual_file)
             self.virtual_file = None

--- a/fiona/compat.py
+++ b/fiona/compat.py
@@ -1,11 +1,6 @@
 import collections
 import sys
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
 if sys.version_info[0] >= 3:
     from urllib.parse import urlparse
     from collections import UserDict

--- a/fiona/errors.py
+++ b/fiona/errors.py
@@ -25,11 +25,11 @@ class UnsupportedOperation(FionaError):
     """Raised when reading from a file opened in 'w' mode"""
 
 
-class DataIOError(IOError):
+class DataIOError(OSError):
     """IO errors involving driver registration or availability."""
 
 
-class DriverIOError(IOError):
+class DriverIOError(OSError):
     """A format specific driver error."""
 
 
@@ -37,7 +37,7 @@ class DriverSupportError(DriverIOError):
     """Driver does not support schema"""
 
 
-class DatasetDeleteError(IOError):
+class DatasetDeleteError(OSError):
     """Failure to delete a dataset"""
 
 

--- a/fiona/fio/bounds.py
+++ b/fiona/fio/bounds.py
@@ -65,7 +65,7 @@ def bounds(ctx, precision, explode, with_id, with_obj, use_rs):
                     else:
                         rec = (w, s, e, n)
                     if use_rs:
-                        click.echo(u'\u001e', nl=False)
+                        click.echo('\x1e', nl=False)
                     click.echo(json.dumps(rec))
                 else:
                     xs.extend([w, e])
@@ -80,7 +80,7 @@ def bounds(ctx, precision, explode, with_id, with_obj, use_rs):
                 else:
                     rec = (w, s, e, n)
                 if use_rs:
-                    click.echo(u'\u001e', nl=False)
+                    click.echo('\x1e', nl=False)
                 click.echo(json.dumps(rec))
 
     except Exception:

--- a/fiona/fio/calc.py
+++ b/fiona/fio/calc.py
@@ -56,7 +56,7 @@ def calc(ctx, property_name, expression, overwrite, use_rs):
                     feat, expression)
 
                 if use_rs:
-                    click.echo(u'\u001e', nl=False)
+                    click.echo('\x1e', nl=False)
                 click.echo(json.dumps(feat))
 
     except Exception:

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -102,7 +102,7 @@ def cat(
                             feat['geometry'] = g
                             feat['bbox'] = fiona.bounds(g)
                         if use_rs:
-                            click.echo(u'\u001e', nl=False)
+                            click.echo('\x1e', nl=False)
                         click.echo(json.dumps(feat, **dump_kwds))
 
     except Exception:

--- a/fiona/fio/collect.py
+++ b/fiona/fio/collect.py
@@ -60,16 +60,16 @@ def collect(ctx, precision, indent, compact, record_buffered, ignore_errors,
     # If parsing geojson
     if parse:
         # If input is RS-delimited JSON sequence.
-        if first_line.startswith(u'\x1e'):
+        if first_line.startswith('\x1e'):
             def feature_text_gen():
-                buffer = first_line.strip(u'\x1e')
+                buffer = first_line.strip('\x1e')
                 for line in stdin:
-                    if line.startswith(u'\x1e'):
+                    if line.startswith('\x1e'):
                         if buffer:
                             feat = json.loads(buffer)
                             feat['geometry'] = transformer(feat['geometry'])
                             yield json.dumps(feat, **dump_kwds)
-                        buffer = line.strip(u'\x1e')
+                        buffer = line.strip('\x1e')
                     else:
                         buffer += line
                 else:
@@ -90,14 +90,14 @@ def collect(ctx, precision, indent, compact, record_buffered, ignore_errors,
     # If *not* parsing geojson
     else:
         # If input is RS-delimited JSON sequence.
-        if first_line.startswith(u'\x1e'):
+        if first_line.startswith('\x1e'):
             def feature_text_gen():
-                buffer = first_line.strip(u'\x1e')
+                buffer = first_line.strip('\x1e')
                 for line in stdin:
-                    if line.startswith(u'\x1e'):
+                    if line.startswith('\x1e'):
                         if buffer:
                             yield buffer
-                        buffer = line.strip(u'\x1e')
+                        buffer = line.strip('\x1e')
                     else:
                         buffer += line
                 else:

--- a/fiona/fio/distrib.py
+++ b/fiona/fio/distrib.py
@@ -32,7 +32,7 @@ def distrib(ctx, use_rs):
                 feat_id = feat.get('id', 'feature:' + str(i))
                 feat['id'] = feat_id
                 if use_rs:
-                    click.echo(u'\u001e', nl=False)
+                    click.echo('\x1e', nl=False)
                 click.echo(json.dumps(feat))
     except Exception:
         logger.exception("Exception caught during processing")

--- a/fiona/fio/filter.py
+++ b/fiona/fio/filter.py
@@ -50,7 +50,7 @@ def filter(ctx, filter_expression, use_rs):
                     continue
 
                 if use_rs:
-                    click.echo(u'\u001e', nl=False)
+                    click.echo('\x1e', nl=False)
                 click.echo(json.dumps(feat))
 
     except Exception:

--- a/fiona/fio/helpers.py
+++ b/fiona/fio/helpers.py
@@ -15,14 +15,14 @@ warnings.simplefilter('default')
 def obj_gen(lines):
     """Return a generator of JSON objects loaded from ``lines``."""
     first_line = next(lines)
-    if first_line.startswith(u'\x1e'):
+    if first_line.startswith('\x1e'):
         def gen():
-            buffer = first_line.strip(u'\x1e')
+            buffer = first_line.strip('\x1e')
             for line in lines:
-                if line.startswith(u'\x1e'):
+                if line.startswith('\x1e'):
                     if buffer:
                         yield json.loads(buffer)
-                    buffer = line.strip(u'\x1e')
+                    buffer = line.strip('\x1e')
                 else:
                     buffer += line
             else:

--- a/fiona/io.py
+++ b/fiona/io.py
@@ -50,7 +50,7 @@ class MemoryFile(MemoryFileBase):
         parameters of `fiona.open()`.
         """
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
 
         if not self.exists():
             self._ensure_extension(driver)
@@ -113,7 +113,7 @@ class ZipMemoryFile(MemoryFile):
 
         """
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
         if path:
             vsi_path = '/vsizip{0}/{1}'.format(self.name, path.lstrip('/'))
         else:

--- a/fiona/io.py
+++ b/fiona/io.py
@@ -29,7 +29,7 @@ class MemoryFile(MemoryFileBase):
     def __init__(self, file_or_bytes=None, filename=None, ext=""):
         if ext and not ext.startswith("."):
             ext = "." + ext
-        super(MemoryFile, self).__init__(
+        super().__init__(
             file_or_bytes=file_or_bytes, filename=filename, ext=ext)
 
     def open(self, driver=None, schema=None, crs=None, encoding=None,
@@ -95,7 +95,7 @@ class ZipMemoryFile(MemoryFile):
     """
 
     def __init__(self, file_or_bytes=None):
-        super(ZipMemoryFile, self).__init__(file_or_bytes, ext=".zip")
+        super().__init__(file_or_bytes, ext=".zip")
 
     def open(self, path=None, driver=None, encoding=None, layer=None,
              enabled_drivers=None, **kwargs):

--- a/fiona/logutils.py
+++ b/fiona/logutils.py
@@ -9,8 +9,8 @@ class FieldSkipLogFilter(logging.Filter):
     At most, one message per field skipped per loop will be passed.
     """
 
-    def __init__(self, name=""):
-        super(FieldSkipLogFilter, self).__init__(name)
+    def __init__(self, name=''):
+        super().__init__(name)
         self.seen_msgs = set()
 
     def filter(self, record):

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1036,7 +1036,7 @@ cdef class WritingSession(Session):
                 GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
                 self.cogr_layer = NULL
-                raise DriverError(u"{}".format(exc))
+                raise DriverError(str(exc))
 
             else:
                 self._fileencoding = userencoding or self._get_fallback_encoding()
@@ -1106,7 +1106,7 @@ cdef class WritingSession(Session):
                 GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
                 self.cogr_layer = NULL
-                raise CRSError(u"{}".format(exc))
+                raise CRSError(str(exc))
 
             # Determine which encoding to use. The encoding parameter given to
             # the collection constructor takes highest precedence, then
@@ -1184,7 +1184,7 @@ cdef class WritingSession(Session):
             except Exception as exc:
                 GDALClose(self.cogr_ds)
                 self.cogr_ds = NULL
-                raise DriverIOError(u"{}".format(exc))
+                raise DriverIOError(str(exc))
 
             finally:
                 if options != NULL:
@@ -1270,7 +1270,7 @@ cdef class WritingSession(Session):
                     GDALClose(self.cogr_ds)
                     self.cogr_ds = NULL
                     self.cogr_layer = NULL
-                    raise SchemaError(u"{}".format(exc))
+                    raise SchemaError(str(exc))
 
                 else:
                     OGR_Fld_Destroy(cogr_fielddefn)

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -10,8 +10,8 @@ import logging
 import os
 import warnings
 import math
+from collections import namedtuple, OrderedDict
 from uuid import uuid4
-from collections import namedtuple
 
 from six import integer_types, string_types, text_type
 
@@ -32,7 +32,7 @@ from fiona.errors import (
     DriverError, DriverIOError, SchemaError, CRSError, FionaValueError,
     TransactionError, GeometryTypeValidationError, DatasetDeleteError,
     FeatureWarning, FionaDeprecationWarning)
-from fiona.compat import OrderedDict, strencode
+from fiona.compat import strencode
 from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import FionaDateType, FionaDateTimeType, FionaTimeType
 from fiona.schema import FIELD_TYPES, FIELD_TYPES_MAP, normalize_field_type

--- a/setup.py
+++ b/setup.py
@@ -280,9 +280,6 @@ requirements = [
     'munch',
     "setuptools",
 ]
-# Python 3.10 workaround as enum34 not available
-if sys.version_info >= (3, 10):
-    requirements.remove('enum34; python_version < "3.4"')
 
 extras_require = {
     'calc': ['shapely'],

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ from setuptools import setup
 from setuptools.extension import Extension
 
 
+# Ensure minimum version of Python is running
+if sys.version_info[0:2] < (3, 6):
+    raise RuntimeError('Fiona requires Python>=3.6')
+
 # Use Cython if available.
 try:
     from Cython.Build import cythonize
@@ -17,18 +21,7 @@ except ImportError:
 
 
 def check_output(cmd):
-    # since subprocess.check_output doesn't exist in 2.6
-    # we wrap it here.
-    try:
-        out = subprocess.check_output(cmd)
-        return out.decode('utf')
-    except AttributeError:
-        # For some reasone check_output doesn't exist
-        # So fall back on Popen
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-        return out
-
+    return subprocess.check_output(cmd).decode('utf')
 
 def copy_data_tree(datadir, destdir):
     try:
@@ -42,16 +35,11 @@ def copy_data_tree(datadir, destdir):
 with open('fiona/__init__.py', 'r') as f:
     for line in f:
         if line.find("__version__") >= 0:
-            version = line.split("=")[1].strip()
-            version = version.strip('"')
-            version = version.strip("'")
+            version = line.split("=")[1].strip().strip('"').strip("'")
             break
 
-# Fiona's auxiliary files are UTF-8 encoded and we'll specify this when
-# reading with Python 3+
-open_kwds = {}
-if sys.version_info > (3,):
-    open_kwds['encoding'] = 'utf-8'
+# Fiona's auxiliary files are UTF-8 encoded
+open_kwds = {'encoding': 'utf-8'}
 
 with open('VERSION.txt', 'w', **open_kwds) as f:
     f.write(version)
@@ -291,9 +279,6 @@ requirements = [
     'six>=1.7',
     'munch',
     "setuptools",
-    'argparse; python_version < "2.7"',
-    'ordereddict; python_version < "2.7"',
-    'enum34; python_version < "3.4"'
 ]
 # Python 3.10 workaround as enum34 not available
 if sys.version_info >= (3, 10):
@@ -313,7 +298,7 @@ setup_args = dict(
     metadata_version='1.2',
     name='Fiona',
     version=version,
-    requires_python='>=2.6',
+    python_requires='>=3.6',
     requires_external='GDAL (>=1.8)',
     description="Fiona reads and writes spatial data files",
     license='BSD',
@@ -354,7 +339,7 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ from setuptools import setup
 from setuptools.extension import Extension
 
 
-# Ensure minimum version of Python is running
-if sys.version_info[0:2] < (3, 6):
-    raise RuntimeError('Fiona requires Python>=3.6')
-
 # Use Cython if available.
 try:
     from Cython.Build import cythonize

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -29,7 +29,7 @@ def test_binary_field(tmpdir):
             "geometry": {"type": "Point", "coordinates": ((0, 0))},
             "properties": {
                 "name": "test",
-                u"data": input_data,
+                "data": input_data,
             }
         }
         dst.write(feature)

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -155,7 +155,7 @@ class TestReading(object):
         assert f['properties']['STATE'] == 'UT'
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -245,7 +245,7 @@ class TestReading(object):
         assert f['id'] == "2"
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):
@@ -403,11 +403,11 @@ class TestGenericWritingTest(object):
         assert self.c.encoding == 'Windows-1252'
 
     def test_no_iter(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             iter(self.c)
 
     def test_no_filter(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.filter()
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -381,7 +381,7 @@ class TestUnsupportedDriver(object):
     def test_immediate_fail_driver(self, tmpdir):
         schema = {
             'geometry': 'Point',
-            'properties': {'label': 'str', u'verit\xe9': 'int'}}
+            'properties': {'label': 'str', 'verit\xe9': 'int'}}
         with pytest.raises(DriverError):
             fiona.open(str(tmpdir.join("foo")), "w", "Bogus", schema=schema)
 
@@ -392,7 +392,7 @@ class TestGenericWritingTest(object):
     def no_iter_shp(self, tmpdir):
         schema = {
             'geometry': 'Point',
-            'properties': [('label', 'str'), (u'verit\xe9', 'int')]}
+            'properties': [('label', 'str'), ('verit\xe9', 'int')]}
         self.c = fiona.open(str(tmpdir.join("test-no-iter.shp")),
                             'w', driver="ESRI Shapefile", schema=schema,
                             encoding='Windows-1252')

--- a/tests/test_collection_legacy.py
+++ b/tests/test_collection_legacy.py
@@ -167,7 +167,7 @@ class ReadingTest(unittest.TestCase):
         assert f['id'] == "2"
 
     def test_no_write(self):
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             self.c.write({})
 
     def test_iter_items_list(self):

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -83,17 +83,6 @@ def test_from_epsg_neg():
         raise
 
 
-def test_to_string_unicode():
-    # See issue #83.
-    val = crs.to_string({
-        u'units': u'm',
-        u'no_defs': True,
-        u'datum': u'NAD83',
-        u'proj': u'utm',
-        u'zone': 16})
-    assert 'NAD83' in val
-
-
 @requires_gdal_lt_3
 def test_wktext():
     """Test +wktext parameter is preserved."""

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -32,7 +32,7 @@ def test_broken_encoding(gre_shp_cp1252):
     with fiona.open(str(gre_shp_cp1252)) as src:
         assert src.session._get_internal_encoding() == 'utf-8'
         feat = next(iter(src))
-        assert feat['properties']['name_ru'] != u'Гренада'
+        assert feat['properties']['name_ru'] != 'Гренада'
 
 
 @requires_gdal2
@@ -42,7 +42,7 @@ def test_cpg_encoding(gre_shp_cp1252):
     with fiona.open(str(gre_shp_cp1252)) as src:
         assert src.session._get_internal_encoding() == 'utf-8'
         feat = next(iter(src))
-        assert feat['properties']['name_ru'] == u'Гренада'
+        assert feat['properties']['name_ru'] == 'Гренада'
 
 
 @requires_gdal2
@@ -50,4 +50,4 @@ def test_override_encoding(gre_shp_cp1252):
     """utf-8 override succeeds"""
     with fiona.open(str(gre_shp_cp1252), encoding='utf-8') as src:
         assert src.session._get_internal_encoding() == 'utf-8'
-        assert next(iter(src))['properties']['name_ru'] == u'Гренада'
+        assert next(iter(src))['properties']['name_ru'] == 'Гренада'

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -28,7 +28,7 @@ class TestPointRoundTrip(object):
     def test_geometry(self):
         f = { 'id': '1',
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert (
             sorted(g['geometry'].items()) ==
@@ -37,7 +37,7 @@ class TestPointRoundTrip(object):
     def test_properties(self):
         f = { 'id': '1',
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert g['properties']['title'] == 'foo'
 
@@ -65,7 +65,7 @@ class TestLineStringRoundTrip(object):
         f = { 'id': '1',
               'geometry': { 'type': 'LineString',
                             'coordinates': [(0.0, 0.0), (1.0, 1.0)] },
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert (
             sorted(g['geometry'].items()) ==
@@ -75,7 +75,7 @@ class TestLineStringRoundTrip(object):
     def test_properties(self):
         f = { 'id': '1',
               'geometry': {'type': 'Point', 'coordinates': (0.0, 0.0)},
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert g['properties']['title'] == 'foo'
 
@@ -101,7 +101,7 @@ class TestPolygonRoundTrip(object):
                                   (1.0, 1.0),
                                   (1.0, 0.0),
                                   (0.0, 0.0)]] },
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert (
             sorted(g['geometry'].items()) ==
@@ -121,7 +121,7 @@ class TestPolygonRoundTrip(object):
                                   (1.0, 1.0),
                                   (1.0, 0.0),
                                   (0.0, 0.0)]] },
-              'properties': {'title': u'foo'} }
+              'properties': {'title': 'foo'} }
         g = featureRT(f, self.c)
         assert g['properties']['title'] == 'foo'
 

--- a/tests/test_fio_bounds.py
+++ b/tests/test_fio_bounds.py
@@ -76,6 +76,6 @@ def test_bounds_explode_with_obj(feature_collection, runner):
 def test_explode_output_rs(feature_collection, runner):
     result = runner.invoke(main_group, ['bounds', '--explode', '--rs'], feature_collection)
     assert result.exit_code == 0
-    assert result.output.count(u'\u001e') == 2
+    assert result.output.count('\x1e') == 2
     assert result.output.count('[') == result.output.count(']') == 2
     assert len(re.findall(r'\d*\.\d*', result.output)) == 8

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -69,7 +69,7 @@ def test_open_closed():
     memfile = MemoryFile()
     memfile.close()
     assert memfile.closed
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         memfile.open()
 
 
@@ -78,7 +78,7 @@ def test_open_closed_zip():
     memfile = ZipMemoryFile()
     memfile.close()
     assert memfile.closed
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         memfile.open()
 
 

--- a/tests/test_multiconxn.py
+++ b/tests/test_multiconxn.py
@@ -1,7 +1,7 @@
 import pytest
 
 import fiona
-from fiona.compat import OrderedDict
+from collections import OrderedDict
 
 
 class TestReadAccess(object):

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -58,10 +58,10 @@ def test_remove(tmpdir, kind, driver, specify_driver):
 
 
 def test_remove_nonexistent(tmpdir):
-    """Attempting to remove a file that does not exist results in an IOError"""
+    """Attempting to remove a file that does not exist results in an OSError"""
     filename = str(tmpdir.join("does_not_exist.shp"))
     assert not os.path.exists(filename)
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         fiona.remove(filename)
 
 @requires_gpkg
@@ -106,12 +106,12 @@ def test_remove_layer_geojson(tmpdir):
     """Removal of layers is not supported by GeoJSON driver
 
     The reason for failure is slightly different between GDAL 2.2+ and < 2.2.
-    With < 2.2 the datasource will fail to open in write mode (IOError), while
+    With < 2.2 the datasource will fail to open in write mode (OSError), while
     with 2.2+ the datasource will open but the removal operation will fail (not
     supported).
     """
     filename = str(tmpdir.join("a_filename.geojson"))
     create_sample_data(filename, "GeoJSON")
-    with pytest.raises((RuntimeError, IOError)):
+    with pytest.raises((RuntimeError, OSError)):
         fiona.remove(filename, layer=0)
     assert os.path.exists(filename)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -17,7 +17,7 @@ class TestUnicodePath(object):
 
     def setup(self):
         tempdir = tempfile.mkdtemp()
-        self.dir = os.path.join(tempdir, u'français')
+        self.dir = os.path.join(tempdir, 'français')
         shutil.copytree(os.path.join(os.path.dirname(__file__), 'data'),
                         self.dir)
 
@@ -75,18 +75,18 @@ class TestUnicodeStringField(object):
                 'type': 'Feature',
                 'geometry': {'type': 'Point', 'coordinates': [0, 0]},
                 'properties': {
-                    'label': u'徐汇区',
+                    'label': '徐汇区',
                     'num': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='latin1') as c:
             f = next(iter(c))
             # Next assert fails.
-            assert f['properties']['label'] == u'徐汇区'
+            assert f['properties']['label'] == '徐汇区'
 
     def test_write_utf8(self):
         schema = {
             'geometry': 'Point',
-            'properties': {'label': 'str', u'verit\xe9': 'int'}}
+            'properties': {'label': 'str', 'verit\xe9': 'int'}}
         with fiona.open(os.path.join(self.tempdir, "test-write.shp"),
                         "w", "ESRI Shapefile", schema=schema,
                         encoding='utf-8') as c:
@@ -94,12 +94,12 @@ class TestUnicodeStringField(object):
                 'type': 'Feature',
                 'geometry': {'type': 'Point', 'coordinates': [0, 0]},
                 'properties': {
-                    'label': u'Ba\u2019kelalan', u'verit\xe9': 0}}])
+                    'label': 'Ba\u2019kelalan', 'verit\xe9': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='utf-8') as c:
             f = next(iter(c))
-            assert f['properties']['label'] == u'Ba\u2019kelalan'
-            assert f['properties'][u'verit\xe9'] == 0
+            assert f['properties']['label'] == 'Ba\u2019kelalan'
+            assert f['properties']['verit\xe9'] == 0
 
     @pytest.mark.iconv
     def test_write_gb18030(self):
@@ -113,11 +113,11 @@ class TestUnicodeStringField(object):
             c.writerecords([{
                 'type': 'Feature',
                 'geometry': {'type': 'Point', 'coordinates': [0, 0]},
-                'properties': {'label': u'徐汇区', 'num': 0}}])
+                'properties': {'label': '徐汇区', 'num': 0}}])
 
         with fiona.open(os.path.join(self.tempdir), encoding='gb18030') as c:
             f = next(iter(c))
-            assert f['properties']['label'] == u'徐汇区'
+            assert f['properties']['label'] == '徐汇区'
             assert f['properties']['num'] == 0
 
     @pytest.mark.iconv
@@ -131,7 +131,7 @@ class TestUnicodeStringField(object):
 
         See GH#595.
         """
-        field_name = u"区县名称"
+        field_name = "区县名称"
         meta = {
             "schema": {
                 "properties": OrderedDict([(field_name, "int")]),


### PR DESCRIPTION
This PR increases the minimum Python version to 3.6 for the maint-1.9 branch, for the upcoming Fiona 1.9.x release series.

It is mainly based on a few cherry picks from:

- #770
- #984
- #1032
- #1020
- #1051

A few manual edits were required. It should have minimal conflicts with `master`. Compatibility with the Fiona 1.8.x series should be maintained.