### PR TITLE
Remove debug logging from _env and env

### DIFF
--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install sphinx==3.2.1 rstcheck==3.3.1
+          python -m pip install jinja2<3.1 sphinx==3.2.1 rstcheck==3.3.1
 
       - name: Run rstcheck
         run: |

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install jinja2<3.1 sphinx==3.2.1 rstcheck==3.3.1
+          python -m pip install jinja2==3.0.3 sphinx==3.2.1 rstcheck==3.3.1
 
       - name: Run rstcheck
         run: |

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -458,16 +458,11 @@ cdef class GDALEnv(ConfigEnv):
                     # actually makes it this far.
                     self._have_registered_drivers = True
 
-        log.debug("Started GDALEnv: self=%r.", self)
-
     def stop(self):
         # NB: do not restore the CPL error handler to its default
         # state here. If you do, log messages will be written to stderr
         # by GDAL instead of being sent to Python's logging module.
-        log.debug("Stopping GDALEnv %r.", self)
         CPLPopErrorHandler()
-        log.debug("Error handler popped.")
-        log.debug("Stopped GDALEnv %r.", self)
 
     def drivers(self):
         cdef OGRSFDriverH driver = NULL


### PR DESCRIPTION
We're no longer doing intensive debugging of GDAL contexts, they're working, and this may expose private config options.