### PR TITLE
Unpin Cython version in pyproject.toml to support future builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cython==0.29.24",
+    "cython",
     "oldest-supported-numpy",
     "setuptools",
     "wheel",


### PR DESCRIPTION
Pinning the Cython version seems to break builds with future Python versions.

Leaving pinned `requirements-dev.txt` alone, as this typical from "pip freeze", and does not break sdist packages.

Closes #1087