### PR TITLE
Small performance improvements for GeomBuilder._buildCoords

### DIFF
--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -124,15 +124,20 @@ cdef class GeomBuilder:
     cdef list _buildCoords(self, void *geom):
         # Build a coordinate sequence
         cdef int i
+        cdef int npoints
+        cdef list coords
+
         if geom == NULL:
             raise ValueError("Null geom")
         npoints = OGR_G_GetPointCount(geom)
         coords = []
-        for i in range(npoints):
-            values = [OGR_G_GetX(geom, i), OGR_G_GetY(geom, i)]
-            if self.ndims > 2:
-                values.append(OGR_G_GetZ(geom, i))
-            coords.append(tuple(values))
+
+        if self.ndims == 2:
+            for i in range(npoints):
+                coords.append((OGR_G_GetX(geom, i), OGR_G_GetY(geom, i)))
+        else:
+            for i in range(npoints):
+                coords.append((OGR_G_GetX(geom, i), OGR_G_GetY(geom, i), OGR_G_GetZ(geom, i)))
         return coords
 
     cdef dict  _buildPoint(self, void *geom):

--- a/fiona/_geometry.pyx
+++ b/fiona/_geometry.pyx
@@ -125,12 +125,11 @@ cdef class GeomBuilder:
         # Build a coordinate sequence
         cdef int i
         cdef int npoints
-        cdef list coords
+        cdef list coords = []
 
         if geom == NULL:
             raise ValueError("Null geom")
         npoints = OGR_G_GetPointCount(geom)
-        coords = []
 
         if self.ndims == 2:
             for i in range(npoints):


### PR DESCRIPTION
Some minor improvements to help build coordinate lists a little more efficiently.

1. Lift the ndim check out of the loop. This only needs to be checked once per call.
2. Build tuples directly instead of creating a list and converting to tuples.
