### PR TITLE
Remove dated comment about Natural Earth encoding

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -254,10 +254,9 @@ collection to get back to the beginning.
 .. admonition:: File Encoding
 
    The format drivers will attempt to detect the encoding of your data, but may
-   fail. In my experience GDAL 1.7.2 (for example) doesn't detect that the
-   encoding of the Natural Earth dataset is Windows-1252. In this case, the
-   proper encoding can be specified explicitly by using the ``encoding``
-   keyword parameter of :py:func:`fiona.open`: ``encoding='Windows-1252'``.
+   fail. In this case, the proper encoding can be specified explicitly by using
+   the ``encoding`` keyword parameter of :py:func:`fiona.open`, for example:
+   ``encoding='Windows-1252'``.
 
    New in version 0.9.1.
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -135,7 +135,7 @@ def open(
 
     The drivers used by Fiona will try to detect the encoding of data
     files. If they fail, you may provide the proper ``encoding``, such
-    as 'Windows-1252' for the Natural Earth datasets.
+    as 'Windows-1252' for the original Natural Earth datasets.
 
     When the provided path is to a file containing multiple named layers
     of data, a layer can be singled out by ``layer``.


### PR DESCRIPTION
There are two references to the Natural Earth datasets having Windows-1252 encoding, which are removed here since those transitioned to UTF-8 some years ago.