### PR TITLE
TST: don't rely on exact order in listdir tests

### DIFF
--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -84,7 +84,9 @@ def test_listing_pathobj(path_coutwildrnp_json):
 
 def test_listdir_path(path_coutwildrnp_zip):
     """List directories in a path"""
-    assert fiona.listdir('zip://{}'.format(path_coutwildrnp_zip)) == ['coutwildrnp.shp', 'coutwildrnp.shx', 'coutwildrnp.dbf', 'coutwildrnp.prj']
+    assert sorted(fiona.listdir('zip://{}'.format(path_coutwildrnp_zip))) == [
+        'coutwildrnp.dbf', 'coutwildrnp.prj', 'coutwildrnp.shp', 'coutwildrnp.shx'
+    ]
 
 
 def test_listdir_path_not_existing(data_dir):
@@ -116,9 +118,9 @@ def test_listdir_zipmemoryfile(bytes_coutwildrnp_zip):
     """Test list directories of a zipped memory file."""
     with ZipMemoryFile(bytes_coutwildrnp_zip) as memfile:
         print(memfile.name)
-        assert fiona.listdir(memfile.name) == [
-            "coutwildrnp.shp",
-            "coutwildrnp.shx",
+        assert sorted(fiona.listdir(memfile.name)) == [
             "coutwildrnp.dbf",
             "coutwildrnp.prj",
+            "coutwildrnp.shp",
+            "coutwildrnp.shx",
         ]


### PR DESCRIPTION
On the conda-forge recipe, those tests were failing because it gave a different order (https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=650034&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=b2a8456a-fb11-5506-ca32-5ccd32538dc0&l=3626). 
I don't know if that's platform or GDAL-version dependent, but it seems OK to not rely on the exact order in the tests. 

Let me know if the PR needs to be targeted against master or maint-1.9