### PR TITLE
ogrext writerecords performance

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1349,13 +1349,6 @@ cdef class WritingSession(Session):
                         record['geometry']['type'],
                         collection.schema['geometry'] ))
 
-            # Validate against collection's schema to give useful message
-            if set(record['properties'].keys()) != schema_props_keys:
-                raise SchemaError(
-                    "Record does not match collection schema: %r != %r" % (
-                        record['properties'].keys(),
-                        list(schema_props_keys) ))
-
             cogr_feature = OGRFeatureBuilder().build(record, collection)
             result = OGR_L_CreateFeature(cogr_layer, cogr_feature)
 


### PR DESCRIPTION
This PR proposes three relatively simple opportunities to speed up writes by doing less work:

1.  ogrext - performance - cache OGR field indices  (can give 2x speedup when writing layers with 400 string columns)
2.  ogrext - performance - cache OGR normalized fields (can give another ~ 10% speedup)
3.  ogrext - writerecs - remove duplicated code (minor speedup)

I had some time to look at this after noticing writes seemed very slow for layers with large number of columns (ref: https://github.com/Toblerity/Fiona/issues/1158).

all timings collected:
- using cProfile
- writing a dataset via geopandas to_file


### benchmark - comparison on synthetic scenario with high column count

data:

-   25,000 records
-   random point geometries
-   400 string columns, each containing random length-16 strings


| library |  version                   |  function                             |  time to write layer (seconds) |
| ------- | -------------------------  | ------------------------------------- | ------------------------------ |
| Fiona   | master branch rev 9c8fe736 | fiona/collection.py:500(writerecords) |   39.719                       |
| Fiona   | proposed, rev bb5bd021     | fiona/collection.py:500(writerecords) |   15.208                       |

Please see https://github.com/Toblerity/Fiona/issues/1158 for the script used for this benchmark.

### benchmark - comparison on real data

data:

-  35,098 records (land parcels with attributes)
-  polygon geometries
-  subset of 15 of the full 400 columns in the data, (includes a mix of strings, missing values, flag columns, etc)


| library |  version                   |  function                             |  time to write layer (seconds) |
| ------- | -------------------------  | ------------------------------------- | ------------------------------ |
| Fiona   |  1.8.21                    | fiona/collection.py:355(writerecords) |  10.495                        |
| Fiona   |  1.9a3                     | fiona/collection.py:544(writerecords) |  11.497                        |
| Fiona   | master branch rev 9c8fe736 | fiona/collection.py:500(writerecords) |   7.473                        |
| Fiona   | proposed, rev bb5bd021     | fiona/collection.py:500(writerecords) |   7.092                        |
| pyogrio |  0.4.2                     | pyogrio/raw.py:163(write)             |   0.560                        |


