### PR TITLE
CI: upgrade rstcheck (and Sphinx) to resolve issue with jinja2

### DIFF
--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -1,7 +1,17 @@
 name: rstcheck
 
-# Run this workflow every time a new commit pushed to your repository
-on: [push, pull_request]
+# Run this workflow for commits to doc files
+on:
+  push:
+    paths:
+      - ".github/workflows/rstcheck.yml"
+      - "README.rst"
+      - "docs/**"
+  pull_request:
+    paths:
+      - ".github/workflows/rstcheck.yml"
+      - "README.rst"
+      - "docs/**"
 
 jobs:
   rstcheck:
@@ -19,7 +29,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install jinja2==3.0.3 sphinx==3.2.1 rstcheck==3.3.1
+          python -m pip install rstcheck[sphinx]==4.1.0
 
       - name: Run rstcheck
         run: |


### PR DESCRIPTION
For reference, the CI error was:
```
Run rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .
  rstcheck -r --ignore-directives automodule --ignore-substitutions version,release,today .
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.1[2](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:2)/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/[3](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:3).8.12/x6[4](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:4)/lib
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/rstcheck", line 33, in <module>
    sys.exit(load_entry_point('rstcheck==3.3.1', 'console_scripts', 'rstcheck')())
  File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/rstcheck", line 2[5](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:5), in importlib_load_entry_point
    return next(matches).load()
  File "/opt/hostedtoolcache/Python/3.8.12/x[6](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:6)4/lib/python3.8/importlib/metadata.py", line [7](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:7)7, in load
    module = import_module(match.group('module'))
  File "/opt/hostedtoolcache/Python/3.[8](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:8).12/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line [9](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:9)91, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.8.[12](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:12)/x64/lib/python3.8/site-packages/rstcheck.py", line 66, in <module>
    import sphinx.application
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/application.py", line 42, in <module>
    from sphinx.registry import SphinxComponentRegistry
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/registry.py", line 24, in <module>
    from sphinx.builders import Builder
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 26, in <module>
    from sphinx.util import import_object, logging, rst, progress_message, status_iterator
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/sphinx/util/rst.py", line [22](https://github.com/Toblerity/Fiona/runs/6167026458?check_suite_focus=true#step:5:22), in <module>
    from jinja2 import environmentfilter
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/jinja2/__init__.py)
Error: Process completed with exit code 1.
```