### PR TITLE
fix `OSError: [WinError 87]The parameter is incorrect. : '.' when using PyInstaller

### DIFF
--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -35,7 +35,7 @@ if platform.system() == "Windows":
         if "PATH" in os.environ:
             for p in os.environ["PATH"].split(os.pathsep):
                 if glob.glob(os.path.join(p, "gdal*.dll")):
-                    os.add_dll_directory(p)
+                    os.add_dll_directory(os.path.abspath(p))
 
 
 from fiona._env import (


### PR DESCRIPTION
When attempting to package a Python script using commands like `pyinstaller.exe -D --collect-all=fiona main.py`, PyInstaller includes the gdal.dll file in the main directory. This causes an issue where the '.' character representing the current directory as a parameter is passed to `os.add_dll_directory` on line 38 of the `__init__.py` file, resulting in an `OSError: [WinError 87]`.

To resolve this issue, I made a modification to 'p' by adding `os.path.abspath()` to obtain the absolute path of 'p'. This adjustment should not introduce any other errors.