### PR TITLE
Use America/Denver instead of US/Mountain to fix pytz.exceptions.UnknownTimeZoneError.

### DIFF
--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -169,10 +169,10 @@ def generate_testdata(field_type, driver):
             ),
             (
                 datetime.datetime(2020, 1, 21, 12, 0, 0, tzinfo=pytz.utc).astimezone(
-                    timezone("US/Mountain")
+                    timezone("America/Denver")
                 ),
                 datetime.datetime(2020, 1, 21, 12, 0, 0, tzinfo=pytz.utc).astimezone(
-                    timezone("US/Mountain")
+                    timezone("America/Denver")
                 ),
             ),
             (
@@ -265,7 +265,7 @@ def test_compare_datetimes_utc():
         timezone("Europe/Zurich")
     )
     d2 = datetime.datetime(2020, 1, 21, 12, 0, 0, tzinfo=pytz.utc).astimezone(
-        timezone("US/Mountain")
+        timezone("America/Denver")
     )
     assert d1 == d2
     assert compare_datetimes_utc(d1, d2)
@@ -274,7 +274,7 @@ def test_compare_datetimes_utc():
         timezone("Europe/Zurich")
     )
     d2 = datetime.datetime(2020, 6, 21, 12, 0, 0, tzinfo=pytz.utc).astimezone(
-        timezone("US/Mountain")
+        timezone("America/Denver")
     )
     assert d1 == d2
     assert compare_datetimes_utc(d1, d2)


### PR DESCRIPTION
tzdata (2023c-8) in Debian no longer provides the US timezones:
> ```
>    * Ship only timezones in tzdata that follow the current rules of geographical
>      region (continent or ocean) and city name. Move all legacy timezone symlinks
>      (that are upgraded during package update) to tzdata-legacy. This includes
>      dropping the special handling for US/* timezones. (Closes: #1040997)
> ```