### PR TITLE
In a weird case, don't fail utterly, but add an error message

### DIFF
--- a/tests/data/issue1451.geojson
+++ b/tests/data/issue1451.geojson
@@ -1,0 +1,74 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          158.197,
+          6.978
+        ]
+      },
+      "properties": {
+        "name": "Pohnpei",
+        "uhslc_id": 1,
+        "ssc_id": "deke",
+        "gloss_id": 115,
+        "country": "Micronesia (Federated States of)",
+        "country_code": "0583",
+        "fd_span": {
+          "oldest": "2001-12-17",
+          "latest": "2024-07-31"
+        },
+        "rq_span": {
+          "oldest": "1969-05-09",
+          "latest": "2021-12-31"
+        },
+        "rq_basin": "pacific",
+        "rq_versions": {
+          "b": {
+            "begin": "1974-04-22",
+            "end": "2004-12-31"
+          },
+          "a": {
+            "begin": "1969-05-09",
+            "end": "1971-02-27"
+          },
+          "c": {
+            "begin": "2001-12-17",
+            "end": "2021-12-31"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          338.017,
+          70.483
+        ]
+      },
+      "properties": {
+        "name": "Upernavi",
+        "uhslc_id": 817,
+        "ssc_id": "none",
+        "gloss_id": 0,
+        "country": "Unknown",
+        "country_code": 0,
+        "fd_span": {
+          "oldest": "2024-08-16",
+          "latest": "2024-08-31"
+        },
+        "rq_span": {
+          "oldest": null,
+          "latest": null
+        },
+        "rq_basin": null,
+        "rq_versions": null
+      }
+    }
+  ]
+}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -256,7 +256,7 @@ def test_feature_encode():
     assert o_dict["id"] == "foo"
     assert o_dict["geometry"]["type"] == "Point"
     assert o_dict["geometry"]["coordinates"] == (0, 0)
-    assert o_dict["properties"]["bytes"] == b'3031323334'
+    assert o_dict["properties"]["bytes"] == b"3031323334"
 
 
 def test_decode_object_hook():
@@ -313,7 +313,7 @@ def test_feature_gi():
 
 def test_encode_bytes():
     """Bytes are encoded using base64."""
-    assert ObjectEncoder().default(b"01234") == b'3031323334'
+    assert ObjectEncoder().default(b"01234") == b"3031323334"
 
 
 def test_null_property_encoding():
@@ -342,7 +342,10 @@ def test_feature_repr():
         geometry=Geometry(type="LineString", coordinates=[(0, 0)] * 100),
         properties=Properties(a=1, foo="bar"),
     )
-    assert repr(feat) == "fiona.Feature(geometry=fiona.Geometry(coordinates=[(0, 0), ...], type='LineString'), id='1', properties=fiona.Properties(a=1, foo='bar'))"
+    assert (
+        repr(feat)
+        == "fiona.Feature(geometry=fiona.Geometry(coordinates=[(0, 0), ...], type='LineString'), id='1', properties=fiona.Properties(a=1, foo='bar'))"
+    )
 
 
 def test_issue1430():
@@ -354,6 +357,9 @@ def test_issue1430():
     assert feat.properties["foo"] == "bar"
 
 
+@pytest.mark.skipif(
+    not gdal_version.at_least("3.6"), reason="Requires at least GDAL 3.6"
+)
 def test_issue1451():
     """Report when a JSON property can't be decoded."""
     with fiona.open("tests/data/issue1451.geojson") as collection:
@@ -363,4 +369,6 @@ def test_issue1451():
         first, second = list(collection)
         assert first.properties["country_code"].startswith("String(JSON)")
         assert "val=b'0583'" in first.properties["country_code"]
-        assert "Extra data: line 1 column 2 (char 1)" in first.properties["country_code"]
+        assert (
+            "Extra data: line 1 column 2 (char 1)" in first.properties["country_code"]
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,6 +3,7 @@
 import pytest
 
 import fiona
+from fiona.env import GDALVersion
 from fiona.errors import FionaDeprecationWarning
 from fiona.model import (
     _Geometry,
@@ -13,6 +14,8 @@ from fiona.model import (
     Properties,
     decode_object,
 )
+
+gdal_version = GDALVersion.runtime()
 
 
 def test_object_len():


### PR DESCRIPTION
Follow up on #1451.

GeoJSON feature properties are not tightly constrained. GDAL/OGR depends on constraints, and would prefer a single type for field values. When GDAL receives features where a named property (or field) may be a string, or a number, or something else, the behavior is not well defined. In versions before 3.6, it seems like GDAL interpreted these as String type fields. After, it seems that these are interpreted as String(JSON) fields.

When GDAL has determined that the field is type: String(JSON) (rightly or wrongly), if a JSONDecodeError occurs, instead of raising an exception and bringing processing to a halt, we might return a error message in place of a normal value.

I honestly have no idea what the best UX is here, I don't see obvious precedent yet.