### PR TITLE
Encode bytes type feature properties using base64

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9.4 (June 2023)
 -----------------
 
+- Bytes type feature properties are now encoded using base64 when serializing to GeoJSON.
 - Docstrings for listdir and listlayers have been clarified and harmonized.
 - Nose style test cases have been converted to unittest.TestCase (#1256).
 - The munch package used by fio-filter and fio-calc is now vendored and patched

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9.4 (June 2023)
 -----------------
 
+- Docstrings for listdir and listlayers have been clarified and harmonized.
 - Nose style test cases have been converted to unittest.TestCase (#1256).
 - The munch package used by fio-filter and fio-calc is now vendored and patched
   to remove usage of the deprecated pkg_resources module (#1255).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,8 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 1.9.4 (June 2023)
 -----------------
 
-- Bytes type feature properties are now encoded using base64 when serializing to GeoJSON.
+- Bytes type feature properties are now hex encoded when serializing to GeoJSON
+  (#1263).
 - Docstrings for listdir and listlayers have been clarified and harmonized.
 - Nose style test cases have been converted to unittest.TestCase (#1256).
 - The munch package used by fio-filter and fio-calc is now vendored and patched

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -365,36 +365,42 @@ def remove(path_or_collection, driver=None, layer=None):
 
 
 @ensure_env_with_credentials
-def listdir(path):
-    """List collections in a directory.
+def listdir(fp):
+    """Lists the datasets in a directory or archive file.
 
     Parameters
     ----------
-    path : str or pathlib.Path
-        A directory path or path to a group of collections.
+    fp : str, pathlib.Path, or file-like object
+        Directory or archive path, or a file object holding an archive.
 
     Returns
     -------
     list of str
-        A list of collection paths.
+        A list of datasets.
 
     """
-    if isinstance(path, Path):
-        path = str(path)
-    if not isinstance(path, str):
-        raise TypeError("invalid path: %r" % path)
-    pobj = parse_path(path)
+    if hasattr(fp, 'read'):
+        with MemoryFile(fp.read()) as memfile:
+            return _listdir(memfile.name, **kwargs)
+    else:
+        if isinstance(fp, Path):
+            fp = str(fp)
+
+        if not isinstance(fp, str):
+            raise TypeError("invalid path: %r" % fp)
+
+    pobj = parse_path(fp)
     return _listdir(vsi_path(pobj))
 
 
 @ensure_env_with_credentials
 def listlayers(fp, vfs=None, **kwargs):
-    """List layer names in their index order.
+    """Lists the layers (collections) in a dataset.
 
     Parameters
     ----------
-    fp : URI (str or pathlib.Path), or file-like object
-        A dataset resource identifier or file object.
+    fp : str, pathlib.Path, or file-like object
+        A dataset identifier or file object containing a dataset.
     vfs : str
         This is a deprecated parameter. A URI scheme such as "zip://"
         should be used instead.
@@ -403,7 +409,7 @@ def listlayers(fp, vfs=None, **kwargs):
 
     Returns
     -------
-    list
+    list of str
         A list of layer name strings.
 
     """

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -368,26 +368,29 @@ def remove(path_or_collection, driver=None, layer=None):
 def listdir(fp):
     """Lists the datasets in a directory or archive file.
 
+    Archive files must be prefixed like "zip://" or "tar://".
+
     Parameters
     ----------
-    fp : str, pathlib.Path, or file-like object
-        Directory or archive path, or a file object holding an archive.
+    fp : str or pathlib.Path
+        Directory or archive path.
 
     Returns
     -------
     list of str
         A list of datasets.
 
-    """
-    if hasattr(fp, 'read'):
-        with MemoryFile(fp.read()) as memfile:
-            return _listdir(memfile.name, **kwargs)
-    else:
-        if isinstance(fp, Path):
-            fp = str(fp)
+    Raises
+    ------
+    TypeError
+        If the input is not a str or Path.
 
-        if not isinstance(fp, str):
-            raise TypeError("invalid path: %r" % fp)
+    """
+    if isinstance(fp, Path):
+        fp = str(fp)
+
+    if not isinstance(fp, str):
+        raise TypeError("invalid path: %r" % fp)
 
     pobj = parse_path(fp)
     return _listdir(vsi_path(pobj))
@@ -396,6 +399,8 @@ def listdir(fp):
 @ensure_env_with_credentials
 def listlayers(fp, vfs=None, **kwargs):
     """Lists the layers (collections) in a dataset.
+
+    Archive files must be prefixed like "zip://" or "tar://".
 
     Parameters
     ----------
@@ -411,6 +416,11 @@ def listlayers(fp, vfs=None, **kwargs):
     -------
     list of str
         A list of layer name strings.
+
+    Raises
+    ------
+    TypeError
+        If the input is not a str, Path, or file object.
 
     """
     if hasattr(fp, 'read'):

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -1,6 +1,6 @@
 """Fiona data model"""
 
-from base64 import b64encode
+from binascii import hexlify
 from collections.abc import MutableMapping
 from collections import OrderedDict
 from enum import Enum
@@ -382,7 +382,7 @@ class ObjectEncoder(JSONEncoder):
                 o_dict["properties"] = self.default(o.properties)
             return o_dict
         elif isinstance(o, bytes):
-            return b64encode(o)
+            return hexlify(o)
         else:
             return o
 

--- a/fiona/model.py
+++ b/fiona/model.py
@@ -1,9 +1,10 @@
 """Fiona data model"""
 
-import itertools
-from collections import OrderedDict
+from base64 import b64encode
 from collections.abc import MutableMapping
+from collections import OrderedDict
 from enum import Enum
+import itertools
 from json import JSONEncoder
 from warnings import warn
 
@@ -367,21 +368,23 @@ class Properties(Object):
 
 
 class ObjectEncoder(JSONEncoder):
-    """Encodes Geometry and Feature"""
+    """Encodes Geometry, Feature, and Properties."""
 
     def default(self, o):
         if isinstance(o, (Geometry, Properties)):
-            return {k: v for k, v in o.items() if v is not None}
+            return {k: self.default(v) for k, v in o.items() if v is not None}
         elif isinstance(o, Feature):
             o_dict = dict(**o)
             o_dict["type"] = "Feature"
             if o.geometry is not None:
-                o_dict["geometry"] = ObjectEncoder().default(o.geometry)
+                o_dict["geometry"] = self.default(o.geometry)
             if o.properties is not None:
-                o_dict["properties"] = ObjectEncoder().default(o.properties)
+                o_dict["properties"] = self.default(o.properties)
             return o_dict
+        elif isinstance(o, bytes):
+            return b64encode(o)
         else:
-            return JSONEncoder().default(o)
+            return o
 
 
 def decode_object(obj):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -243,25 +243,19 @@ def test_geometry_encode():
     }
 
 
-@pytest.mark.parametrize("value", [100, "foo"])
-def test_encode_error(value):
-    """Raises TypeError"""
-    with pytest.raises(TypeError):
-        ObjectEncoder().default(value)
-
-
 def test_feature_encode():
     """Can encode a feature"""
     o_dict = ObjectEncoder().default(
         Feature(
             id="foo",
             geometry=Geometry(type="Point", coordinates=(0, 0)),
-            properties=Properties(a=1, foo="bar"),
+            properties=Properties(a=1, foo="bar", bytes=b"01234"),
         )
     )
     assert o_dict["id"] == "foo"
     assert o_dict["geometry"]["type"] == "Point"
     assert o_dict["geometry"]["coordinates"] == (0, 0)
+    assert o_dict["properties"]["bytes"] == b"MDEyMzQ="
 
 
 def test_decode_object_hook():
@@ -314,3 +308,9 @@ def test_feature_gi():
     assert gi["id"] == "foo"
     assert gi["geometry"]["type"] == "Point"
     assert gi["geometry"]["coordinates"] == (0, 0)
+
+
+def test_encode_bytes():
+    """Bytes are encoded using base64."""
+    assert ObjectEncoder().default(b"01234") == b"MDEyMzQ="
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -255,7 +255,7 @@ def test_feature_encode():
     assert o_dict["id"] == "foo"
     assert o_dict["geometry"]["type"] == "Point"
     assert o_dict["geometry"]["coordinates"] == (0, 0)
-    assert o_dict["properties"]["bytes"] == b"MDEyMzQ="
+    assert o_dict["properties"]["bytes"] == b'3031323334'
 
 
 def test_decode_object_hook():
@@ -312,5 +312,5 @@ def test_feature_gi():
 
 def test_encode_bytes():
     """Bytes are encoded using base64."""
-    assert ObjectEncoder().default(b"01234") == b"MDEyMzQ="
+    assert ObjectEncoder().default(b"01234") == b'3031323334'
 


### PR DESCRIPTION
Resolves #1262, which I discovered when trying to convert https://github.com/OSGeo/gdal/blob/master/autotest/ogr/data/parquet/test.parquet to GeoJSON. This bug has been lurking for a while.

@mwtoews what do you think?

@jorisvandenbossche what's the pyogrio approach to serializing bytes in GeoJSON? 