### PR TITLE
CI: upgrade actions/checkout@v3 -> v4; move GHA to .yml suffix

### DIFF
--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test_gdal_latest.yml
+++ b/.github/workflows/test_gdal_latest.yml
@@ -24,7 +24,7 @@ jobs:
       GDAL_DATA: ${{ github.workspace }}/gdal_install/share/gdal
       LD_LIBRARY_PATH: "${{ github.workspace }}/gdal_install/lib/:${LD_LIBRARY_PATH}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update
         run: |
           apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
             gdal-version: '3.3.3'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update
         run: |
@@ -92,7 +92,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Conda Setup
         uses: s-weigand/setup-conda@v1


### PR DESCRIPTION
Similar to #1292 but for the `maint-1.9` branch.