### PR TITLE
Normalize recursive extra requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-all = ["Fiona[calc,s3,test]"]
+all = ["fiona[calc,s3,test]"]
 calc = ["shapely"]
 s3 = ["boto3>=1.3.1"]
 test = [
-    "Fiona[s3]",
+    "fiona[s3]",
     "pytest>=7",
     "pytest-cov",
     "pytz",


### PR DESCRIPTION
Since the package name is now all-lowercase, normalize the self-referential extras for consistency.