### PR TITLE
Fix badge link in Readme for maint-1.9 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Fiona
 =====
 
-.. image:: https://github.com/Toblerity/Fiona/workflows/Linux%20CI/badge.svg?branch=master
-   :target: https://github.com/Toblerity/Fiona/actions?query=branch%3Amaster
+.. image:: https://github.com/Toblerity/Fiona/workflows/Tests/badge.svg?branch=maint-1.9
+   :target: https://github.com/Toblerity/Fiona/actions?query=branch%3Amaint-1.9
 
 Fiona streams simple feature data to and from GIS formats like GeoPackage and
 Shapefile.


### PR DESCRIPTION
Fix the badge links for the new tests and point to the maint-1.9 branch tests. 

@sgillies 
The Readme mentions `and GDAL 3.2 or higher.` but we don't test these old GDAL versions anymore in the CI. Should we update the Readme?