### PR TITLE
Attempt to fix the broken online documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,8 @@ build:
 
 conda:
   environment: environment.yml
+
+python:
+  install:
+    - method: setuptools
+      path: .

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,8 @@ dependencies:
 - pip
 - python=3.9.*
 - libgdal=3.4.*
+- geos=3.10.3
+- cython=3
 - sphinx-click
 - sphinx-rtd-theme
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - pip
 - python=3.9.*
 - libgdal=3.4.*
-- geos
 - cython=3
 - sphinx-click
 - sphinx-rtd-theme

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - pip
 - python=3.9.*
 - libgdal=3.4.*
-- geos=3.10.3
+- geos
 - cython=3
 - sphinx-click
 - sphinx-rtd-theme


### PR DESCRIPTION
The "API documentation" section of the online documentation uses sphinx autodoc, which requires fiona to be install in the sphinx build environment. Apparently this is needs to be done explicitly via `.readthedocs.yaml` conf file. This is what this PR does

#1306