### PR TITLE
Dependabot: Group GitHub Actions updates to reduce number of PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Update the Dependabot configuration to group GitHub Actions updates to a single PR, to reduce number of PRs opened.

For reference:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
- https://learn.scientific-python.org/development/guides/gha-basic/#updating