### PR TITLE
Change schema properties from OrderedDict back to dict built-in

### DIFF
--- a/fiona/collection.py
+++ b/fiona/collection.py
@@ -4,7 +4,6 @@ from contextlib import ExitStack
 import logging
 import os
 import warnings
-from collections import OrderedDict
 
 from fiona import compat, vfs
 from fiona.ogrext import Iterator, ItemsIterator, KeysIterator
@@ -199,12 +198,12 @@ class Collection:
             if not schema:
                 raise SchemaError("no schema")
             if "properties" in schema:
-                # Make an ordered dict of schema properties.
+                # Make properties as a dict built-in
                 this_schema = schema.copy()
-                this_schema["properties"] = OrderedDict(schema["properties"])
+                this_schema["properties"] = dict(schema["properties"])
                 schema = this_schema
             else:
-                schema["properties"] = OrderedDict()
+                schema["properties"] = {}
             if "geometry" not in schema:
                 schema["geometry"] = None
             self._schema = schema

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -1,7 +1,6 @@
 """Fiona data model"""
 
 import itertools
-from collections import OrderedDict
 from collections.abc import MutableMapping
 from enum import Enum
 from json import JSONEncoder
@@ -120,7 +119,7 @@ class Object(MutableMapping):
     _delegated_properties = []
 
     def __init__(self, **kwds):
-        self._data = OrderedDict(**kwds)
+        self._data = dict(**kwds)
 
     def _props(self):
         return {

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -10,7 +10,7 @@ import logging
 import os
 import warnings
 import math
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 from typing import List
 from uuid import uuid4
 
@@ -269,7 +269,7 @@ cdef class FeatureBuilder:
 
         # Skeleton of the feature to be returned.
         fid = OGR_F_GetFID(feature)
-        props = OrderedDict()
+        props = {}
 
         ignore_fields = set(ignore_fields or [])
 
@@ -1260,7 +1260,7 @@ cdef class WritingSession(Session):
             log.debug("Created layer %s", collection.name)
 
             # Next, make a layer definition from the given schema properties,
-            # which are an ordered dict since Fiona 1.0.1.
+            # which are a dict built-in since Fiona 2.0
 
             encoding = self._get_internal_encoding()
 
@@ -1274,8 +1274,8 @@ cdef class WritingSession(Session):
                         f"for driver '{self.collection.driver}'"
                     )
 
-            new_fields = OrderedDict([(key, value) for key, value in schema_fields.items()
-                                      if key not in default_fields])
+            new_fields = {key: value for key, value in schema_fields.items()
+                          if key not in default_fields}
             before_fields = default_fields.copy()
             before_fields.update(new_fields)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import os.path
 import shutil
 import tarfile
 import zipfile
-from collections import OrderedDict
 from click.testing import CliRunner
 import pytest
 
@@ -369,35 +368,33 @@ def testdata_generator():
 
     def get_schema(driver):
         special_schemas = {
-            "CSV": {"geometry": None, "properties": OrderedDict([("position", "int")])},
+            "CSV": {"geometry": None, "properties": {"position": "int"}},
             "BNA": {"geometry": "Point", "properties": {}},
             "DXF": {
-                "properties": OrderedDict(
-                    [
-                        ("Layer", "str"),
-                        ("SubClasses", "str"),
-                        ("Linetype", "str"),
-                        ("EntityHandle", "str"),
-                        ("Text", "str"),
-                    ]
-                ),
+                "properties": {
+                    "Layer": "str",
+                    "SubClasses": "str",
+                    "Linetype": "str",
+                    "EntityHandle": "str",
+                    "Text": "str",
+                },
                 "geometry": "Point",
             },
             "GPX": {
                 "geometry": "Point",
-                "properties": OrderedDict([("ele", "float"), ("time", "datetime")]),
+                "properties": {"ele": "float", "time": "datetime"},
             },
-            "GPSTrackMaker": {"properties": OrderedDict([]), "geometry": "Point"},
-            "DGN": {"properties": OrderedDict([]), "geometry": "LineString"},
+            "GPSTrackMaker": {"properties": {}, "geometry": "Point"},
+            "DGN": {"properties": {}, "geometry": "LineString"},
             "MapInfo File": {
                 "geometry": "Point",
-                "properties": OrderedDict([("position", "str")]),
+                "properties": {"position": "str"},
             },
         }
 
         return special_schemas.get(
             driver,
-            {"geometry": "Point", "properties": OrderedDict([("position", "int")])},
+            {"geometry": "Point", "properties": {"position": "int"}},
         )
 
     def get_crs(driver):
@@ -423,15 +420,13 @@ def testdata_generator():
                 Feature.from_dict(
                     **{
                         "geometry": {"type": "Point", "coordinates": (0.0, float(i))},
-                        "properties": OrderedDict(
-                            [
-                                ("Layer", "0"),
-                                ("SubClasses", "AcDbEntity:AcDbPoint"),
-                                ("Linetype", None),
-                                ("EntityHandle", str(i + 20000)),
-                                ("Text", None),
-                            ]
-                        ),
+                        "properties": {
+                            "Layer": "0",
+                            "SubClasses": "AcDbEntity:AcDbPoint",
+                            "Linetype": None,
+                            "EntityHandle": str(i + 20000),
+                            "Text": None,
+                        },
                     }
                 )
                 for i in range
@@ -510,7 +505,8 @@ def testdata_generator():
                             "type": "LineString",
                             "coordinates": [(float(i), 0.0), (0.0, 0.0)],
                         },
-                        "properties": OrderedDict(
+                        # TODO py39: use PEP 584 to union two dict objs
+                        "properties": dict(
                             [
                                 ("Type", 4),
                                 ("Level", 0),

--- a/tests/test_binary_field.py
+++ b/tests/test_binary_field.py
@@ -1,8 +1,6 @@
 """Binary BLOB field testing."""
 
-import pytest
 import struct
-from collections import OrderedDict
 
 import fiona
 from fiona.model import Feature
@@ -16,12 +14,7 @@ def test_binary_field(tmpdir):
         "driver": "GPKG",
         "schema": {
             "geometry": "Point",
-            "properties": OrderedDict(
-                [
-                    ("name", "str"),
-                    ("data", "bytes"),
-                ]
-            ),
+            "properties": {"name": "str", "data": "bytes"},
         },
     }
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,6 +1,5 @@
 # Testing collections and workspaces
 
-from collections import OrderedDict
 import datetime
 import logging
 import random
@@ -1101,7 +1100,7 @@ def test_mask_polygon_triangle(tmpdir, driver, filename):
     """Test if mask works for non trivial geometries"""
     schema = {
         "geometry": "Polygon",
-        "properties": OrderedDict([("position_i", "int"), ("position_j", "int")]),
+        "properties": {"position_i": "int", "position_j": "int"},
     }
     records = [
         Feature.from_dict(

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -2,7 +2,6 @@
 See also test_rfc3339.py for datetime parser tests.
 """
 
-from collections import OrderedDict
 import fiona
 from fiona._env import get_gdal_version_num, calc_gdal_version_num
 import pytest
@@ -31,19 +30,17 @@ gdal_version = GDALVersion.runtime()
 def get_schema(driver, field_type):
     if driver == "GPX":
         return {
-            "properties": OrderedDict([("ele", "float"), ("time", field_type)]),
+            "properties": {"ele": "float", "time": field_type},
             "geometry": "Point",
         }
     if driver == "GPSTrackMaker":
         return {
-            "properties": OrderedDict(
-                [
-                    ("name", "str"),
-                    ("comment", "str"),
-                    ("icon", "int"),
-                    ("time", field_type),
-                ]
-            ),
+            "properties": {
+                "name": "str",
+                "comment": "str",
+                "icon": "int",
+                "time": field_type,
+            },
             "geometry": "Point",
         }
     if driver == "CSV":
@@ -67,9 +64,7 @@ def get_records(driver, values):
             Feature.from_dict(
                 **{
                     "geometry": {"type": "Point", "coordinates": [1, 2]},
-                    "properties": OrderedDict(
-                        [("name", ""), ("comment", ""), ("icon", 48), ("time", val)]
-                    ),
+                    "properties": {"name": "", "comment": "", "icon": 48, "time": val},
                 }
             )
             for val in values

--- a/tests/test_driver_options.py
+++ b/tests/test_driver_options.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import glob
 import os
 import tempfile
@@ -12,7 +11,7 @@ from .conftest import get_temp_filename, requires_gdal2
 def test_gml_format_option(tmp_path):
     """Test GML dataset creation option FORMAT (see gh-968)"""
 
-    schema = {"geometry": "Point", "properties": OrderedDict([("position", "int")])}
+    schema = {"geometry": "Point", "properties": {"position": "int"}}
     records = [
         Feature.from_dict(
             **{

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -1,9 +1,7 @@
 """Tests of MemoryFile and ZippedMemoryFile"""
 
 import os
-from collections import OrderedDict
 from io import BytesIO
-import os
 
 import pytest
 import fiona
@@ -197,7 +195,7 @@ def test_append_bytesio_exception(data_coutwildrnp_json):
 def test_mapinfo_raises():
     """Reported to be a crasher in #937"""
     driver = "MapInfo File"
-    schema = {"geometry": "Point", "properties": OrderedDict([("position", "str")])}
+    schema = {"geometry": "Point", "properties": {"position": "str"}}
 
     with BytesIO() as fout:
         with pytest.raises(OSError):

--- a/tests/test_multiconxn.py
+++ b/tests/test_multiconxn.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import pytest
 
 import fiona
@@ -94,7 +92,7 @@ class TestLayerCreation:
         )
         self.f = Feature(
             geometry=Geometry(type="Point", coordinates=(0.0, 0.1)),
-            properties=OrderedDict([("title", "point one"), ("date", "2012-01-29")]),
+            properties={"title": "point one", "date": "2012-01-29"},
         )
         self.c.writerecords([self.f])
         self.c.flush()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import os
 import tempfile
 
@@ -404,7 +403,7 @@ def test_schema_default_fields_wrong_type(tmpdir):
 
     name = str(tmpdir.join("test.gpx"))
     schema = {
-        "properties": OrderedDict([("ele", "str"), ("time", "datetime")]),
+        "properties": {"ele": "str", "time": "datetime"},
         "geometry": "Point",
     }
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -3,7 +3,6 @@
 import tempfile
 import shutil
 import os
-from collections import OrderedDict
 import pytest
 
 from fiona.env import GDALVersion
@@ -65,11 +64,11 @@ def slice_dataset_path(request):
 
     def get_schema(driver):
         special_schemas = {
-            "CSV": {"geometry": None, "properties": OrderedDict([("position", "int")])}
+            "CSV": {"geometry": None, "properties": {"position": "int"}}
         }
         return special_schemas.get(
             driver,
-            {"geometry": "Point", "properties": OrderedDict([("position", "int")])},
+            {"geometry": "Point", "properties": {"position": "int"}},
         )
 
     def get_records(driver, range):

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import sys
 import tempfile
-from collections import OrderedDict
 
 import pytest
 
@@ -155,7 +154,7 @@ class TestUnicodeStringField:
         field_name = "区县名称"
         meta = {
             "schema": {
-                "properties": OrderedDict([(field_name, "int")]),
+                "properties": {field_name: "int"},
                 "geometry": "Point",
             },
             "driver": "ESRI Shapefile",


### PR DESCRIPTION
Since Python 3.7 (and CPython 3.6), the `dict` built-in preserves insertion order, so there is no longer any need to use OrderedDict for feature properties in Fiona.

This PR undoes 2d51d932bcab4f2b20ff4bbc7c8a802960d85c88 discussed in #57 for Fiona 1.0.1.

Closes #1094