### PR TITLE
Invalid creation options are filtered and ignored

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9b2 (TBD)
 -----------
 
+- Invalid creation options are filtered and ignored (#).
 - The readme doc has been shortened and freshened up, with a modern example for
   version 1.9.0 (#1174).
 - The Geometry class now provides and looks for __geo_interface__ (#1174).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9b2 (TBD)
 -----------
 
-- Invalid creation options are filtered and ignored (#).
+- Invalid creation options are filtered and ignored (#1180).
 - The readme doc has been shortened and freshened up, with a modern example for
   version 1.9.0 (#1174).
 - The Geometry class now provides and looks for __geo_interface__ (#1174).

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -1180,6 +1180,9 @@ cdef class WritingSession(Session):
             geometry_code = geometry_type_code(geometry_type)
 
             try:
+                # In GDAL versions > 3.6.0 the following directive may
+                # suffice and we might be able to eliminate the import
+                # of fiona.meta in a future version of Fiona.
                 with Env(GDAL_VALIDATE_CREATION_OPTIONS="NO"):
                     self.cogr_layer = exc_wrap_pointer(
                         GDALDatasetCreateLayer(

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,11 +1,12 @@
 # Testing collections and workspaces
 
+from collections import OrderedDict
 import datetime
+import logging
 import os
 import random
-import sys
 import re
-from collections import OrderedDict
+import sys
 
 import pytest
 
@@ -1047,14 +1048,16 @@ def test_collection_zip_http():
 
 def test_encoding_option_warning(tmpdir, caplog):
     """There is no ENCODING creation option log warning for GeoJSON"""
-    fiona.Collection(
-        str(tmpdir.join("test.geojson")),
-        "w",
-        driver="GeoJSON",
-        crs="epsg:4326",
-        schema={"geometry": "Point", "properties": {"foo": "int"}},
-    )
-    assert not caplog.text
+    with caplog.at_level(logging.WARNING):
+        fiona.Collection(
+            str(tmpdir.join("test.geojson")),
+            "w",
+            driver="GeoJSON",
+            crs="EPSG:4326",
+            schema={"geometry": "Point", "properties": {"foo": "int"}},
+            encoding="bogus",
+        )
+        assert not caplog.text
 
 
 def test_closed_session_next(gdalenv, path_coutwildrnp_shp):


### PR DESCRIPTION
Resolves #504 in a more general way than previously, taking care of all invalid creation options, not only `ENCODING`.