### PR TITLE
Drop Python 3.8 & 3.9 and macos-13 with test fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,13 +39,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         gdal-version: ['3.9.3']
         include:
-          - python-version: '3.8'
-            gdal-version: '3.4.3'
-          - python-version: '3.9'
-            gdal-version: '3.5.3'
           - python-version: '3.10'
             gdal-version: '3.6.4'
           - python-version: '3.11'
@@ -96,7 +92,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-13, macos-14]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         include:
           - os: ubuntu-latest
             python-version: '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14]
         python-version: ['3.10', '3.11', '3.12']
         include:
           - os: ubuntu-latest
@@ -150,7 +150,7 @@ jobs:
           micromamba run -n test python -m pytest -v -m "not wheel" -rxXs --cov fiona --cov-report term-missing
 
       - name: Test with Coverage (OSX)
-        if: "${{matrix.os}} == 'macos-13' || ${{matrix.os}} == 'macos-14'"
+        if: matrix.os == 'macos-14'
         shell: bash -l {0}
         run: |
           micromamba run -n test python -m pytest -v -m "not wheel" -rxXs --cov fiona --cov-report term-missing

--- a/fiona/_vendor/snuggs.py
+++ b/fiona/_vendor/snuggs.py
@@ -262,7 +262,7 @@ def processList(lst):
 
 def handleLine(line):
     try:
-        result = expr.parseString(line)
+        result = expr.parse_string(line)
         return processList(result[0])
     except ParseException as exc:
         text = str(exc)

--- a/fiona/_vendor/snuggs.py
+++ b/fiona/_vendor/snuggs.py
@@ -34,7 +34,7 @@ from typing import Mapping
 
 from pyparsing import (  # type: ignore
     Keyword,
-    oneOf,
+    one_of,
     Literal,
     QuotedString,
     ParseException,
@@ -158,7 +158,7 @@ var = pyparsing_common.identifier.set_parse_action(resolve_var)
 string = QuotedString("'") | QuotedString('"')
 lparen = Literal("(").suppress()
 rparen = Literal(")").suppress()
-op = oneOf(" ".join(op_map.keys())).set_parse_action(
+op = one_of(" ".join(op_map.keys())).set_parse_action(
     lambda source, loc, toks: op_map[toks[0]]
 )
 
@@ -177,7 +177,7 @@ def resolve_func(source, loc, toks):
 # variables.
 func = Regex(r"(?<=\()[{}]+".format(alphanums + "_")).set_parse_action(resolve_func)
 
-higher_func = oneOf(" ".join(higher_func_map.keys())).set_parse_action(
+higher_func = one_of(" ".join(higher_func_map.keys())).set_parse_action(
     lambda source, loc, toks: higher_func_map[toks[0]]
 )
 

--- a/fiona/fio/cat.py
+++ b/fiona/fio/cat.py
@@ -55,8 +55,6 @@ warnings.simplefilter("default")
     default=False,
     help="Optionally cut geometries at the anti-meridian. To be used only for a geographic destination CRS.",
 )
-@click.option('--where', default=None,
-              help="attribute filter using SQL where clause")
 @options.open_opt
 @click.pass_context
 @with_context_env

--- a/fiona/fio/features.py
+++ b/fiona/fio/features.py
@@ -160,7 +160,7 @@ def filter_cmd(ctx, pipeline, use_rs, snuggs_only):
 
             if not pipeline.startswith("("):
                 test_string = f"({pipeline})"
-            expr.parseString(test_string)
+            expr.parse_string(test_string)
         except ExpressionError:
             # It's a snuggs expression.
             log.info("Detected a snuggs expression.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "attrs>=19.2.0",
     "certifi",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 aiohttp
 boto3>=1.3.1
-coverage~=6.5
+coverage>=7.14.3
 cython>=3
 fsspec
 pyparsing


### PR DESCRIPTION
- Python 3.8 & 3.9 is EOL already and breaks some methods and tests.
- `macos-13` is no longer available in GitHub Actions

Changes:
- drop support of python 3.8 and 3.9
- drop `macos-13` in GitHub Actions
- fix method and dependency versions such that all tests pass

Out of Scope:
- add support of newer python and GDAL