### PR TITLE
Fix test failure with tzdata 2024b-3.

### DIFF
--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -318,12 +318,12 @@ def test_compare_times_utc():
 
     d1 = (
         datetime.datetime(2020, 6, 21, 12, 0, 0, tzinfo=pytz.utc)
-        .astimezone(timezone("MET"))
+        .astimezone(timezone("Europe/Brussels"))
         .timetz()
     )
     d2 = (
         datetime.datetime(2020, 6, 21, 12, 0, 0, tzinfo=pytz.utc)
-        .astimezone(timezone("EST"))
+        .astimezone(timezone("America/Panama"))
         .timetz()
     )
     assert compare_times_utc(d1, d2)


### PR DESCRIPTION
Debian CI reported a test failure for the test with GDAL 3.9.3-rc1:
```
 77s =================================== FAILURES ===================================
 77s ____________________________ test_compare_times_utc ____________________________
 77s 
 77s     def test_compare_times_utc():
 77s         """
 77s         Test compare_times_utc
 77s         """
 77s         d1 = datetime.time(12, 30, 0, tzinfo=TZ(60))
 77s         d2 = datetime.time(11, 30, 0, tzinfo=TZ(0))
 77s         assert compare_times_utc(d1, d2)
 77s     
 77s         d1 = datetime.time(12, 30, 0, tzinfo=TZ(-60))
 77s         d2 = datetime.time(11, 30, 0, tzinfo=TZ(0))
 77s         assert not compare_times_utc(d1, d2)
 77s     
 77s         d1 = datetime.time(13, 0, 0, tzinfo=TZ(60))
 77s         d2 = datetime.time(5, 0, 0, tzinfo=TZ(-60 * 7))
 77s         assert compare_times_utc(d1, d2)
 77s     
 77s         d1 = (
 77s             datetime.datetime(2020, 6, 21, 12, 0, 0, tzinfo=pytz.utc)
 77s >           .astimezone(timezone("MET"))
 77s             .timetz()
 77s         )
 77s 
 77s tests/test_datetime.py:321: 
 77s _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 77s 
 77s zone = 'MET'
 77s 
 77s     def timezone(zone):
 77s         r''' Return a datetime.tzinfo implementation for the given timezone
 77s     
 77s         >>> from datetime import datetime, timedelta
 77s         >>> utc = timezone('UTC')
 77s         >>> eastern = timezone('US/Eastern')
 77s         >>> eastern.zone
 77s         'US/Eastern'
 77s         >>> timezone(unicode('US/Eastern')) is eastern
 77s         True
 77s         >>> utc_dt = datetime(2002, 10, 27, 6, 0, 0, tzinfo=utc)
 77s         >>> loc_dt = utc_dt.astimezone(eastern)
 77s         >>> fmt = '%Y-%m-%d %H:%M:%S %Z (%z)'
 77s         >>> loc_dt.strftime(fmt)
 77s         '2002-10-27 01:00:00 EST (-0500)'
 77s         >>> (loc_dt - timedelta(minutes=10)).strftime(fmt)
 77s         '2002-10-27 00:50:00 EST (-0500)'
 77s         >>> eastern.normalize(loc_dt - timedelta(minutes=10)).strftime(fmt)
 77s         '2002-10-27 01:50:00 EDT (-0400)'
 77s         >>> (loc_dt + timedelta(minutes=10)).strftime(fmt)
 77s         '2002-10-27 01:10:00 EST (-0500)'
 77s     
 77s         Raises UnknownTimeZoneError if passed an unknown zone.
 77s     
 77s         >>> try:
 77s         ...     timezone('Asia/Shangri-La')
 77s         ... except UnknownTimeZoneError:
 77s         ...     print('Unknown')
 77s         Unknown
 77s     
 77s         >>> try:
 77s         ...     timezone(unicode('\N{TRADE MARK SIGN}'))
 77s         ... except UnknownTimeZoneError:
 77s         ...     print('Unknown')
 77s         Unknown
 77s     
 77s         '''
 77s         if zone is None:
 77s             raise UnknownTimeZoneError(None)
 77s     
 77s         if zone.upper() == 'UTC':
 77s             return utc
 77s     
 77s         try:
 77s             zone = ascii(zone)
 77s         except UnicodeEncodeError:
 77s             # All valid timezones are ASCII
 77s             raise UnknownTimeZoneError(zone)
 77s     
 77s         zone = _case_insensitive_zone_lookup(_unmunge_zone(zone))
 77s         if zone not in _tzinfo_cache:
 77s             if zone in all_timezones_set:  # noqa
 77s                 fp = open_resource(zone)
 77s                 try:
 77s                     _tzinfo_cache[zone] = build_tzinfo(zone, fp)
 77s                 finally:
 77s                     fp.close()
 77s             else:
 77s >               raise UnknownTimeZoneError(zone)
 77s E               pytz.exceptions.UnknownTimeZoneError: 'MET'
 77s 
 77s /usr/lib/python3/dist-packages/pytz/__init__.py:201: UnknownTimeZoneError
```
https://ci.debian.net/packages/f/fiona/unstable/amd64/52840231/

This is caused by changes in tzdata (2024b-3):
```
  * Upstream obsoleted the System V names CET, CST6CDT, EET, EST*, HST, MET,
    MST*, PST8PDT, and WET. They are symlinks now. Move those zones to
    tzdata-legacy and update /etc/localtime on package update to the new names.
    Please use Etc/GMT* in case you want to avoid DST changes.
```

This is fixed by using Europe/Brussels instead of MET, and America/Panama instead of EST.