### PR TITLE
Install new VSI plugin handler for every instance of using an opener

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,11 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
 Bug fixes:
 
-- Pyopener registry is not compatible with multithreading (#).
+- The Pyopener registry and VSI plugin have been rewritten to avoid filename
+  conflicts and to be compatible with multithreading. Now, a new plugin handler
+  is registered for each instance of using an opener (#1408). Before GDAL 3.9.0
+  plugin handlers cannot not be removed and so it may be observed that the size
+  of the Pyopener registry grows during the execution of a program.
 - A CSLConstList ctypedef has been added and is used where appropriate (#1404).
 - Fiona model objects have a informative, printable representation again (#).
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.
 
 Bug fixes:
 
+- Pyopener registry is not compatible with multithreading (#).
 - A CSLConstList ctypedef has been added and is used where appropriate (#1404).
 - Fiona model objects have a informative, printable representation again (#).
 

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -324,7 +324,7 @@ def open(
                 log.debug("Registering opener: raw_dataset_path=%r, opener=%r", raw_dataset_path, opener)
                 vsi_path_ctx = _opener_registration(raw_dataset_path, opener)
                 registered_vsi_path = stack.enter_context(vsi_path_ctx)
-                log.debug("Registered vsi path: registered_vsi_path%r", registered_vsi_path)
+                log.debug("Registered vsi path: registered_vsi_path=%r", registered_vsi_path)
                 path = _UnparsedPath(registered_vsi_path)
             else:
                 if vfs:

--- a/fiona/__init__.py
+++ b/fiona/__init__.py
@@ -386,7 +386,7 @@ collection = open
 
 
 @ensure_env_with_credentials
-def remove(path_or_collection, driver=None, layer=None):
+def remove(path_or_collection, driver=None, layer=None, opener=None):
     """Delete an OGR data source or one of its layers.
 
     If no layer is specified, the entire dataset and all of its layers
@@ -396,6 +396,19 @@ def remove(path_or_collection, driver=None, layer=None):
     ----------
     path_or_collection : str, pathlib.Path, or Collection
         The target Collection or its path.
+    opener : callable or obj, optional
+        A custom dataset opener which can serve GDAL's virtual
+        filesystem machinery via Python file-like objects. The
+        underlying file-like object is obtained by calling *opener* with
+        (*fp*, *mode*) or (*fp*, *mode* + "b") depending on the format
+        driver's native mode. *opener* must return a Python file-like
+        object that provides read, seek, tell, and close methods. Note:
+        only one opener at a time per fp, mode pair is allowed.
+
+        Alternatively, opener may be a filesystem object from a package
+        like fsspec that provides the following methods: isdir(),
+        isfile(), ls(), mtime(), open(), and size(). The exact interface
+        is defined in the fiona._vsiopener._AbstractOpener class.
     driver : str, optional
         The name of a driver to be used for deletion, optional. Can
         usually be detected.
@@ -414,21 +427,37 @@ def remove(path_or_collection, driver=None, layer=None):
     """
     if isinstance(path_or_collection, Collection):
         collection = path_or_collection
-        path = collection.path
+        raw_dataset_path = collection.path
         driver = collection.driver
         collection.close()
-    elif isinstance(path_or_collection, Path):
-        path = str(path_or_collection)
+
     else:
-        path = path_or_collection
-    if layer is None:
-        _remove(path, driver)
+        fp = path_or_collection
+        if hasattr(fp, "path") and hasattr(fp, "fs"):
+            log.debug("Detected fp is an OpenFile: fp=%r", fp)
+            raw_dataset_path = fp.path
+            opener = fp.fs.open
+        else:
+            raw_dataset_path = os.fspath(fp)
+
+    if opener:
+        log.debug("Registering opener: raw_dataset_path=%r, opener=%r", raw_dataset_path, opener)
+        with _opener_registration(raw_dataset_path, opener) as registered_vsi_path:
+            log.debug("Registered vsi path: registered_vsi_path=%r", registered_vsi_path)
+            if layer is None:
+                _remove(registered_vsi_path, driver)
+            else:
+                _remove_layer(registered_vsi_path, layer, driver)
     else:
-        _remove_layer(path, layer, driver)
+        pobj = _parse_path(raw_dataset_path)
+        if layer is None:
+            _remove(_vsi_path(pobj), driver)
+        else:
+            _remove_layer(_vsi_path(pobj), layer, driver)
 
 
 @ensure_env_with_credentials
-def listdir(fp):
+def listdir(fp, opener=None):
     """Lists the datasets in a directory or archive file.
 
     Archive files must be prefixed like "zip://" or "tar://".
@@ -437,6 +466,19 @@ def listdir(fp):
     ----------
     fp : str or pathlib.Path
         Directory or archive path.
+    opener : callable or obj, optional
+        A custom dataset opener which can serve GDAL's virtual
+        filesystem machinery via Python file-like objects. The
+        underlying file-like object is obtained by calling *opener* with
+        (*fp*, *mode*) or (*fp*, *mode* + "b") depending on the format
+        driver's native mode. *opener* must return a Python file-like
+        object that provides read, seek, tell, and close methods. Note:
+        only one opener at a time per fp, mode pair is allowed.
+
+        Alternatively, opener may be a filesystem object from a package
+        like fsspec that provides the following methods: isdir(),
+        isfile(), ls(), mtime(), open(), and size(). The exact interface
+        is defined in the fiona._vsiopener._AbstractOpener class.
 
     Returns
     -------
@@ -449,18 +491,25 @@ def listdir(fp):
         If the input is not a str or Path.
 
     """
-    if isinstance(fp, Path):
-        fp = str(fp)
+    if hasattr(fp, "path") and hasattr(fp, "fs"):
+        log.debug("Detected fp is an OpenFile: fp=%r", fp)
+        raw_dataset_path = fp.path
+        opener = fp.fs.open
+    else:
+        raw_dataset_path = os.fspath(fp)
 
-    if not isinstance(fp, str):
-        raise TypeError("invalid path: %r" % fp)
-
-    pobj = _parse_path(fp)
-    return _listdir(_vsi_path(pobj))
+    if opener:
+        log.debug("Registering opener: raw_dataset_path=%r, opener=%r", raw_dataset_path, opener)
+        with _opener_registration(raw_dataset_path, opener) as registered_vsi_path:
+            log.debug("Registered vsi path: registered_vsi_path=%r", registered_vsi_path)
+            return _listdir(registered_vsi_path)
+    else:
+        pobj = _parse_path(raw_dataset_path)
+        return _listdir(_vsi_path(pobj))
 
 
 @ensure_env_with_credentials
-def listlayers(fp, vfs=None, **kwargs):
+def listlayers(fp, opener=None, vfs=None, **kwargs):
     """Lists the layers (collections) in a dataset.
 
     Archive files must be prefixed like "zip://" or "tar://".
@@ -469,6 +518,19 @@ def listlayers(fp, vfs=None, **kwargs):
     ----------
     fp : str, pathlib.Path, or file-like object
         A dataset identifier or file object containing a dataset.
+    opener : callable or obj, optional
+        A custom dataset opener which can serve GDAL's virtual
+        filesystem machinery via Python file-like objects. The
+        underlying file-like object is obtained by calling *opener* with
+        (*fp*, *mode*) or (*fp*, *mode* + "b") depending on the format
+        driver's native mode. *opener* must return a Python file-like
+        object that provides read, seek, tell, and close methods. Note:
+        only one opener at a time per fp, mode pair is allowed.
+
+        Alternatively, opener may be a filesystem object from a package
+        like fsspec that provides the following methods: isdir(),
+        isfile(), ls(), mtime(), open(), and size(). The exact interface
+        is defined in the fiona._vsiopener._AbstractOpener class.
     vfs : str
         This is a deprecated parameter. A URI scheme such as "zip://"
         should be used instead.
@@ -486,18 +548,26 @@ def listlayers(fp, vfs=None, **kwargs):
         If the input is not a str, Path, or file object.
 
     """
+    if vfs and not isinstance(vfs, str):
+        raise TypeError(f"invalid vfs: {vfs!r}")
+
     if hasattr(fp, 'read'):
         with MemoryFile(fp.read()) as memfile:
             return _listlayers(memfile.name, **kwargs)
+
+    if hasattr(fp, "path") and hasattr(fp, "fs"):
+        log.debug("Detected fp is an OpenFile: fp=%r", fp)
+        raw_dataset_path = fp.path
+        opener = fp.fs.open
     else:
-        if isinstance(fp, Path):
-            fp = str(fp)
+        raw_dataset_path = os.fspath(fp)
 
-        if not isinstance(fp, str):
-            raise TypeError(f"invalid path: {fp!r}")
-        if vfs and not isinstance(vfs, str):
-            raise TypeError(f"invalid vfs: {vfs!r}")
-
+    if opener:
+        log.debug("Registering opener: raw_dataset_path=%r, opener=%r", raw_dataset_path, opener)
+        with _opener_registration(raw_dataset_path, opener) as registered_vsi_path:
+            log.debug("Registered vsi path: registered_vsi_path=%r", registered_vsi_path)
+            return _listlayers(registered_vsi_path, **kwargs)
+    else:
         if vfs:
             warnings.warn(
                 "The vfs keyword argument is deprecated and will be removed in 2.0. "
@@ -506,10 +576,10 @@ def listlayers(fp, vfs=None, **kwargs):
                 stacklevel=2,
             )
             pobj_vfs = _parse_path(vfs)
-            pobj_path = _parse_path(fp)
+            pobj_path = _parse_path(raw_dataset_path)
             pobj = _ParsedPath(pobj_path.path, pobj_vfs.path, pobj_vfs.scheme)
         else:
-            pobj = _parse_path(fp)
+            pobj = _parse_path(raw_dataset_path)
 
         return _listlayers(_vsi_path(pobj), **kwargs)
 

--- a/fiona/_env.pxd
+++ b/fiona/_env.pxd
@@ -1,11 +1,6 @@
 include "gdal.pxi"
 
 
-cdef extern from "ogr_srs_api.h":
-    void OSRSetPROJSearchPaths(const char *const *papszPaths)
-    void OSRGetPROJVersion	(int *pnMajor, int *pnMinor, int *pnPatch)
-
-
 cdef class ConfigEnv(object):
     cdef public object options
 

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -405,10 +405,8 @@ cdef class GDALEnv(ConfigEnv):
         if not self._have_registered_drivers:
             with threading.Lock():
                 if not self._have_registered_drivers:
-
                     GDALAllRegister()
                     OGRRegisterAll()
-                    # install_pyopener_plugin(pyopener_plugin)
 
                     if 'GDAL_DATA' in os.environ:
                         log.debug("GDAL_DATA found in environment.")

--- a/fiona/_env.pyx
+++ b/fiona/_env.pyx
@@ -17,7 +17,6 @@ import threading
 
 from fiona._err cimport exc_wrap_int, exc_wrap_ogrerr
 from fiona._err import CPLE_BaseError
-from fiona._vsiopener cimport install_pyopener_plugin
 from fiona.errors import EnvError
 
 level_map = {
@@ -409,7 +408,7 @@ cdef class GDALEnv(ConfigEnv):
 
                     GDALAllRegister()
                     OGRRegisterAll()
-                    install_pyopener_plugin(pyopener_plugin)
+                    # install_pyopener_plugin(pyopener_plugin)
 
                     if 'GDAL_DATA' in os.environ:
                         log.debug("GDAL_DATA found in environment.")

--- a/fiona/_err.pxd
+++ b/fiona/_err.pxd
@@ -1,15 +1,14 @@
+include "gdal.pxi"
+
 from libc.stdio cimport *
-
-cdef extern from "cpl_vsi.h":
-
-    ctypedef FILE VSILFILE
-
-cdef extern from "ogr_core.h":
-
-    ctypedef int OGRErr
 
 cdef get_last_error_msg()
 cdef int exc_wrap_int(int retval) except -1
 cdef OGRErr exc_wrap_ogrerr(OGRErr retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL
 cdef VSILFILE *exc_wrap_vsilfile(VSILFILE *f) except NULL
+
+cdef class StackChecker:
+    cdef object error_stack
+    cdef int exc_wrap_int(self, int retval) except -1
+    cdef void *exc_wrap_pointer(self, void *ptr) except NULL

--- a/fiona/_err.pyx
+++ b/fiona/_err.pyx
@@ -29,23 +29,17 @@ manager raises a more useful and informative error:
     ValueError: The PNG driver does not support update access to existing datasets.
 """
 
-# CPL function declarations.
-cdef extern from "cpl_error.h":
-
-    ctypedef enum CPLErr:
-        CE_None
-        CE_Debug
-        CE_Warning
-        CE_Failure
-        CE_Fatal
-
-    int CPLGetLastErrorNo()
-    const char* CPLGetLastErrorMsg()
-    int CPLGetLastErrorType()
-    void CPLErrorReset()
-
-
+import contextlib
+from contextvars import ContextVar
 from enum import IntEnum
+from itertools import zip_longest
+import logging
+
+log = logging.getLogger(__name__)
+
+_ERROR_STACK = ContextVar("error_stack")
+_ERROR_STACK.set([])
+
 
 # Python exceptions expressing the CPL error numbers.
 
@@ -132,6 +126,10 @@ class CPLE_AWSSignatureDoesNotMatchError(CPLE_BaseError):
     pass
 
 
+class CPLE_AWSError(CPLE_BaseError):
+    pass
+
+
 class FionaNullPointerError(CPLE_BaseError):
     """
     Returned from exc_wrap_pointer when a NULL pointer is passed, but no GDAL
@@ -147,6 +145,14 @@ class FionaCPLError(CPLE_BaseError):
     """
     pass
 
+
+cdef dict _LEVEL_MAP = {
+    0: 0,
+    1: logging.DEBUG,
+    2: logging.WARNING,
+    3: logging.ERROR,
+    4: logging.CRITICAL
+}
 
 # Map of GDAL error numbers to the Python exceptions.
 exception_map = {
@@ -168,8 +174,30 @@ exception_map = {
     13: CPLE_AWSObjectNotFoundError,
     14: CPLE_AWSAccessDeniedError,
     15: CPLE_AWSInvalidCredentialsError,
-    16: CPLE_AWSSignatureDoesNotMatchError}
+    16: CPLE_AWSSignatureDoesNotMatchError,
+    17: CPLE_AWSError
+}
 
+cdef dict _CODE_MAP = {
+    0: 'CPLE_None',
+    1: 'CPLE_AppDefined',
+    2: 'CPLE_OutOfMemory',
+    3: 'CPLE_FileIO',
+    4: 'CPLE_OpenFailed',
+    5: 'CPLE_IllegalArg',
+    6: 'CPLE_NotSupported',
+    7: 'CPLE_AssertionFailed',
+    8: 'CPLE_NoWriteAccess',
+    9: 'CPLE_UserInterrupt',
+    10: 'ObjectNull',
+    11: 'CPLE_HttpResponse',
+    12: 'CPLE_AWSBucketNotFound',
+    13: 'CPLE_AWSObjectNotFound',
+    14: 'CPLE_AWSAccessDenied',
+    15: 'CPLE_AWSInvalidCredentials',
+    16: 'CPLE_AWSSignatureDoesNotMatch',
+    17: 'CPLE_AWSError'
+}
 
 # CPL Error types as an enum.
 class GDALError(IntEnum):
@@ -305,3 +333,127 @@ cdef VSILFILE *exc_wrap_vsilfile(VSILFILE *f) except NULL:
     return f
 
 cpl_errs = GDALErrCtxManager()
+
+
+cdef class StackChecker:
+
+    def __init__(self, error_stack=None):
+        self.error_stack = error_stack or {}
+
+    cdef int exc_wrap_int(self, int err) except -1:
+        """Wrap a GDAL/OGR function that returns CPLErr (int).
+
+        Raises a Rasterio exception if a non-fatal error has be set.
+        """
+        if err:
+            stack = self.error_stack.get()
+            for error, cause in zip_longest(stack[::-1], stack[::-1][1:]):
+                if error is not None and cause is not None:
+                    error.__cause__ = cause
+
+            if stack:
+                last = stack.pop()
+                if last is not None:
+                    raise last
+
+        return err
+
+    cdef void *exc_wrap_pointer(self, void *ptr) except NULL:
+        """Wrap a GDAL/OGR function that returns a pointer.
+
+        Raises a Rasterio exception if a non-fatal error has be set.
+        """
+        if ptr == NULL:
+            stack = self.error_stack.get()
+            for error, cause in zip_longest(stack[::-1], stack[::-1][1:]):
+                if error is not None and cause is not None:
+                    error.__cause__ = cause
+
+            if stack:
+                last = stack.pop()
+                if last is not None:
+                    raise last
+
+        return ptr
+
+
+cdef void log_error(
+    CPLErr err_class,
+    int err_no,
+    const char* msg,
+) noexcept with gil:
+    """Send CPL errors to Python's logger.
+
+    Because this function is called by GDAL with no Python context, we
+    can't propagate exceptions that we might raise here. They'll be
+    ignored.
+
+    """
+    if err_no in _CODE_MAP:
+        # We've observed that some GDAL functions may emit multiple
+        # ERROR level messages and yet succeed. We want to see those
+        # messages in our log file, but not at the ERROR level. We
+        # turn the level down to INFO.
+        if err_class == 3:
+            log.info(
+                "GDAL signalled an error: err_no=%r, msg=%r",
+                err_no,
+                msg.decode("utf-8")
+            )
+        elif err_no == 0:
+            log.log(_LEVEL_MAP[err_class], "%s", msg.decode("utf-8"))
+        else:
+            log.log(_LEVEL_MAP[err_class], "%s:%s", _CODE_MAP[err_no], msg.decode("utf-8"))
+    else:
+        log.info("Unknown error number %r", err_no)
+
+
+IF UNAME_SYSNAME == "Windows":
+    cdef void __stdcall chaining_error_handler(
+        CPLErr err_class,
+        int err_no,
+        const char* msg
+    ) noexcept with gil:
+        global _ERROR_STACK
+        log_error(err_class, err_no, msg)
+        if err_class == 3:
+            stack = _ERROR_STACK.get()
+            stack.append(
+                exception_map.get(err_no, CPLE_BaseError)(err_class, err_no, msg.decode("utf-8")),
+            )
+            _ERROR_STACK.set(stack)
+ELSE:
+    cdef void chaining_error_handler(
+        CPLErr err_class,
+        int err_no,
+        const char* msg
+    ) noexcept with gil:
+        global _ERROR_STACK
+        log_error(err_class, err_no, msg)
+        if err_class == 3:
+            stack = _ERROR_STACK.get()
+            stack.append(
+                exception_map.get(err_no, CPLE_BaseError)(err_class, err_no, msg.decode("utf-8")),
+            )
+            _ERROR_STACK.set(stack)
+
+
+@contextlib.contextmanager
+def stack_errors():
+    # TODO: better name?
+    # Note: this manager produces one chain of errors and thus assumes
+    # that no more than one GDAL function is called.
+    CPLErrorReset()
+    global _ERROR_STACK
+    _ERROR_STACK.set([])
+
+    # chaining_error_handler (better name a TODO) records GDAL errors
+    # in the order they occur and converts to exceptions.
+    CPLPushErrorHandlerEx(<CPLErrorHandler>chaining_error_handler, NULL)
+
+    # Run code in the `with` block.
+    yield StackChecker(_ERROR_STACK)
+
+    CPLPopErrorHandler()
+    _ERROR_STACK.set([])
+    CPLErrorReset()

--- a/fiona/_vsiopener.pxd
+++ b/fiona/_vsiopener.pxd
@@ -1,4 +1,1 @@
 include "gdal.pxi"
-
-cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)
-cdef void uninstall_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)

--- a/fiona/_vsiopener.pyx
+++ b/fiona/_vsiopener.pyx
@@ -79,10 +79,8 @@ cdef int pyopener_stat(
         mtime = file_opener.mtime(urlpath)
     except (FileNotFoundError, KeyError) as err:
         # No such file or directory.
-        log.error("File or key not found: err=%r", err)
         return -1
     except Exception as err:
-        log.error("Other error: err=%r", err)
         errmsg = f"Opener failed to determine file info: {repr(err)}".encode("utf-8")
         CPLError(CE_Failure, <CPLErrorNum>4, <const char *>"%s", <const char *>errmsg)
         return -1
@@ -124,10 +122,8 @@ cdef int pyopener_unlink(
         return 0
     except (FileNotFoundError, KeyError) as err:
         # No such file or directory.
-        log.error("File or key not found: err=%r", err)
         return -1
     except Exception as err:
-        log.error("Other error: err=%r", err)
         errmsg = f"Opener failed to determine file info: {repr(err)}".encode("utf-8")
         CPLError(CE_Failure, <CPLErrorNum>4, <const char *>"%s", <const char *>errmsg)
         return -1
@@ -166,7 +162,6 @@ cdef char ** pyopener_read_dir(
         log.debug("Looking for dir contents: urlpath=%r, contents=%r", urlpath, contents)
     except (FileNotFoundError, KeyError) as err:
         # No such file or directory.
-        log.error("File or key not found: err=%r", err)
         return NULL
     except Exception as err:
         errmsg = f"Opener failed to determine directory contents: {repr(err)}".encode("utf-8")
@@ -542,6 +537,7 @@ class _FilesystemOpener(_AbstractOpener):
     def isdir(self, path):
         return self._obj.isdir(path)
     def ls(self, path):
+        # return value of ls() varies between file and zip fsspec filesystems.
         return [item if isinstance(item, str) else item["filename"] for item in self._obj.ls(path)]
     def mtime(self, path):
         try:

--- a/fiona/_vsiopener.pyx
+++ b/fiona/_vsiopener.pyx
@@ -165,6 +165,8 @@ cdef void* pyopener_open(
     """
     urlpath = pszFilename.decode("utf-8")
     mode = pszAccess.decode("utf-8")
+    if not "b" in mode:
+        mode += "b"
     key = Path(urlpath).parent
 
     registry = _OPENER_REGISTRY.get()
@@ -207,7 +209,7 @@ cdef void* pyopener_open(
         errmsg = "OpenFile didn't resolve".encode("utf-8")
         return NULL
     else:
-        exit_stacks = _OPEN_FILE_EXIT_STACKS.get()
+        exit_stacks = _OPEN_FILE_EXIT_STACKS.get({})
         exit_stacks[file_obj] = stack
         _OPEN_FILE_EXIT_STACKS.set(exit_stacks)
         log.debug("Returning: file_obj=%r", file_obj)
@@ -284,7 +286,8 @@ def _opener_registration(urlpath, obj):
     # Might raise.
     opener = _create_opener(obj)
 
-    registry = _OPENER_REGISTRY.get()
+    registry = _OPENER_REGISTRY.get({})
+
     if key in registry:
         if registry[key] != opener:
             raise OpenerRegistrationError(f"Opener already registered for urlpath.")

--- a/fiona/gdal.pxi
+++ b/fiona/gdal.pxi
@@ -51,7 +51,9 @@ cdef extern from "cpl_error.h" nogil:
     const char* CPLGetLastErrorMsg()
     CPLErr CPLGetLastErrorType()
     void CPLPushErrorHandler(CPLErrorHandler handler)
+    void CPLPushErrorHandlerEx(CPLErrorHandler handler, void *userdata)
     void CPLPopErrorHandler()
+    void CPLQuietErrorHandler(CPLErr eErrClass, CPLErrorNum nError, const char *pszErrorMsg)
 
 
 cdef extern from "cpl_vsi.h" nogil:
@@ -139,6 +141,11 @@ cdef extern from "cpl_vsi.h" nogil:
     int VSIRmdir(const char *path)
     int VSIStatL(const char *pszFilename, VSIStatBufL *psStatBuf)
     int VSI_ISDIR(int mode)
+
+
+IF (CTE_GDAL_MAJOR_VERSION, CTE_GDAL_MINOR_VERSION) >= (3, 9):
+    cdef extern from "cpl_vsi.h" nogil:
+        int VSIRemovePluginHandler(const char*)
 
 
 cdef extern from "ogr_core.h" nogil:
@@ -301,7 +308,7 @@ cdef extern from "ogr_srs_api.h" nogil:
     OGRErr OSRExportToPROJJSON(OGRSpatialReferenceH hSRS,
                                 char ** ppszReturn,
                                 const char* const* papszOptions)
-
+    void OSRGetPROJVersion	(int *pnMajor, int *pnMinor, int *pnPatch)
 
 cdef extern from "gdal.h" nogil:
 

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -2127,10 +2127,8 @@ def _remove_layer(path, layer, driver=None):
 
 
 def _listlayers(path, **kwargs):
-
     """Provides a list of the layers in an OGR data source.
     """
-
     cdef void *cogr_ds = NULL
     cdef void *cogr_layer = NULL
     cdef const char *path_c

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -78,3 +78,18 @@ def test_opener_fsspec_fs_write(tmp_path):
         collection.write(feature)
         assert len(collection) == 1
         assert collection.crs == "OGC:CRS84"
+
+
+def test_threads_context():
+    import io
+    from threading import Thread
+
+
+    def target():
+        with fiona.open("tests/data/coutwildrnp.shp", opener=io.open):
+            pass
+
+
+    thread = Thread(target=target)
+    thread.start()
+    thread.join()

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -86,8 +86,9 @@ def test_threads_context():
 
 
     def target():
-        with fiona.open("tests/data/coutwildrnp.shp", opener=io.open):
-            pass
+        with fiona.open("tests/data/coutwildrnp.shp", opener=io.open) as colxn:
+            print(colxn.profile)
+            assert len(colxn) == 67
 
 
     thread = Thread(target=target)

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -143,7 +143,7 @@ def test_opener_fsspec_file_fs_listdir():
     """Use fsspec file filesystem as opener for listdir()."""
     fs = fsspec.filesystem("file")
     listing = fiona.listdir("tests/data", opener=fs)
-    assert len(listing) == 37
+    assert len(listing) >= 35
     assert set(
         ["coutwildrnp.shp", "coutwildrnp.dbf", "coutwildrnp.shx", "coutwildrnp.prj"]
     ) & set(listing)


### PR DESCRIPTION
Resolves #1406 by giving each `fiona.open()` collection its own VSI plugin handler when the `opener` keyword argument is used. Works with threads.

The approach is not unlike the one mentioned in https://github.com/OSGeo/gdal/pull/8772 and benefits from the `VSIRemovePluginHandler()` function added in GDAL 3.9.0. With older versions of GDAL, the Pyopener registry will accumulate openers and GDAL will accumulate plugin handlers.

This PR also adds and uses Rasterio's chaining error handler and error stack checker.