### PR TITLE
Issue 1487 - Suggested Fix - Return false when comparing Object against values that can't be unpacked 

### DIFF
--- a/fiona/model.py
+++ b/fiona/model.py
@@ -1,7 +1,7 @@
 """Fiona data model"""
 
 from binascii import hexlify
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from enum import Enum
 import itertools
 from json import JSONEncoder
@@ -187,6 +187,9 @@ class Object(MutableMapping):
             del self._data[key]
 
     def __eq__(self, other):
+        if not isinstance(other, Mapping):
+            return False
+
         return dict(**self) == dict(**other)
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -113,7 +113,6 @@ def test_object_eq(other):
     assert obj == other
 
 
-@pytest.mark.xfail(reason="Throws TypeError on comparisons where the comparison object cannot be unpacked")
 @pytest.mark.parametrize(
     "other",
     ("", 1, [1, 2], {"g": 5}, Object(g=10), OrderedDict(a=1)),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
 """Test of deprecations following RFC 1"""
+from collections import OrderedDict
 
 import pytest
 
@@ -100,6 +101,27 @@ def test_object_delitem_delegated():
     with pytest.warns(FionaDeprecationWarning, match="immutable"):
         del thing["value"]
     assert thing["value"] is None
+
+
+@pytest.mark.parametrize(
+    "other",
+    ({"g": 1}, Object(g=1), OrderedDict(g=1)),
+)
+def test_object_eq(other):
+    """Object eq identifies a match"""
+    obj = Object(g=1)
+    assert obj == other
+
+
+@pytest.mark.xfail(reason="Throws TypeError on comparisons where the comparison object cannot be unpacked")
+@pytest.mark.parametrize(
+    "other",
+    ("", 1, [1, 2], {"g": 5}, Object(g=10), OrderedDict(a=1)),
+)
+def test_object_eq_not(other):
+    """Object eq identifies not a match"""
+    obj = Object(g=1)
+    assert obj != other
 
 
 def test__geometry_ctor():


### PR DESCRIPTION
This is a suggested fix for [Issue 1847](https://github.com/Toblerity/Fiona/issues/1487)

In cases where eq is used for an object that cannot be unpacked (i.e. is not an instance of Mapping) simply default to returning false.

Depending on style/preference, another way this could be implemented is:
```python
try:
    return dict(**self) == dict(**other)
except TypeError:
    return False
```
I went with the Mapping approach as it seemed to tie in more nicely with the inheritance from MutableMapping for Object, but both are pythonic and I'm happy to switch the fix over if you have a preference.

I made the assumption that the decision to do equality explicitly against the unpacked versions of the objects was in part to maintain backwards compatibility with old style Fiona representations of geometries (or similar). So I tried to stay away from anything that would create more direct comparisons between object types (e.g. return false if it's not a dict/Object), leaving the option open for other Mapping based objects to also resolve to True when compared.