### PR TITLE
TST: Mark test_opener_fsspec_zip_http_fs as using the network

### DIFF
--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -29,6 +29,7 @@ def test_opener_fsspec_zip_fs():
         assert "AGBUR" in colxn.schema["properties"]
 
 
+@pytest.mark.network
 def test_opener_fsspec_zip_http_fs():
     """Use fsspec zip+http filesystem as opener."""
     fs = fsspec.filesystem(


### PR DESCRIPTION
As with other tests that use the network.