### PR TITLE
Update CITATION.cff for 1.9.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "Please cite this software using these metadata."
 type: software
 title: Fiona
-version: "1.9b2"
-date-released: "2023-01-22"
+version: "1.9.0"
+date-released: "2023-01-30"
 abstract: "OGR's neat, nimble, no-nonsense API."
 keywords:
   - cartography


### PR DESCRIPTION
This one missed the boat for the 1.9.0 release. @sgillies could you update your how-to-release notes to update CITATION.cff?

This isn't really a big deal, it would only matter for Zenodo (which directly uses this metadata for releases). It's fine to have in the maintenance branch, and I'll cherry-pick this to the now active master branch.