### PR TITLE
Add required sphinx.configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,6 @@ python:
   install:
     - method: setuptools
       path: .
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
All newer PRs are failed because ReadtheDocs [pipeline](https://app.readthedocs.org/projects/fiona/builds/33374098/) failed and [need adding](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) `sphinx.configuration` 