### PR TITLE
Setuptools is required at run-time, not just build-time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "click-plugins>=1.0",
     "cligj>=0.5",
     "munch>=2.3.2",
+    "setuptools",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Previously, we relied on the fact that setuptools must be installed at build-time to ensure that it was also available at run-time. However, unless setuptools is explicitly listed as a run-time dependency, there's no guarantee that it won't be uninstalled. Package managers like [Spack](https://spack.io) only add run-time dependencies to `PYTHONPATH`, so this distinction becomes even more important.

I'm not sure what versions of setuptools are required, but let me know if you want me to add an upper/lower bound.