### PR TITLE
requirements.txt: Allow munch versions >=2.3.2 to support Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ attrs>=19.2.0
 click~=8.0
 click-plugins
 cligj>=0.5.0
-munch==2.3.2
+munch>=2.3.2
 setuptools>=49.0
 certifi


### PR DESCRIPTION
Python 3.11 currently fails on building munch 2.3.2, while it can build newer versions of munch. By unfixing the munch version this helps Python 3.11 support

Part of #1087.