### PR TITLE
BUG: force sdist to cythonize files, rather than keeping cythonized files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,11 +2,11 @@ global-exclude .DS_Store
 global-exclude *.pyc
 recursive-exclude docs/data *
 recursive-exclude docs/_build *
-exclude MANIFEST.in
 exclude *.txt *.py
 recursive-include docs *.rst *.txt
 recursive-include tests *.py
 recursive-include tests/data *
-include fiona/*.c fiona/*.cpp
-include CHANGES.txt CREDITS.txt LICENSE.txt VERSION.txt README.rst
-include benchmark.py setup.py requirements.txt
+recursive-include fiona *.pyx *.pxd *.pxi
+recursive-exclude fiona *.c *.cpp
+include CHANGES.txt CITATION.txt CREDITS.txt LICENSE.txt VERSION.txt README.rst
+include benchmark.py pyproject.toml setup.py requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,6 @@ with open('CREDITS.txt', **open_kwds) as f:
 with open('CHANGES.txt', **open_kwds) as f:
     changes = f.read()
 
-# Set a flag for builds where the source directory is a repo checkout.
-source_is_repo = os.path.exists("MANIFEST.in")
-
-
 # Extend distutil's sdist command to generate C extension sources from
 # the _shim extension modules for GDAL 1.x and 2.x.
 class sdist_multi_gdal(sdist):
@@ -199,7 +195,7 @@ if sys.platform != "win32":
 # Define the extension modules.
 ext_modules = []
 
-if source_is_repo and "clean" not in sys.argv:
+if "clean" not in sys.argv:
     # When building from a repo, Cython is required.
     log.info("MANIFEST.in found, presume a repo, cythonizing...")
     if not cythonize:


### PR DESCRIPTION
This should resolve #1087, where a future Python version is unable to build from a source distribution that include cythonized `*.c` and `*.cpp` files. The source distributions should only keep the source cython files, and a build should cythonize its own files.

Tested locally using `python -m build` with success. (Using Python 3.8 -- Python 3.110b1 not tested)

Other minor changes to MANIFEST.in:

- Include CITATION.txt, which was recently added
- Include pyproject.toml, which was necessary to build binary wheel
- Remove exclude MANIFEST.in, <s>as this is normally excluded</s> (update: this is [normally included](https://packaging.python.org/en/latest/guides/using-manifest-in/), so perhaps there's a good reason to leave it alone)