### PR TITLE
Run pyupgrade --py37-plus

### DIFF
--- a/benchmark-max.py
+++ b/benchmark-max.py
@@ -1,4 +1,3 @@
-
 import timeit
 from fiona import collection
 from osgeo import ogr

--- a/benchmark-min.py
+++ b/benchmark-min.py
@@ -1,4 +1,3 @@
-
 import timeit
 from fiona import collection
 from osgeo import ogr

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,4 +1,3 @@
-
 import timeit
 from fiona import collection
 from osgeo import ogr

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Fiona documentation build configuration file, created by
 # sphinx-quickstart on Mon Dec 26 12:16:26 2011.

--- a/examples/open.py
+++ b/examples/open.py
@@ -1,4 +1,3 @@
-
 import fiona
 
 # This module contains examples of opening files to get feature collections in

--- a/examples/orient-ccw.py
+++ b/examples/orient-ccw.py
@@ -60,6 +60,6 @@ with fiona.open('docs/data/test_uk.shp', 'r') as source:
 
                 sink.write(f)
             
-            except Exception, e:
+            except Exception as e:
                 logging.exception("Error processing feature %s:", f['id'])
 

--- a/examples/with-descartes.py
+++ b/examples/with-descartes.py
@@ -1,4 +1,3 @@
-
 import subprocess
 
 from matplotlib import pyplot

--- a/examples/with-pyproj.py
+++ b/examples/with-pyproj.py
@@ -33,7 +33,7 @@ with fiona.open('docs/data/test_uk.shp', 'r') as source:
                 f['geometry']['coordinates'] = new_coords
                 sink.write(f)
             
-            except Exception, e:
+            except Exception as e:
                 # Writing uncleanable features to a different shapefile
                 # is another option.
                 logging.exception("Error transforming feature %s:", f['id'])

--- a/examples/with-pyproj.py
+++ b/examples/with-pyproj.py
@@ -1,4 +1,3 @@
-
 import logging
 import sys
 

--- a/examples/with-shapely.py
+++ b/examples/with-shapely.py
@@ -27,7 +27,7 @@ with fiona.open('docs/data/test_uk.shp', 'r') as source:
                 f['geometry'] = mapping(geom)
                 sink.write(f)
             
-            except Exception, e:
+            except Exception as e:
                 # Writing uncleanable features to a different shapefile
                 # is another option.
                 logging.exception("Error cleaning feature %s:", f['id'])

--- a/examples/with-shapely.py
+++ b/examples/with-shapely.py
@@ -1,4 +1,3 @@
-
 import logging
 import sys
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Fiona is OGR's neat, nimble API.
 

--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Collections provide file-like access to feature data."""
 
 from contextlib import ExitStack
@@ -41,7 +39,7 @@ _GDAL_RELEASE_NAME = get_gdal_release_name()
 log = logging.getLogger(__name__)
 
 
-class Collection(object):
+class Collection:
 
     """A file-like interface to features of a vector dataset
 
@@ -252,7 +250,7 @@ class Collection(object):
         self._closed = False
 
     def __repr__(self):
-        return "<%s Collection '%s', mode '%s' at %s>" % (
+        return "<{} Collection '{}', mode '{}' at {}>".format(
             self.closed and "closed" or "open",
             self.path + ":" + str(self.name),
             self.mode,
@@ -695,13 +693,11 @@ class Collection(object):
             self.close()
 
 
-ALL_GEOMETRY_TYPES = set(
-    [
+ALL_GEOMETRY_TYPES = {
         geom_type
         for geom_type in GEOMETRY_TYPES.values()
         if "3D " not in geom_type and geom_type != "None"
-    ]
-)
+}
 ALL_GEOMETRY_TYPES.add("None")
 
 
@@ -784,7 +780,7 @@ class BytesCollection(Collection):
             self.bytesbuf = None
 
     def __repr__(self):
-        return "<%s BytesCollection '%s', mode '%s' at %s>" % (
+        return "<{} BytesCollection '{}', mode '{}' at {}>".format(
             self.closed and "closed" or "open",
             self.path + ":" + str(self.name),
             self.mode,

--- a/fiona/drvsupport.py
+++ b/fiona/drvsupport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from fiona.env import Env

--- a/fiona/env.py
+++ b/fiona/env.py
@@ -61,7 +61,7 @@ local = ThreadEnv()
 log = logging.getLogger(__name__)
 
 
-class Env(object):
+class Env:
     """Abstraction for GDAL and AWS configuration
 
     The GDAL library is stateful: it has a registry of format drivers,
@@ -354,7 +354,7 @@ def delenv():
     local._env = None
 
 
-class NullContextManager(object):
+class NullContextManager:
     def __init__(self):
         pass
 
@@ -461,7 +461,7 @@ def ensure_env_with_credentials(f):
 
 @attr.s(slots=True)
 @total_ordering
-class GDALVersion(object):
+class GDALVersion:
     """Convenience class for obtaining GDAL major and minor version
     components and comparing between versions.  This is highly
     simplistic and assumes a very normal numbering scheme for versions
@@ -479,10 +479,10 @@ class GDALVersion(object):
         return (self.major, self.minor) < tuple(other.major, other.minor)
 
     def __repr__(self):
-        return "GDALVersion(major={0}, minor={1})".format(self.major, self.minor)
+        return f"GDALVersion(major={self.major}, minor={self.minor})"
 
     def __str__(self):
-        return "{0}.{1}".format(self.major, self.minor)
+        return f"{self.major}.{self.minor}"
 
     @classmethod
     def parse(cls, input):
@@ -591,7 +591,7 @@ def require_gdal_version(
     version = GDALVersion.parse(version)
     runtime = GDALVersion.runtime()
     inequality = ">=" if runtime < version else "<="
-    reason = "\n{0}".format(reason) if reason else reason
+    reason = f"\n{reason}" if reason else reason
 
     def decorator(f):
         @wraps(f)
@@ -602,7 +602,7 @@ def require_gdal_version(
 
                 if param is None:
                     raise GDALVersionError(
-                        "GDAL version must be {0} {1}{2}".format(
+                        "GDAL version must be {} {}{}".format(
                             inequality, str(version), reason
                         )
                     )
@@ -627,16 +627,16 @@ def require_gdal_version(
                             full_kwds[param] != defaults[param]
                         ):
                             raise GDALVersionError(
-                                'usage of parameter "{0}" requires '
-                                "GDAL {1} {2}{3}".format(
+                                'usage of parameter "{}" requires '
+                                "GDAL {} {}{}".format(
                                     param, inequality, version, reason
                                 )
                             )
 
                     elif full_kwds[param] in values:
                         raise GDALVersionError(
-                            'parameter "{0}={1}" requires '
-                            "GDAL {2} {3}{4}".format(
+                            'parameter "{}={}" requires '
+                            "GDAL {} {}{}".format(
                                 param, full_kwds[param], inequality, version, reason
                             )
                         )

--- a/fiona/fio/calc.py
+++ b/fiona/fio/calc.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import json
 
 import click
@@ -50,7 +49,7 @@ def calc(ctx, property_name, expression, overwrite, use_rs):
 
             if not overwrite and property_name in feat["properties"]:
                 raise click.UsageError(
-                    "{0} already exists in properties; "
+                    "{} already exists in properties; "
                     "rename or use --overwrite".format(property_name)
                 )
 

--- a/fiona/fio/collect.py
+++ b/fiona/fio/collect.py
@@ -147,8 +147,7 @@ def collect(
 
             def feature_text_gen():
                 yield first_line
-                for line in stdin:
-                    yield line
+                yield from stdin
 
     source = feature_text_gen()
 

--- a/fiona/fio/env.py
+++ b/fiona/fio/env.py
@@ -28,7 +28,7 @@ def env(ctx, key):
         if key == 'formats':
             for k, v in sorted(fiona.supported_drivers.items()):
                 modes = ', '.join("'" + m + "'" for m in v)
-                stdout.write("%s (modes %s)\n" % (k, modes))
+                stdout.write(f"{k} (modes {modes})\n")
             stdout.write('\n')
         elif key == 'credentials':
             click.echo(json.dumps(env.session.credentials))

--- a/fiona/fio/load.py
+++ b/fiona/fio/load.py
@@ -33,7 +33,7 @@ def _cb_key_val(ctx, param, value):
         for pair in value:
             if "=" not in pair:
                 raise click.BadParameter(
-                    "Invalid syntax for KEY=VAL arg: {}".format(pair)
+                    f"Invalid syntax for KEY=VAL arg: {pair}"
                 )
             else:
                 k, v = pair.split("=", 1)
@@ -115,12 +115,10 @@ def load(ctx, output, driver, src_crs, dst_crs, features, layer, creation_option
 
     # print(first, first.geometry)
     schema = {"geometry": first.geometry.type}
-    schema["properties"] = dict(
-        [
-            (k, FIELD_TYPES_MAP_REV.get(type(v)) or "str")
+    schema["properties"] = {
+            k: FIELD_TYPES_MAP_REV.get(type(v)) or "str"
             for k, v in first.properties.items()
-        ]
-    )
+    }
 
     with fiona.open(
         output,

--- a/fiona/fio/options.py
+++ b/fiona/fio/options.py
@@ -41,4 +41,4 @@ def validate_multilayer_file_index(files, layerdict):
     for key in layerdict.keys():
         if key not in [str(k) for k in range(1, len(files) + 1)]:
             layer = key + ":" + layerdict[key][0]
-            raise click.BadParameter("Layer {} does not exist".format(layer))
+            raise click.BadParameter(f"Layer {layer} does not exist")

--- a/fiona/fio/rm.py
+++ b/fiona/fio/rm.py
@@ -21,10 +21,10 @@ def rm(ctx, input, layer, yes):
         kind = "layer"
 
     if not yes:
-        click.confirm("The {} will be removed. Are you sure?".format(kind), abort=True)
+        click.confirm(f"The {kind} will be removed. Are you sure?", abort=True)
 
     try:
         fiona.remove(input, layer=layer)
     except Exception:
-        logger.exception("Failed to remove {}.".format(kind))
+        logger.exception(f"Failed to remove {kind}.")
         raise click.Abort()

--- a/fiona/io.py
+++ b/fiona/io.py
@@ -69,9 +69,9 @@ class MemoryFile(MemoryFileBase):
             raise DriverError("Driver {} does not support virtual files.")
 
         if mode in ('r', 'a') and not self.exists():
-            raise IOError("MemoryFile does not exist.")
+            raise OSError("MemoryFile does not exist.")
         if layer is None and mode == 'w' and self.exists():
-            raise IOError("MemoryFile already exists.")
+            raise OSError("MemoryFile already exists.")
 
         if not self.exists() or mode == 'w':
             if driver is not None:
@@ -111,9 +111,9 @@ class MemoryFile(MemoryFileBase):
         if self.closed:
             raise OSError("I/O operation on closed file.")
         if path:
-            vsi_path = "{0}/{1}".format(self.name, path.lstrip("/"))
+            vsi_path = "{}/{}".format(self.name, path.lstrip("/"))
         else:
-            vsi_path = "{0}".format(self.name)
+            vsi_path = f"{self.name}"
         return _listdir(vsi_path)
 
     def listlayers(self, path=None):
@@ -133,9 +133,9 @@ class MemoryFile(MemoryFileBase):
         if self.closed:
             raise OSError("I/O operation on closed file.")
         if path:
-            vsi_path = "{0}/{1}".format(self.name, path.lstrip("/"))
+            vsi_path = "{}/{}".format(self.name, path.lstrip("/"))
         else:
-            vsi_path = "{0}".format(self.name)
+            vsi_path = f"{self.name}"
         return _listlayers(vsi_path)
 
     def __enter__(self):
@@ -154,7 +154,7 @@ class ZipMemoryFile(MemoryFile):
 
     def __init__(self, file_or_bytes=None):
         super().__init__(file_or_bytes, ext=".zip")
-        self.name = "/vsizip{}".format(self.name)
+        self.name = f"/vsizip{self.name}"
 
     def open(
         self,
@@ -182,9 +182,9 @@ class ZipMemoryFile(MemoryFile):
         if self.closed:
             raise OSError("I/O operation on closed file.")
         if path:
-            vsi_path = "{0}/{1}".format(self.name, path.lstrip("/"))
+            vsi_path = "{}/{}".format(self.name, path.lstrip("/"))
         else:
-            vsi_path = "{0}".format(self.name)
+            vsi_path = f"{self.name}"
 
         return Collection(
             vsi_path,

--- a/fiona/logutils.py
+++ b/fiona/logutils.py
@@ -24,7 +24,7 @@ class FieldSkipLogFilter(logging.Filter):
             return 1
 
 
-class LogFiltering(object):
+class LogFiltering:
     def __init__(self, logger, filter):
         self.logger = logger
         self.filter = filter

--- a/fiona/meta.py
+++ b/fiona/meta.py
@@ -145,12 +145,12 @@ def print_driver_options(driver):
                                  ("Dataset Creation Options", dataset_creation_options(driver)),
                                  ("Layer Creation Options", layer_creation_options(driver))]:
 
-        print("{option_type}:".format(option_type=option_type))
+        print(f"{option_type}:")
         if len(options) == 0:
             print("\tNo options available.")
         else:
             for option_name in options:
-                print("\t{option_name}:".format(option_name=option_name))
+                print(f"\t{option_name}:")
                 if 'description' in options[option_name]:
                     print("\t\tDescription: {description}".format(description=options[option_name]['description']))
                 if 'type' in options[option_name]:

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -168,7 +168,7 @@ class Object(MutableMapping):
         return dict(**self) == dict(**other)
 
 
-class _Geometry(object):
+class _Geometry:
     def __init__(self, coordinates=None, type=None, geometries=None):
         self.coordinates = coordinates
         self.type = type
@@ -191,7 +191,7 @@ class Geometry(Object):
         self._delegate = _Geometry(
             coordinates=coordinates, type=type, geometries=geometries
         )
-        super(Geometry, self).__init__(**data)
+        super().__init__(**data)
 
     @classmethod
     def from_dict(cls, ob=None, **kwargs):
@@ -244,7 +244,7 @@ class Geometry(Object):
         return ObjectEncoder().default(self)
 
 
-class _Feature(object):
+class _Feature:
     def __init__(self, geometry=None, id=None, properties=None):
         self.geometry = geometry
         self.id = id
@@ -267,7 +267,7 @@ class Feature(Object):
         if properties is None:
             properties = Properties()
         self._delegate = _Feature(geometry=geometry, id=id, properties=properties)
-        super(Feature, self).__init__(**data)
+        super().__init__(**data)
 
     @classmethod
     def from_dict(cls, ob=None, **kwargs):
@@ -349,7 +349,7 @@ class Properties(Object):
     """A GeoJSON-like feature's properties"""
 
     def __init__(self, **kwds):
-        super(Properties, self).__init__(**kwds)
+        super().__init__(**kwds)
 
     @classmethod
     def from_dict(cls, mapping=None, **kwargs):

--- a/fiona/path.py
+++ b/fiona/path.py
@@ -23,15 +23,15 @@ SCHEMES = {
     "az": "az",
 }
 
-CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
+CURLSCHEMES = {k for k, v in SCHEMES.items() if v == 'curl'}
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set(
-    [k for k, v in SCHEMES.items() if v in ("curl", "s3", "gs", "oss", "az")]
-)
+REMOTESCHEMES = {
+    k for k, v in SCHEMES.items() if v in ("curl", "s3", "gs", "oss", "az")
+}
 
 
-class Path(object):
+class Path:
     """Base class for dataset paths"""
 
 
@@ -76,9 +76,9 @@ class ParsedPath(Path):
         if not self.scheme:
             return self.path
         elif self.archive:
-            return "{}://{}!{}".format(self.scheme, self.archive, self.path)
+            return f"{self.scheme}://{self.archive}!{self.path}"
         else:
-            return "{}://{}".format(self.scheme, self.path)
+            return f"{self.scheme}://{self.path}"
 
     @property
     def is_remote(self):
@@ -177,13 +177,13 @@ def vsi_path(path):
             else:
                 suffix = ''
 
-            prefix = '/'.join('vsi{0}'.format(SCHEMES[p]) for p in path.scheme.split('+') if p != 'file')
+            prefix = '/'.join(f'vsi{SCHEMES[p]}' for p in path.scheme.split('+') if p != 'file')
 
             if prefix:
                 if path.archive:
                     result = '/{}/{}{}/{}'.format(prefix, suffix, path.archive, path.path.lstrip('/'))
                 else:
-                    result = '/{}/{}{}'.format(prefix, suffix, path.path)
+                    result = f'/{prefix}/{suffix}{path.path}'
             else:
                 result = path.path
             return result

--- a/fiona/rfc3339.py
+++ b/fiona/rfc3339.py
@@ -32,7 +32,7 @@ pattern_datetime = re.compile(
     r"(\d\d\d\d)(-)?(\d\d)(-)?(\d\d)(T)?(\d\d)(:)?(\d\d)(:)?(\d\d)?(\.\d+)?(Z|([+-])?(\d\d)?(:)?(\d\d))?")
 
 
-class group_accessor(object):
+class group_accessor:
     def __init__(self, m):
         self.match = m
 

--- a/fiona/session.py
+++ b/fiona/session.py
@@ -14,7 +14,7 @@ except ImportError:
     boto3 = None
 
 
-class Session(object):
+class Session:
     """Base for classes that configure access to secured resources.
 
     Attributes

--- a/fiona/vfs.py
+++ b/fiona/vfs.py
@@ -18,10 +18,10 @@ SCHEMES = {
     'gs': 'gs',
 }
 
-CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
+CURLSCHEMES = {k for k, v in SCHEMES.items() if v == 'curl'}
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'gs')])
+REMOTESCHEMES = {k for k, v in SCHEMES.items() if v in ('curl', 's3', 'gs')}
 
 
 def valid_vsi(vsi):
@@ -39,11 +39,11 @@ def vsi_path(path, vsi=None, archive=None):
     # If a VSI and archive file are specified, we convert the path to
     # an OGR VSI path (see cpl_vsi.h).
     if vsi:
-        prefix = '/'.join('vsi{0}'.format(SCHEMES[p]) for p in vsi.split('+'))
+        prefix = '/'.join(f'vsi{SCHEMES[p]}' for p in vsi.split('+'))
         if archive:
-            result = '/{0}/{1}{2}'.format(prefix, archive, path)
+            result = f'/{prefix}/{archive}{path}'
         else:
-            result = '/{0}/{1}'.format(prefix, path)
+            result = f'/{prefix}/{path}'
     else:
         result = path
 

--- a/scripts/check_deprecated.py
+++ b/scripts/check_deprecated.py
@@ -43,15 +43,15 @@ for path in files:
     if os.path.basename(path) in ignored_files:
         continue
 
-    with open(path, 'r') as f:
+    with open(path) as f:
         for i, line in enumerate(f):
             for deprecated_method in deprecated:
-                match = re.search('{}\s*\('.format(deprecated_method), line)
+                match = re.search(fr'{deprecated_method}\s*\(', line)
                 if match:
                     found_lines[path].append((i+1, line.strip(), deprecated_method))
 
 for path in sorted(found_lines):
     print(path)
     for line_nr, line, method in found_lines[path]:
-        print("\t{}\t{}".format(line_nr, line))
+        print(f"\t{line_nr}\t{line}")
     print("")

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -7,11 +7,11 @@ def test_urls(files):
     headers = {'User-Agent': 'Mozilla/5.0 (compatible; MSIE 6.0; Fiona CI check)'}
 
     for fpath in files:
-        print("Processing: {}".format(fpath))
+        print(f"Processing: {fpath}")
         with open(fpath) as f:
 
             text = f.read()
-            urls = re.findall('(https?:\/\/[^\s`>\'"()]+)', text)
+            urls = re.findall('(https?:\\/\\/[^\\s`>\'"()]+)', text)
 
             for url in urls:
                 http_code = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,13 +40,13 @@ def pytest_report_header(config):
     # gdal version number
     gdal_release_name = fiona.get_gdal_release_name()
     headers.append(
-        "GDAL: {} ({})".format(gdal_release_name, fiona.get_gdal_version_num())
+        f"GDAL: {gdal_release_name} ({fiona.get_gdal_version_num()})"
     )
     supported_drivers = ", ".join(
         sorted(list(fiona.drvsupport.supported_drivers.keys()))
     )
     # supported drivers
-    headers.append("Supported drivers: {}".format(supported_drivers))
+    headers.append(f"Supported drivers: {supported_drivers}")
     return "\n".join(headers)
 
 
@@ -57,8 +57,8 @@ def get_temp_filename(driver):
     if exts is None or len(exts) == 0:
         ext = ""
     else:
-        ext = ".{}".format(exts[0])
-    return "{basename}{extension}".format(basename=basename, extension=ext)
+        ext = f".{exts[0]}"
+    return f"{basename}{ext}"
 
 
 _COUTWILDRNP_FILES = [

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -1,10 +1,8 @@
 """Tests of _env util module"""
 
+from unittest import mock
+
 import pytest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 from fiona._env import GDALDataFinder, PROJDataFinder
 
@@ -72,7 +70,7 @@ def test_search_debian_gdal_data_failure(tmpdir):
 def test_search_debian_gdal_data(mock_debian):
     """Find GDAL data under Debian locations"""
     finder = GDALDataFinder()
-    assert finder.search_debian(str(mock_debian)) == str(mock_debian.join("share").join("gdal").join("{}.{}".format(gdal_version.major, gdal_version.minor)))
+    assert finder.search_debian(str(mock_debian)) == str(mock_debian.join("share").join("gdal").join(f"{gdal_version.major}.{gdal_version.minor}"))
 
 
 def test_search_gdal_data_wheel(mock_wheel):
@@ -88,7 +86,7 @@ def test_search_gdal_data_fhs(mock_fhs):
 def test_search_gdal_data_debian(mock_debian):
     """Find GDAL data under Debian locations"""
     finder = GDALDataFinder()
-    assert finder.search(str(mock_debian)) == str(mock_debian.join("share").join("gdal").join("{}.{}".format(gdal_version.major, gdal_version.minor)))
+    assert finder.search(str(mock_debian)) == str(mock_debian.join("share").join("gdal").join(f"{gdal_version.major}.{gdal_version.minor}"))
 
 
 def test_search_wheel_proj_data_failure(tmpdir):

--- a/tests/test_bytescollection.py
+++ b/tests/test_bytescollection.py
@@ -7,7 +7,7 @@ import fiona
 from fiona.model import Geometry
 
 
-class TestReading(object):
+class TestReading:
     @pytest.fixture(autouse=True)
     def bytes_collection_object(self, path_coutwildrnp_json):
         with open(path_coutwildrnp_json) as src:
@@ -171,7 +171,7 @@ class TestReading(object):
         assert 0 in self.c
 
 
-class TestFilterReading(object):
+class TestFilterReading:
     @pytest.fixture(autouse=True)
     def bytes_collection_object(self, path_coutwildrnp_json):
         with open(path_coutwildrnp_json) as src:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -25,7 +25,7 @@ from fiona.model import Feature, Geometry
 from .conftest import WGS84PATTERN, get_temp_filename
 
 
-class TestSupportedDrivers(object):
+class TestSupportedDrivers:
     def test_shapefile(self):
         assert "ESRI Shapefile" in supported_drivers
         assert set(supported_drivers["ESRI Shapefile"]) == set("raw")
@@ -35,7 +35,7 @@ class TestSupportedDrivers(object):
         assert set(supported_drivers["MapInfo File"]) == set("raw")
 
 
-class TestCollectionArgs(object):
+class TestCollectionArgs:
     def test_path(self):
         with pytest.raises(TypeError):
             Collection(0)
@@ -85,13 +85,13 @@ class TestCollectionArgs(object):
             Collection("foo", mode="w", driver="ARCGEN")
 
 
-class TestOpenException(object):
+class TestOpenException:
     def test_no_archive(self):
         with pytest.warns(FionaDeprecationWarning), pytest.raises(DriverError):
             fiona.open("/", mode="r", vfs="zip:///foo.zip")
 
 
-class TestReading(object):
+class TestReading:
     @pytest.fixture(autouse=True)
     def shapefile(self, path_coutwildrnp_shp):
         self.c = fiona.open(path_coutwildrnp_shp, "r")
@@ -263,7 +263,7 @@ class TestReading(object):
         assert 0 in self.c
 
 
-class TestReadingPathTest(object):
+class TestReadingPathTest:
     def test_open_path(self, path_coutwildrnp_shp):
         pathlib = pytest.importorskip("pathlib")
         with fiona.open(pathlib.Path(path_coutwildrnp_shp)) as collection:
@@ -271,7 +271,7 @@ class TestReadingPathTest(object):
 
 
 @pytest.mark.usefixtures("unittest_path_coutwildrnp_shp")
-class TestIgnoreFieldsAndGeometry(object):
+class TestIgnoreFieldsAndGeometry:
     def test_without_ignore(self):
         with fiona.open(self.path_coutwildrnp_shp, "r") as collection:
             assert "AREA" in collection.schema["properties"].keys()
@@ -361,7 +361,7 @@ class TestIgnoreFieldsAndGeometry(object):
             assert feature.geometry is None
 
 
-class TestFilterReading(object):
+class TestFilterReading:
     @pytest.fixture(autouse=True)
     def shapefile(self, path_coutwildrnp_shp):
         self.c = fiona.open(path_coutwildrnp_shp, "r")
@@ -407,7 +407,7 @@ class TestFilterReading(object):
         results = set(
             self.c.keys(bbox=(-120.0, 40.0, -100.0, 50.0), where="NAME LIKE 'Mount%'")
         )
-        assert results == set([0, 2, 5, 13])
+        assert results == {0, 2, 5, 13}
         results = set(self.c.keys())
         assert len(results) == 67
 
@@ -417,7 +417,7 @@ class TestFilterReading(object):
                 self.c.filter(where=w)
 
 
-class TestUnsupportedDriver(object):
+class TestUnsupportedDriver:
     def test_immediate_fail_driver(self, tmpdir):
         schema = {
             "geometry": "Point",
@@ -428,7 +428,7 @@ class TestUnsupportedDriver(object):
 
 
 @pytest.mark.iconv
-class TestGenericWritingTest(object):
+class TestGenericWritingTest:
     @pytest.fixture(autouse=True)
     def no_iter_shp(self, tmpdir):
         schema = {
@@ -457,7 +457,7 @@ class TestGenericWritingTest(object):
             self.c.filter()
 
 
-class TestPropertiesNumberFormatting(object):
+class TestPropertiesNumberFormatting:
     @pytest.fixture(autouse=True)
     def shapefile(self, tmpdir):
         self.filename = str(tmpdir.join("properties_number_formatting_test"))
@@ -676,7 +676,7 @@ class TestPropertiesNumberFormatting(object):
             assert 0 == rf1.properties["property1"]
 
 
-class TestPointWriting(object):
+class TestPointWriting:
     @pytest.fixture(autouse=True)
     def shapefile(self, tmpdir):
         self.filename = str(tmpdir.join("point_writing_test.shp"))
@@ -759,7 +759,7 @@ class TestPointWriting(object):
         assert not self.sink.validate_record(finvalid)
 
 
-class TestLineWriting(object):
+class TestLineWriting:
     @pytest.fixture(autouse=True)
     def shapefile(self, tmpdir):
         self.sink = fiona.open(
@@ -820,7 +820,7 @@ class TestLineWriting(object):
         assert self.sink.bounds == (0.0, -0.2, 0.0, 0.2)
 
 
-class TestPointAppend(object):
+class TestPointAppend:
     @pytest.fixture(autouse=True)
     def shapefile(self, tmpdir, path_coutwildrnp_shp):
         with fiona.open(path_coutwildrnp_shp, "r") as input:
@@ -868,7 +868,7 @@ class TestPointAppend(object):
             assert len(c) == 68
 
 
-class TestLineAppend(object):
+class TestLineAppend:
     @pytest.fixture(autouse=True)
     def shapefile(self, tmpdir):
         with fiona.open(
@@ -944,7 +944,7 @@ def test_shapefile_field_width(tmpdir):
     c.close()
 
 
-class TestCollection(object):
+class TestCollection:
     def test_invalid_mode(self, tmpdir):
         with pytest.raises(ValueError):
             fiona.open(str(tmpdir.join("bogus.shp")), "r+")
@@ -1184,7 +1184,7 @@ def test_collection__empty_column_name(tmpdir):
 )
 def test_driver_detection(tmpdir, extension, driver):
     with fiona.open(
-        str(tmpdir.join("test.{}".format(extension))),
+        str(tmpdir.join(f"test.{extension}")),
         "w",
         schema={
             "geometry": "MultiLineString",

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -58,7 +58,7 @@ def test_invalid_crs(invalid_input):
 
 
 def test_custom_crs():
-    class CustomCRS(object):
+    class CustomCRS:
         def to_wkt(self):
             return (
                 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",'

--- a/tests/test_cursor_interruptions.py
+++ b/tests/test_cursor_interruptions.py
@@ -19,7 +19,7 @@ def test_write_getextent(tmpdir, driver, testdata_generator):
         driver, range(0, 10), range(10, 20)
     )
     path = str(tmpdir.join(get_temp_filename(driver)))
-    positions = set([int(r['properties']['position']) for r in records1 + records2])
+    positions = {int(r['properties']['position']) for r in records1 + records2}
 
     with fiona.open(
         path,
@@ -39,7 +39,7 @@ def test_write_getextent(tmpdir, driver, testdata_generator):
         c.writerecords(records2)
 
     with fiona.open(path) as c:
-        data = set([int(f['properties']['position']) for f in c])
+        data = {int(f['properties']['position']) for f in c}
         assert len(positions) == len(data)
         for p in positions:
             assert p in data
@@ -59,7 +59,7 @@ def test_read_getextent(tmpdir, driver, testdata_generator):
         driver, range(0, 10), range(10, 20)
     )
     path = str(tmpdir.join(get_temp_filename(driver)))
-    positions = set([int(r['properties']['position']) for r in records1 + records2])
+    positions = {int(r['properties']['position']) for r in records1 + records2}
 
     with fiona.open(
         path,
@@ -105,7 +105,7 @@ def test_write_getfeaturecount(tmpdir, driver, testdata_generator):
         driver, range(0, 10), range(10, 20)
     )
     path = str(tmpdir.join(get_temp_filename(driver)))
-    positions = set([int(r['properties']['position']) for r in records1 + records2])
+    positions = {int(r['properties']['position']) for r in records1 + records2}
 
     with fiona.open(
         path,
@@ -124,7 +124,7 @@ def test_write_getfeaturecount(tmpdir, driver, testdata_generator):
         c.writerecords(records2)
 
     with fiona.open(path) as c:
-        data = set([int(f['properties']['position']) for f in c])
+        data = {int(f['properties']['position']) for f in c}
         assert len(positions) == len(data)
         for p in positions:
             assert p in data
@@ -144,7 +144,7 @@ def test_read_getfeaturecount(tmpdir, driver, testdata_generator):
         driver, range(0, 10), range(10, 20)
     )
     path = str(tmpdir.join(get_temp_filename(driver)))
-    positions = set([int(r['properties']['position']) for r in records1 + records2])
+    positions = {int(r['properties']['position']) for r in records1 + records2}
 
     with fiona.open(
         path,

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -468,7 +468,7 @@ def test_datefield(tmpdir, driver, field_type):
         for val, val_exp in zip(items, values_exp):
             assert _validate(
                 val, val_exp, field_type, driver
-            ), "{} does not match {}".format(val, val_exp.isoformat())
+            ), f"{val} does not match {val_exp.isoformat()}"
 
 
 @pytest.mark.parametrize("driver, field_type", test_cases_datefield_to_str)
@@ -548,7 +548,7 @@ def test_datefield_driver_converts_to_string(tmpdir, driver, field_type):
                         sign=sign, hours=int(hours), minutes=int(minutes)
                     )
                 else:
-                    tz = "{sign}{hours:02d}".format(sign=sign, hours=int(hours))
+                    tz = f"{sign}{int(hours):02d}"
                 print("tz", tz)
                 # No Milliseconds
                 if not _driver_supports_milliseconds(driver):
@@ -636,7 +636,7 @@ def test_datefield_driver_converts_to_string(tmpdir, driver, field_type):
                         sign=sign, hours=int(hours), minutes=int(minutes)
                     )
                 else:
-                    tz = "{sign}{hours:02d}".format(sign=sign, hours=int(hours))
+                    tz = f"{sign}{int(hours):02d}"
                 # No Milliseconds
                 if not _driver_supports_milliseconds(driver):
                     if (
@@ -685,7 +685,7 @@ def test_datefield_driver_converts_to_string(tmpdir, driver, field_type):
         for val, val_exp in zip(items, values_exp):
             assert _validate(
                 val, val_exp, field_type, driver
-            ), "{} does not match {}".format(val, val_exp.isoformat())
+            ), f"{val} does not match {val_exp.isoformat()}"
 
 
 @pytest.mark.filterwarnings("ignore:.*driver silently converts *:UserWarning")
@@ -725,7 +725,7 @@ def test_datefield_null(tmpdir, driver, field_type):
 
         assert _validate(
             items[0], None, field_type, driver
-        ), "{} does not match {}".format(items[0], None)
+        ), f"{items[0]} does not match {None}"
 
 
 @pytest.mark.parametrize("driver, field_type", test_cases_datefield_not_supported)

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -23,7 +23,7 @@ def test_options(tmpdir, path_coutwildrnp_shp):
         with fiona.drivers(CPL_DEBUG=True):
             c = fiona.open(path_coutwildrnp_shp)
             c.close()
-            with open(logfile, "r") as f:
+            with open(logfile) as f:
                 log = f.read()
             if fiona.gdal_version.major >= 2:
                 assert "GDALOpen" in log

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Encoding tests"""
 
 from glob import glob

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,11 +2,7 @@
 
 import os
 import sys
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import boto3
 import pytest

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -14,7 +14,7 @@ from fiona.model import Feature
 from fiona.ogrext import featureRT
 
 
-class TestPointRoundTrip(object):
+class TestPointRoundTrip:
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {"geometry": "Point", "properties": {"title": "str"}}
@@ -62,7 +62,7 @@ class TestPointRoundTrip(object):
         assert g.properties["title"] is None
 
 
-class TestLineStringRoundTrip(object):
+class TestLineStringRoundTrip:
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {"geometry": "LineString", "properties": {"title": "str"}}
@@ -101,7 +101,7 @@ class TestLineStringRoundTrip(object):
         assert g.properties["title"] == "foo"
 
 
-class TestPolygonRoundTrip(object):
+class TestPolygonRoundTrip:
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
         schema = {"geometry": "Polygon", "properties": {"title": "str"}}

--- a/tests/test_fio_calc.py
+++ b/tests/test_fio_calc.py
@@ -1,7 +1,6 @@
 """Tests for `$ fio calc`."""
 
 
-from __future__ import division
 import json
 
 from click.testing import CliRunner

--- a/tests/test_fio_cat.py
+++ b/tests/test_fio_cat.py
@@ -127,7 +127,7 @@ def test_multi_layer_fail(data_dir):
 def test_vfs(path_coutwildrnp_zip):
     runner = CliRunner()
     result = runner.invoke(main_group, [
-        'cat', 'zip://{}'.format(path_coutwildrnp_zip)])
+        'cat', f'zip://{path_coutwildrnp_zip}'])
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 67
 

--- a/tests/test_fio_dump.py
+++ b/tests/test_fio_dump.py
@@ -25,7 +25,7 @@ def test_dump_layer(path_gpx):
 
 
 def test_dump_layer_vfs(path_coutwildrnp_zip):
-    path = "zip://{}".format(path_coutwildrnp_zip)
+    path = f"zip://{path_coutwildrnp_zip}"
     result = CliRunner().invoke(main_group, ["dump", path])
     assert result.exit_code == 0
     loaded = json.loads(result.output)

--- a/tests/test_fio_info.py
+++ b/tests/test_fio_info.py
@@ -80,7 +80,7 @@ def test_info_layer(path_gpx):
 def test_info_vfs(path_coutwildrnp_zip, path_coutwildrnp_shp):
     runner = CliRunner()
     zip_result = runner.invoke(main_group, [
-        'info', 'zip://{}'.format(path_coutwildrnp_zip)])
+        'info', f'zip://{path_coutwildrnp_zip}'])
     shp_result = runner.invoke(main_group, [
         'info', path_coutwildrnp_shp])
     assert zip_result.exit_code == shp_result.exit_code == 0

--- a/tests/test_fio_load.py
+++ b/tests/test_fio_load.py
@@ -143,7 +143,7 @@ def test_creation_options(tmpdir, runner, feature_seq):
     ("SHP", "ESRI Shapefile"),
 ])
 def test_load__auto_detect_format(tmpdir, runner, feature_seq, extension, driver):
-    tmpfile = str(tmpdir.mkdir('tests').join('test_src_vs_dst_crs.{}'.format(extension)))
+    tmpfile = str(tmpdir.mkdir('tests').join(f'test_src_vs_dst_crs.{extension}'))
     result = runner.invoke(main_group, [
         'load',
         '--src-crs',

--- a/tests/test_fio_ls.py
+++ b/tests/test_fio_ls.py
@@ -53,7 +53,7 @@ def test_fio_ls_multi_layer(path_coutwildrnp_shp, tmpdir):
 def test_fio_ls_vfs(path_coutwildrnp_zip):
     runner = CliRunner()
     result = runner.invoke(main_group, [
-        'ls', 'zip://{}'.format(path_coutwildrnp_zip)])
+        'ls', f'zip://{path_coutwildrnp_zip}'])
     assert result.exit_code == 0
     loaded = json.loads(result.output)
     assert len(loaded) == 1

--- a/tests/test_fio_rm.py
+++ b/tests/test_fio_rm.py
@@ -32,7 +32,7 @@ drivers = ["ESRI Shapefile", "GeoJSON"]
 @pytest.mark.parametrize("driver", drivers)
 def test_remove(tmpdir, driver):
     extension = {"ESRI Shapefile": "shp", "GeoJSON": "json"}[driver]
-    filename = "delete_me.{extension}".format(extension=extension)
+    filename = f"delete_me.{extension}"
     filename = str(tmpdir.join(filename))
     create_sample_data(filename, driver)
 

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -32,11 +32,11 @@ def test_directory_trailing_slash(data_dir):
 
 def test_zip_path(path_coutwildrnp_zip):
     assert fiona.listlayers(
-        'zip://{}'.format(path_coutwildrnp_zip)) == ['coutwildrnp']
+        f'zip://{path_coutwildrnp_zip}') == ['coutwildrnp']
 
 
 def test_zip_path_arch(path_coutwildrnp_zip):
-    vfs = 'zip://{}'.format(path_coutwildrnp_zip)
+    vfs = f'zip://{path_coutwildrnp_zip}'
     with pytest.warns(FionaDeprecationWarning):
         assert fiona.listlayers('/coutwildrnp.shp', vfs=vfs) == ['coutwildrnp']
 
@@ -77,7 +77,7 @@ def test_listing_pathobj(path_coutwildrnp_json):
 
 def test_listdir_path(path_coutwildrnp_zip):
     """List directories in a path"""
-    assert fiona.listdir('zip://{}'.format(path_coutwildrnp_zip)) == ['coutwildrnp.shp', 'coutwildrnp.shx', 'coutwildrnp.dbf', 'coutwildrnp.prj']
+    assert fiona.listdir(f'zip://{path_coutwildrnp_zip}') == ['coutwildrnp.shp', 'coutwildrnp.shx', 'coutwildrnp.dbf', 'coutwildrnp.prj']
 
 
 def test_listdir_path_not_existing(data_dir):
@@ -96,13 +96,13 @@ def test_listdir_invalid_path():
 def test_listdir_file(path_coutwildrnp_zip):
     """ Test list directories of a file"""
     with pytest.raises(FionaValueError):
-        fiona.listdir('zip://{}/coutwildrnp.shp'.format(path_coutwildrnp_zip))
+        fiona.listdir(f'zip://{path_coutwildrnp_zip}/coutwildrnp.shp')
 
 
 def test_listdir_file(path_coutwildrnp_zip):
     """Test list directories of a file"""
     with pytest.raises(FionaValueError):
-        fiona.listdir("zip://{}/coutwildrnp.shp".format(path_coutwildrnp_zip))
+        fiona.listdir(f"zip://{path_coutwildrnp_zip}/coutwildrnp.shp")
 
 
 def test_listdir_zipmemoryfile(bytes_coutwildrnp_zip):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -63,7 +63,7 @@ def test_object_delitem_warning():
 def test_object_setitem_delegated():
     """Delegation in __setitem__ works"""
 
-    class ThingDelegate(object):
+    class ThingDelegate:
         def __init__(self, value):
             self.value = value
 
@@ -72,7 +72,7 @@ def test_object_setitem_delegated():
 
         def __init__(self, value=None, **data):
             self._delegate = ThingDelegate(value)
-            super(Thing, self).__init__(**data)
+            super().__init__(**data)
 
     thing = Thing()
     assert thing["value"] is None
@@ -84,7 +84,7 @@ def test_object_setitem_delegated():
 def test_object_delitem_delegated():
     """Delegation in __delitem__ works"""
 
-    class ThingDelegate(object):
+    class ThingDelegate:
         def __init__(self, value):
             self.value = value
 
@@ -93,7 +93,7 @@ def test_object_delitem_delegated():
 
         def __init__(self, value=None, **data):
             self._delegate = ThingDelegate(value)
-            super(Thing, self).__init__(**data)
+            super().__init__(**data)
 
     thing = Thing(1)
     assert thing["value"] == 1

--- a/tests/test_multiconxn.py
+++ b/tests/test_multiconxn.py
@@ -6,7 +6,7 @@ import fiona
 from fiona.model import Feature, Geometry, Properties
 
 
-class TestReadAccess(object):
+class TestReadAccess:
     # To check that we'll be able to get multiple 'r' connections to layers
     # in a single file.
 
@@ -76,7 +76,7 @@ class TestReadWriteAccess:
         c2.close()
 
 
-class TestLayerCreation(object):
+class TestLayerCreation:
     @pytest.fixture(autouse=True)
     def layer_creation_shp(self, tmpdir):
         self.dir = tmpdir.mkdir("layer_creation")

--- a/tests/test_non_counting_layer.py
+++ b/tests/test_non_counting_layer.py
@@ -5,7 +5,7 @@ from fiona.errors import FionaDeprecationWarning
 
 
 @pytest.mark.usefixtures('uttc_path_gpx')
-class TestNonCountingLayer(object):
+class TestNonCountingLayer:
     def setup(self):
         self.c = fiona.open(self.path_gpx, "r", layer="track_points")
 

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -39,7 +39,7 @@ test_data = itertools.product(drivers, kinds, specify_drivers)
 def test_remove(tmpdir, kind, driver, specify_driver):
     """Test various dataset removal operations"""
     extension = {"ESRI Shapefile": "shp", "GeoJSON": "json"}[driver]
-    filename = "delete_me.{extension}".format(extension=extension)
+    filename = f"delete_me.{extension}"
     output_filename = str(tmpdir.join(filename))
 
     create_sample_data(output_filename, driver=driver)

--- a/tests/test_rfc3339.py
+++ b/tests/test_rfc3339.py
@@ -9,7 +9,7 @@ from fiona.rfc3339 import parse_date, parse_datetime, parse_time
 from fiona.rfc3339 import group_accessor, pattern_date
 
 
-class TestDateParse(object):
+class TestDateParse:
 
     def test_yyyymmdd(self):
         assert parse_date("2012-01-29") == (2012, 1, 29, 0, 0, 0, 0.0, None)
@@ -19,7 +19,7 @@ class TestDateParse(object):
             parse_date("xxx")
 
 
-class TestTimeParse(object):
+class TestTimeParse:
 
     def test_hhmmss(self):
         assert parse_time("10:11:12") == (0, 0, 0, 10, 11, 12, 0.0, None)
@@ -44,7 +44,7 @@ class TestTimeParse(object):
             parse_time("xxx")
 
 
-class TestDatetimeParse(object):
+class TestDatetimeParse:
 
     def test_yyyymmdd(self):
         assert (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -179,18 +179,18 @@ def test_unsupported_geometry_type():
 
 @pytest.mark.parametrize("x", list(range(1, 10)))
 def test_normalize_int32(x):
-    assert normalize_field_type("int:{}".format(x)) == "int32"
+    assert normalize_field_type(f"int:{x}") == "int32"
 
 
 @requires_gdal2
 @pytest.mark.parametrize("x", list(range(10, 20)))
 def test_normalize_int64(x):
-    assert normalize_field_type("int:{}".format(x)) == "int64"
+    assert normalize_field_type(f"int:{x}") == "int64"
 
 
 @pytest.mark.parametrize("x", list(range(0, 20)))
 def test_normalize_str(x):
-    assert normalize_field_type("str:{}".format(x)) == "str"
+    assert normalize_field_type(f"str:{x}") == "str"
 
 
 def test_normalize_bool():

--- a/tests/test_subtypes.py
+++ b/tests/test_subtypes.py
@@ -45,7 +45,7 @@ def test_write_bool_subtype(tmpdir):
     with fiona.open(str(path), "w", driver="GeoJSON", schema=schema) as dst:
         dst.write(feature)
 
-    with open(str(path), "r") as f:
+    with open(str(path)) as f:
         data = f.read()
 
     if fiona.gdal_version.major >= 2:

--- a/tests/test_topojson.py
+++ b/tests/test_topojson.py
@@ -18,7 +18,7 @@ has_driver = driver in fiona.drvsupport.supported_drivers.keys()
 
 
 @pytest.mark.skipif(not gdal_version.at_least((1, 11)), reason="Requires GDAL >= 1.11")
-@pytest.mark.skipif(not has_driver, reason="Requires {} driver".format(driver))
+@pytest.mark.skipif(not has_driver, reason=f"Requires {driver} driver")
 def test_read_topojson(data_dir):
     """Test reading a TopoJSON file
 

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import logging
 import os
 import shutil
@@ -14,7 +12,7 @@ from fiona.errors import SchemaError
 from fiona.model import Feature
 
 
-class TestUnicodePath(object):
+class TestUnicodePath:
     def setup(self):
         tempdir = tempfile.mkdtemp()
         self.dir = os.path.join(tempdir, "français")
@@ -41,7 +39,7 @@ class TestUnicodePath(object):
                 assert len(c) == 67
 
 
-class TestUnicodeStringField(object):
+class TestUnicodeStringField:
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
 

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -88,13 +88,13 @@ class TestZipReading(TestVsiReading):
         )
 
     def test_path(self):
-        assert self.c.path == "/vsizip/{path}".format(path=self.path)
+        assert self.c.path == f"/vsizip/{self.path}"
 
 
 class TestZipArchiveReading(TestVsiReading):
     @pytest.fixture(autouse=True)
     def zipfile(self, data_dir, path_coutwildrnp_zip):
-        vfs = "zip://{}".format(path_coutwildrnp_zip)
+        vfs = f"zip://{path_coutwildrnp_zip}"
         self.c = fiona.open(vfs + "!coutwildrnp.shp", "r")
         self.path = os.path.join(data_dir, "coutwildrnp.zip")
         yield
@@ -114,13 +114,13 @@ class TestZipArchiveReading(TestVsiReading):
         )
 
     def test_path(self):
-        assert self.c.path == "/vsizip/{path}/coutwildrnp.shp".format(path=self.path)
+        assert self.c.path == f"/vsizip/{self.path}/coutwildrnp.shp"
 
 
 class TestZipArchiveReadingAbsPath(TestZipArchiveReading):
     @pytest.fixture(autouse=True)
     def zipfile(self, path_coutwildrnp_zip):
-        vfs = "zip://{}".format(os.path.abspath(path_coutwildrnp_zip))
+        vfs = f"zip://{os.path.abspath(path_coutwildrnp_zip)}"
         self.c = fiona.open(vfs + "!coutwildrnp.shp", "r")
         yield
         self.c.close()
@@ -139,7 +139,7 @@ class TestZipArchiveReadingAbsPath(TestZipArchiveReading):
 @pytest.mark.usefixtures("uttc_path_coutwildrnp_tar", "uttc_data_dir")
 class TarArchiveReadingTest(VsiReadingTest):
     def setUp(self):
-        vfs = "tar://{}".format(self.path_coutwildrnp_tar)
+        vfs = f"tar://{self.path_coutwildrnp_tar}"
         self.c = fiona.open(vfs + "!testing/coutwildrnp.shp", "r")
         self.path = os.path.join(self.data_dir, "coutwildrnp.tar")
 


### PR DESCRIPTION
This is a 99% automated edit using [pyupgrade](https://github.com/asottile/pyupgrade):

    pyupgrade --py37-plus `find . -name "*.py"`

Despite the large number of changes, I don't expect any surprises here as the logic is the same. Most automated edits are removing stale code required for Python 2, or upgrading formatters to use f-strings or old % formatters to more modern styles. The code is guaranteed to run with a minimum Python 3.7 version.