### PR TITLE
Don't attempt to test append to parquet dataset in test_append_memoryfile_drivers

### DIFF
--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -280,13 +280,20 @@ def test_append_memoryfile_drivers(driver, testdata_generator):
         with memfile.open(driver=driver, crs="OGC:CRS84", schema=schema) as c:
             c.writerecords(records1)
 
-        with memfile.open(mode='a', driver=driver, schema=schema) as c:
-            c.writerecords(records2)
+        # The parquet dataset does not seem to support append mode
+        if driver == "Parquet":
+            with memfile.open(driver=driver) as c:
+                assert driver == c.driver
+                items = list(c)
+                assert len(items) == len(range1)
+        else:
+            with memfile.open(mode='a', driver=driver, schema=schema) as c:
+                c.writerecords(records2)
 
-        with memfile.open(driver=driver) as c:
-            assert driver == c.driver
-            items = list(c)
-            assert len(items) == len(range1 + range2)
+            with memfile.open(driver=driver) as c:
+                assert driver == c.driver
+                items = list(c)
+                assert len(items) == len(range1 + range2)
 
 
 def test_memoryfile_driver_does_not_support_vsi():


### PR DESCRIPTION
The parquet driver does not appear to support append mode, and opening with `mode='a'` fails with

> fiona._err.CPLE_OpenFailedError: '/vsimem/f66391b5a3ba47bc93363c6b80a15e96/f66391b5a3ba47bc93363c6b80a15e96.parquet' not recognized as being in a supported file format.

Opening in regular write mode succeeds though.