### PR TITLE
Add methods _dir_exists and _isdir

### DIFF
--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -2169,15 +2169,16 @@ def _dir_exists(path):
     """Checks if a path exists."""
     cdef const char *path_c
     cdef VSIStatBufL st_buf
-    path_c = _encode_path(path)
+    py_path = _encode_path(path)
+    path_c = py_path
     return VSIStatL(path_c, &st_buf) == 0
 
 
 def _isdir(path_c):
     """Checks if a path is a directory."""
-    cdef const char *path_c
     cdef VSIStatBufL st_buf
     return VSI_ISDIR(st_buf.st_mode)
+
 
 
 def _listdir(path):

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -2156,18 +2156,38 @@ def _listlayers(path, **kwargs):
     return layer_names
 
 
+def _encode_path(path):
+    """Encodes a path to utf-8."""
+    try:
+        path_b = path.encode('utf-8')
+    except UnicodeDecodeError:
+        path_b = path
+    return path_b
+
+
+def _dir_exists(path):
+    """Checks if a path exists."""
+    cdef const char *path_c
+    cdef VSIStatBufL st_buf
+    path_c = _encode_path(path)
+    return VSIStatL(path_c, &st_buf) == 0
+
+
+def _isdir(path_c):
+    """Checks if a path is a directory."""
+    cdef const char *path_c
+    cdef VSIStatBufL st_buf
+    return VSI_ISDIR(st_buf.st_mode)
+
+
 def _listdir(path):
-    """List all files in path, if path points to a directory"""
+    """List all files in path, if path points to a directory."""
     cdef const char *path_c
     cdef int n
     cdef char** papszFiles
     cdef VSIStatBufL st_buf
 
-    try:
-        path_b = path.encode('utf-8')
-    except UnicodeDecodeError:
-        path_b = path
-    path_c = path_b
+    path_c = _encode_path(path)
     if not VSIStatL(path_c, &st_buf) == 0:
         raise FionaValueError(f"Path '{path}' does not exist.")
     if not VSI_ISDIR(st_buf.st_mode):

--- a/fiona/ogrext.pyx
+++ b/fiona/ogrext.pyx
@@ -2169,8 +2169,8 @@ def _dir_exists(path):
     """Checks if a path exists."""
     cdef const char *path_c
     cdef VSIStatBufL st_buf
-    py_path = _encode_path(path)
-    path_c = py_path
+    path_b = _encode_path(path)
+    path_c = path_b
     return VSIStatL(path_c, &st_buf) == 0
 
 
@@ -2188,7 +2188,8 @@ def _listdir(path):
     cdef char** papszFiles
     cdef VSIStatBufL st_buf
 
-    path_c = _encode_path(path)
+    path_b = _encode_path(path)
+    path_c = path_b
     if not VSIStatL(path_c, &st_buf) == 0:
         raise FionaValueError(f"Path '{path}' does not exist.")
     if not VSI_ISDIR(st_buf.st_mode):


### PR DESCRIPTION
This PR is my best effort to add utility methods for checking if a file or vsi exists, and if it is a directory. (I have no expereince with Pyrex and C, so I would love feedback and guidance.)

The motivation comes from the need of these checks to [list a directory recursively](https://github.com/microsoft/torchgeo/blob/c786a575da3a47b55c4d1bf98be325d1f3576df0/torchgeo/datasets/utils.py#L642). The current workaround is this, which is a bit hacky.

```python
try:
    subdirs = fiona.listdir(dir)
except FionaValueError as e:
    if 'does not exist' in str(e):
        # handle does not exist
    elif 'is not a directory' in str(e):
        # handle is a file
    else:
        # handle is a directory
```

with this pr, this would instead be possible:

```python
if not fiona.dir_exists(path):
    # handle does not exist
elif fiona.isdir(path):
    # handle is a directory
else:
    # handle is a file
```