### PR TITLE
Remove `setuptools` as a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,6 @@ requirements = [
     'cligj>=0.5',
     'click-plugins>=1.0',
     'munch',
-    "setuptools",
 ]
 
 extras_require = {


### PR DESCRIPTION
Depending on `setuptools` at runtime (`install_requires` is for
specifying runtime dependencies) creates problems for external packaging
tools such as [poetry2nix](https://github.com/nix-community/poetry2nix) due to
the need to use setuptools to bootstrap package installs in nix itself.

`setuptools` is already installed by the time this line of code runs,
and isn't imported anywhere in the codebase. There should be zero change
in behavior, while allowing external packaging tools like poetry2nix to
cleanly handle Fiona.
